### PR TITLE
feat: add Phoenix Project tracker

### DIFF
--- a/config/trackers/phoenixproject.json
+++ b/config/trackers/phoenixproject.json
@@ -1,0 +1,41 @@
+{
+  "id": "phoenixproject",
+  "name": "Phoenix Project",
+  "baseUrl": "https://phoenixproject.app",
+  "enabled": false,
+  "login": {
+    "url": "login.php",
+    "method": "POST",
+    "contentType": "form",
+    "body": {
+      "username": "{{username}}",
+      "password": "{{password}}"
+    },
+    "failurePatterns": ["login.php", "This is a mirage"],
+    "cookieOnly": true
+  },
+  "fetch": {
+    "url": "index.php",
+    "mode": "browser",
+    "responseType": "html",
+    "fields": {
+      "uploadedBytes": {
+        "regex": "stats_seeding[\\s\\S]{0,200}?title=\"(?<value>[\\d.]+ (?:TiB|GiB|MiB|KiB))\"",
+        "transform": "bytes"
+      },
+      "downloadedBytes": {
+        "regex": "stats_leeching[\\s\\S]{0,200}?title=\"(?<value>[\\d.]+ (?:TiB|GiB|MiB|KiB))\"",
+        "transform": "bytes"
+      },
+      "ratio": {
+        "regex": "stats_ratio[\\s\\S]{0,200}?title=\"(?<value>[\\d.]+)\"",
+        "transform": "number"
+      },
+      "seedBonus": {
+        "regex": "nav_bonus[\\s\\S]{0,200}?Bonus \\((?<value>[\\d,]+)\\)",
+        "transform": "string"
+      }
+    }
+  },
+  "dashboard": { "byteUnit": "binary" }
+}


### PR DESCRIPTION
## Summary

Add support for Phoenix Project (https://phoenixproject.app).

The tracker's homepage displays a "This is a mirage" page that redirects unauthenticated users to `/login.php`. Login automation is not possible — a session cookie is required.

- `cookieOnly: true` — prevents any automated login attempt
- `mode: browser` — required for cookie injection to work (HTTP mode ignores the stored session cookie)
- `failurePatterns` covers both the mirage page and the login page

## Screenshot

![Phoenix Project](https://zupimages.net/up/26/24/ef3m.png)