### PR TITLE
feat: add BrokenStones tracker

### DIFF
--- a/config/trackers/brokenstones.json
+++ b/config/trackers/brokenstones.json
@@ -1,0 +1,45 @@
+{
+  "id": "brokenstones",
+  "name": "BrokenStones",
+  "baseUrl": "https://brokenstones.is",
+  "enabled": false,
+  "login": {
+    "url": "login.php",
+    "method": "POST",
+    "contentType": "form",
+    "body": {
+      "username": "{{username}}",
+      "password": "{{password}}",
+      "keeplogged": "1"
+    },
+    "failurePatterns": [
+      "login.php",
+      "type=\"password\"",
+      "Please login"
+    ]
+  },
+  "fetch": {
+    "url": "index.php",
+    "mode": "http",
+    "responseType": "html",
+    "fields": {
+      "uploadedBytes": {
+        "regex": "stats_seeding[\\s\\S]{0,200}?<span[^>]*>\\s*(?<value>[\\d.]+ (?:TB|GB|MB|KB))\\s*</span>",
+        "transform": "bytes"
+      },
+      "downloadedBytes": {
+        "regex": "stats_leeching[\\s\\S]{0,200}?<span[^>]*>\\s*(?<value>[\\d.]+ (?:TB|GB|MB|KB))\\s*</span>",
+        "transform": "bytes"
+      },
+      "ratio": {
+        "regex": "stats_ratio[\\s\\S]{0,200}?<span[^>]*>\\s*(?<value>[\\d.]+)\\s*</span>",
+        "transform": "number"
+      },
+      "tokens": {
+        "regex": "fl_tokens[\\s\\S]{0,200}?<a[^>]*>\\s*(?<value>\\d+)\\s*</a>",
+        "transform": "integer"
+      }
+    }
+  },
+  "dashboard": { "byteUnit": "decimal" }
+}


### PR DESCRIPTION
Adds support for BrokenStones (https://brokenstones.is/), a Gazelle-based private tracker.
Tested and working — retrieves upload, download, ratio and tokens from the homepage after login.

![Dashboard](https://zupimages.net/up/26/24/rz5y.png)