### PR TITLE
Integrer la planification et les notifications Autovisit

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1828,6 +1828,14 @@
         <section class="beta-section" data-beta-section="alerts">
         <div class="beta-grid-2">
           <section class="beta-panel">
+            <h3>Planification des logins</h3>
+            <p class="beta-note" style="margin-bottom:10px">Planification globale inspirée d'Autovisit. Chaque cycle visite tous les trackers actifs disposant de credentials.</p>
+            <div id="beta-schedule-settings"></div>
+            <div style="margin-top:10px; display:flex; gap:8px; flex-wrap:wrap">
+              <button class="beta-icon-btn primary" onclick="saveBetaSettings()" type="button">Enregistrer la planification</button>
+            </div>
+          </section>
+          <section class="beta-panel">
             <h3>Alertes par tracker</h3>
             <div id="beta-alert-rules"></div>
             <div style="margin-top:10px; display:flex; gap:8px; flex-wrap:wrap">
@@ -1836,7 +1844,8 @@
             </div>
           </section>
           <section class="beta-panel">
-            <h3>Notifications Discord / Apprise</h3>
+            <h3>Notifications Autovisit / Discord</h3>
+            <div id="beta-notification-preferences"></div>
             <div id="beta-notification-targets"></div>
             <div style="margin-top:10px; display:flex; gap:8px; flex-wrap:wrap">
               <button class="beta-icon-btn" onclick="addBetaNotificationTarget('discord')" type="button">Ajouter Discord</button>
@@ -2172,39 +2181,6 @@
     return `<span class="badge badge-stale" title="${escapeHtml((stat.stale.error || 'Timeout pendant le refresh') + failedAt)}">Données anciennes</span>`;
   }
 
-  function trackerSchedule(stat) {
-    const configured = trackerConfig.find(t => t.id === stat.id);
-    return configured?.schedule || {};
-  }
-
-  function scheduleControls(stat) {
-    const schedule = trackerSchedule(stat);
-    const enabled = Boolean(schedule.enabled);
-    const interval = schedule.intervalHours || 24;
-    const next = schedule.nextRunAt ? `Prochaine ${relativeTime(schedule.nextRunAt)}` : 'Non planifiee';
-    return `
-      <div class="card-schedule">
-        <div class="card-schedule-text">
-          <strong>Connexion automatique</strong>
-          <span>${enabled ? next : 'Desactivee'}</span>
-        </div>
-        <div class="schedule-controls">
-          <label class="toggle-switch" title="Activer la connexion automatique">
-            <input type="checkbox" ${enabled ? 'checked' : ''} onchange="saveSchedule('${escapeHtml(stat.id)}', this.checked)">
-            <div class="toggle-track"><div class="toggle-knob"></div></div>
-          </label>
-          <select id="schedule-${escapeHtml(stat.id)}" onchange="saveSchedule('${escapeHtml(stat.id)}', true)">
-            <option value="6" ${interval === 6 ? 'selected' : ''}>6h</option>
-            <option value="12" ${interval === 12 ? 'selected' : ''}>12h</option>
-            <option value="24" ${interval === 24 ? 'selected' : ''}>24h</option>
-            <option value="48" ${interval === 48 ? 'selected' : ''}>48h</option>
-            <option value="168" ${interval === 168 ? 'selected' : ''}>7j</option>
-            <option value="504" ${interval === 504 ? 'selected' : ''}>21j</option>
-          </select>
-        </div>
-      </div>`;
-  }
-
   function lastLoginText(stat) {
     return formatDateTime(stat.lastLoginAt || stat.lastUpdated);
   }
@@ -2243,7 +2219,14 @@
   let betaSection = 'overview';
   let betaCalendarMonth = new Date();
   let betaOverview = null;
-  let betaSettings = { qbitClients: [], notificationTargets: [], alertRules: [], defaults: {} };
+  let betaSettings = {
+    qbitClients: [],
+    notificationTargets: [],
+    notificationPreferences: {},
+    schedule: {},
+    alertRules: [],
+    defaults: {},
+  };
   let betaHistory = [];
   let betaSelectedTrackerId = null;
   let betaSelectedCalendarDay = new Date().toISOString().slice(0, 10);
@@ -3075,6 +3058,54 @@
     });
   }
 
+  function renderBetaScheduleSettings() {
+    const container = document.getElementById('beta-schedule-settings');
+    if (!container) return;
+    const schedule = betaSettings.schedule || {};
+    const weekdays = new Set(schedule.weekdays || []);
+    const dayLabels = ['Dim', 'Lun', 'Mar', 'Mer', 'Jeu', 'Ven', 'Sam'];
+    container.innerHTML = `
+      <div class="beta-form-row" style="grid-template-columns:repeat(2,minmax(0,1fr))">
+        <div class="beta-field"><label>Planification active</label><select id="beta-schedule-enabled"><option value="true" ${schedule.enabled ? 'selected' : ''}>Oui</option><option value="false" ${!schedule.enabled ? 'selected' : ''}>Non</option></select></div>
+        <div class="beta-field"><label>Mode</label><select id="beta-schedule-mode" onchange="updateBetaScheduleMode()"><option value="hours" ${schedule.mode === 'hours' ? 'selected' : ''}>Toutes les X heures</option><option value="days" ${schedule.mode !== 'hours' && schedule.mode !== 'weekdays' ? 'selected' : ''}>Tous les X jours à heure fixe</option><option value="weekdays" ${schedule.mode === 'weekdays' ? 'selected' : ''}>Certains jours de la semaine</option></select></div>
+      </div>
+      <div id="beta-schedule-hours" class="beta-form-row"><div class="beta-field"><label>Intervalle en heures</label><input id="beta-schedule-interval-hours" type="number" min="1" max="168" value="${escapeHtml(schedule.intervalHours || 6)}"></div></div>
+      <div id="beta-schedule-days" class="beta-form-row">
+        <div class="beta-field"><label>Intervalle en jours</label><input id="beta-schedule-interval-days" type="number" min="1" max="30" value="${escapeHtml(schedule.intervalDays || 1)}"></div>
+        <div class="beta-field"><label>Heure</label><input id="beta-schedule-time" type="time" value="${String(schedule.hour ?? 3).padStart(2, '0')}:${String(schedule.minute ?? 0).padStart(2, '0')}"></div>
+      </div>
+      <div id="beta-schedule-weekdays" class="beta-form-row" style="grid-template-columns:1fr">
+        <div class="beta-field"><label>Jours</label><div style="display:flex;gap:8px;flex-wrap:wrap">${dayLabels.map((label, day) => `<label><input type="checkbox" data-beta-weekday="${day}" ${weekdays.has(day) ? 'checked' : ''}> ${label}</label>`).join('')}</div></div>
+      </div>
+      <p class="beta-note">Prochaine exécution : ${schedule.nextRunAt ? escapeHtml(new Date(schedule.nextRunAt).toLocaleString('fr-FR')) : 'non planifiée'}${schedule.lastRunAt ? ` · Dernière : ${escapeHtml(new Date(schedule.lastRunAt).toLocaleString('fr-FR'))}` : ''}</p>
+    `;
+    updateBetaScheduleMode();
+  }
+
+  function updateBetaScheduleMode() {
+    const mode = document.getElementById('beta-schedule-mode')?.value || betaSettings.schedule?.mode || 'days';
+    const hours = document.getElementById('beta-schedule-hours');
+    const days = document.getElementById('beta-schedule-days');
+    const weekdays = document.getElementById('beta-schedule-weekdays');
+    if (hours) hours.style.display = mode === 'hours' ? '' : 'none';
+    if (days) days.style.display = mode === 'hours' ? 'none' : '';
+    if (weekdays) weekdays.style.display = mode === 'weekdays' ? '' : 'none';
+  }
+
+  function renderBetaNotificationPreferences() {
+    const container = document.getElementById('beta-notification-preferences');
+    if (!container) return;
+    const preferences = betaSettings.notificationPreferences || {};
+    container.innerHTML = `
+      <div class="beta-form-row" style="grid-template-columns:repeat(2,minmax(0,1fr));margin-bottom:10px">
+        <label><input id="beta-notify-error" type="checkbox" ${preferences.notifyError !== false ? 'checked' : ''}> Échecs</label>
+        <label><input id="beta-notify-success" type="checkbox" ${preferences.notifySuccess ? 'checked' : ''}> Succès</label>
+        <label><input id="beta-notify-recovery" type="checkbox" ${preferences.notifySuccessAfterFailure !== false ? 'checked' : ''}> Rétablissement après échec</label>
+        <label><input id="beta-notify-stats" type="checkbox" ${preferences.notifyStats ? 'checked' : ''}> Inclure les statistiques</label>
+      </div>
+    `;
+  }
+
   function renderBetaNotificationTargets() {
     const container = document.getElementById('beta-notification-targets');
     if (!container) return;
@@ -3082,8 +3113,9 @@
     container.innerHTML = targets.map((target, idx) => `
       <div class="beta-form-row" data-beta-target="${idx}">
         <div class="beta-field"><label>Nom</label><input data-field="label" value="${escapeHtml(target.label || '')}"></div>
-        <div class="beta-field"><label>Type</label><select data-field="type"><option value="discord" ${target.type !== 'apprise' ? 'selected' : ''}>Discord</option><option value="apprise" ${target.type === 'apprise' ? 'selected' : ''}>Apprise</option></select></div>
-        <div class="beta-field" style="grid-column:span 2"><label>Webhook / endpoint</label><input data-field="url" value="${escapeHtml(target.url || '')}" placeholder="https://..."></div>
+        <div class="beta-field"><label>Type</label><select data-field="type" onchange="changeBetaNotificationType(${idx}, this.value)"><option value="discord" ${target.type !== 'apprise' ? 'selected' : ''}>Discord</option><option value="apprise" ${target.type === 'apprise' ? 'selected' : ''}>Apprise</option></select></div>
+        <div class="beta-field" style="grid-column:span 2"><label>${target.type === 'apprise' ? 'URL du serveur Apprise' : 'Webhook Discord'}</label><input data-field="url" value="${escapeHtml(target.url || '')}" placeholder="https://..."></div>
+        ${target.type === 'apprise' ? `<div class="beta-field" style="grid-column:span 2"><label>URLs Apprise (une par ligne)</label><textarea data-field="urls" rows="3" placeholder="pover://...&#10;discord://...">${escapeHtml((target.urls || []).join('\n'))}</textarea></div>` : ''}
         <div class="beta-field"><label>Actif</label><select data-field="enabled"><option value="true" ${target.enabled !== false ? 'selected' : ''}>Oui</option><option value="false" ${target.enabled === false ? 'selected' : ''}>Non</option></select></div>
         <div style="display:flex; gap:6px"><button class="beta-icon-btn" onclick="testBetaNotification('${escapeHtml(target.id)}')" type="button">Tester</button><button class="beta-icon-btn" onclick="removeBetaNotificationTarget(${idx})" type="button">X</button></div>
       </div>
@@ -3131,6 +3163,8 @@
     drawBetaHistoryChart();
     renderBetaQbitClients();
     renderBetaAnnounceMappings();
+    renderBetaScheduleSettings();
+    renderBetaNotificationPreferences();
     renderBetaNotificationTargets();
     renderBetaAlertRules();
   }
@@ -3154,6 +3188,7 @@
       label: row.querySelector('[data-field="label"]').value.trim(),
       type: row.querySelector('[data-field="type"]').value,
       url: row.querySelector('[data-field="url"]').value.trim(),
+      urls: row.querySelector('[data-field="urls"]')?.value.split('\n').map(value => value.trim()).filter(Boolean) || [],
       enabled: row.querySelector('[data-field="enabled"]').value === 'true',
     })).filter(target => target.url);
     const alertRules = Array.from(document.querySelectorAll('[data-beta-rule]')).map((row, idx) => ({
@@ -3165,11 +3200,30 @@
       enabled: row.querySelector('[data-field="enabled"]').value === 'true',
       targetIds: notificationTargets.filter(target => target.enabled).map(target => target.id),
     })).filter(rule => rule.trackerId);
+    const [hour, minute] = (document.getElementById('beta-schedule-time')?.value || '03:00').split(':').map(Number);
+    const schedule = {
+      ...(betaSettings.schedule || {}),
+      enabled: document.getElementById('beta-schedule-enabled')?.value === 'true',
+      mode: document.getElementById('beta-schedule-mode')?.value || 'days',
+      intervalHours: Number(document.getElementById('beta-schedule-interval-hours')?.value || 6),
+      intervalDays: Number(document.getElementById('beta-schedule-interval-days')?.value || 1),
+      hour,
+      minute,
+      weekdays: Array.from(document.querySelectorAll('[data-beta-weekday]:checked')).map(input => Number(input.dataset.betaWeekday)),
+    };
+    const notificationPreferences = {
+      notifyError: document.getElementById('beta-notify-error')?.checked !== false,
+      notifySuccess: document.getElementById('beta-notify-success')?.checked === true,
+      notifySuccessAfterFailure: document.getElementById('beta-notify-recovery')?.checked !== false,
+      notifyStats: document.getElementById('beta-notify-stats')?.checked === true,
+    };
     return {
       ...betaSettings,
       qbitClients,
       announceMappings,
       notificationTargets,
+      schedule,
+      notificationPreferences,
       alertRules,
     };
   }
@@ -3209,7 +3263,14 @@
 
   function addBetaNotificationTarget(type) {
     betaSettings = collectBetaSettingsFromDom();
-    betaSettings.notificationTargets.push({ id: genId(), type, label: type === 'apprise' ? 'Apprise' : 'Discord', url: '', enabled: true });
+    betaSettings.notificationTargets.push({ id: genId(), type, label: type === 'apprise' ? 'Apprise' : 'Discord', url: '', urls: [], enabled: true });
+    renderBetaNotificationTargets();
+  }
+
+  function changeBetaNotificationType(index, type) {
+    betaSettings = collectBetaSettingsFromDom();
+    if (!betaSettings.notificationTargets[index]) return;
+    betaSettings.notificationTargets[index].type = type;
     renderBetaNotificationTargets();
   }
 
@@ -3537,7 +3598,6 @@
           </div>
           ${reachabilityLine}
           ${incidentBox}
-          ${scheduleControls(stat)}
           <div class="card-footer">Derniere connexion : ${lastLoginText(stat)}</div>
         </div>`;
     }
@@ -3583,7 +3643,6 @@
           ${bottomCells}
         </div>
         ${stat.stale ? renderIncidentBox(stat) : ''}
-        ${scheduleControls(stat)}
         <div class="card-footer">Derniere connexion : ${lastLoginText(stat)}</div>
       </div>`;
   }
@@ -3600,26 +3659,10 @@
   }
 
   function rowScheduleCell(stat) {
-    const schedule = trackerSchedule(stat);
-    const enabled = Boolean(schedule.enabled);
-    const interval = schedule.intervalHours || 24;
-    const next = schedule.nextRunAt ? `Prochaine ${relativeTime(schedule.nextRunAt)}` : 'Non planifiee';
-    const id = escapeHtml(stat.id);
-    return `
-      <div class="row-sched" title="${enabled ? escapeHtml(next) : 'Desactivee'}">
-        <label class="toggle-switch" title="Activer la connexion automatique">
-          <input type="checkbox" ${enabled ? 'checked' : ''} onchange="saveSchedule('${id}', this.checked)">
-          <div class="toggle-track"><div class="toggle-knob"></div></div>
-        </label>
-        <select id="schedule-${id}" onchange="saveSchedule('${id}', true)">
-          <option value="6" ${interval === 6 ? 'selected' : ''}>6h</option>
-          <option value="12" ${interval === 12 ? 'selected' : ''}>12h</option>
-          <option value="24" ${interval === 24 ? 'selected' : ''}>24h</option>
-          <option value="48" ${interval === 48 ? 'selected' : ''}>48h</option>
-          <option value="168" ${interval === 168 ? 'selected' : ''}>7j</option>
-          <option value="504" ${interval === 504 ? 'selected' : ''}>21j</option>
-        </select>
-      </div>`;
+    const schedule = betaSettings.schedule || {};
+    return schedule.enabled
+      ? `<span class="cell-muted" title="Planification globale">Global</span>`
+      : '<span class="cell-muted">Désactivée</span>';
   }
 
   function rowStatusBadges(stat) {
@@ -4251,22 +4294,6 @@
         body: JSON.stringify({ enabled }),
       });
     } catch (e) { console.warn('saveFastFetch:', e.message); }
-  }
-
-  async function saveSchedule(trackerId, enabled) {
-    const select = document.getElementById(`schedule-${trackerId}`);
-    const r = await fetch(`/api/schedules/${trackerId}`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        enabled,
-        intervalHours: Number(select.value),
-      }),
-    });
-    const d = await r.json();
-    if (!d.ok) console.warn(d.error || 'Schedule save failed');
-    await loadConfig();
-    await loadStats();
   }
 
   async function saveSettings() {

--- a/src/server.ts
+++ b/src/server.ts
@@ -20,10 +20,8 @@ import {
   resolveLogoPath, refreshAllLogos, listTrackersWithoutLogo,
 } from './logos.js';
 import {
-  ensureTrackerSchedules,
   deleteTrackerCredentials,
   getTrackerCredentials,
-  getTrackerSchedule,
   importLegacyCredentialsIfNeeded,
   importLegacySettingsIfNeeded,
   importLegacyTrackersIfNeeded,
@@ -32,15 +30,12 @@ import {
   listStatSnapshots,
   listTrackerCredentialSummaries,
   listTrackerDefinitionFiles,
-  listTrackerSchedules,
   loadCredentialsFromDb,
   loadTrackerConfigsFromDb,
   loadTrackerDefinitionFile,
-  markTrackerScheduleRun,
   saveStatSnapshots,
   saveTrackerCredentials,
   saveTrackerConfig,
-  saveTrackerSchedule,
   setJsonSetting,
   hasTrackerCookie,
   setTrackerCookie,
@@ -127,7 +122,28 @@ interface BetaNotificationTarget {
   type: 'discord' | 'apprise';
   label: string;
   url: string;
+  urls?: string[];
   enabled: boolean;
+}
+
+interface BetaScheduleSettings {
+  enabled: boolean;
+  mode: 'hours' | 'days' | 'weekdays';
+  intervalHours: number;
+  intervalDays: number;
+  hour: number;
+  minute: number;
+  weekdays: number[];
+  nextRunAt: string | null;
+  lastRunAt: string | null;
+  lastFailedTrackerIds: string[];
+}
+
+interface BetaNotificationPreferences {
+  notifyError: boolean;
+  notifySuccess: boolean;
+  notifySuccessAfterFailure: boolean;
+  notifyStats: boolean;
 }
 
 interface BetaAlertRule {
@@ -149,6 +165,8 @@ interface BetaSettings {
   qbitClients: BetaQbitClient[];
   announceMappings: BetaAnnounceMapping[];
   notificationTargets: BetaNotificationTarget[];
+  schedule: BetaScheduleSettings;
+  notificationPreferences: BetaNotificationPreferences;
   alertRules: BetaAlertRule[];
   defaults: {
     ratioEnabled: boolean;
@@ -1248,8 +1266,8 @@ function hydrateFromSnapshots(trackers: TrackerConfig[]): TrackerConfig[] {
   return stale;
 }
 
-async function refresh(trackers: TrackerConfig[]): Promise<void> {
-  if (isRefreshing) return;
+async function refresh(trackers: TrackerConfig[]): Promise<TrackerStats[]> {
+  if (isRefreshing) return [];
   isRefreshing = true;
   console.log(`\n[${new Date().toISOString()}] Refresh...`);
   try {
@@ -1257,14 +1275,14 @@ async function refresh(trackers: TrackerConfig[]): Promise<void> {
       cachedStats = fakeStatsForPresentation();
       lastRefresh = new Date().toISOString();
       console.log('  Mode presentation actif - donnees factices');
-      return;
+      return cachedStats;
     }
 
     if (!proxyAllowsTrackerConnections()) {
       cachedStats = blockedStats(trackers);
       lastRefresh = new Date().toISOString();
       console.warn('  Connexions trackers bloquees : proxy absent et connexion directe non autorisee');
-      return;
+      return cachedStats;
     }
 
     const credentials = loadCredentialsFromDb();
@@ -1310,6 +1328,7 @@ async function refresh(trackers: TrackerConfig[]): Promise<void> {
     console.log(`  ✅ ${ok} ok  ❌ ${err} erreur(s)`);
     results.filter(s => s.status === 'error')
       .forEach(s => console.log(`  ⚠️  ${s.name}: ${s.error}`));
+    return results;
   } finally {
     isRefreshing = false;
   }
@@ -1360,27 +1379,6 @@ async function refreshOneTracker(
 
 // ─── Serveur ──────────────────────────────────────────────────────────────────
 
-function nextRandomRun(intervalHours: number): string {
-  const next = new Date();
-  // Sous-journalier (6h/12h) : prochaine = maintenant + intervalle + jitter (0-30 min)
-  // pour eviter que tous les trackers tombent pile a la meme minute.
-  if (intervalHours < 24) {
-    const jitterMs = Math.floor(Math.random() * 30 * 60_000);
-    next.setTime(next.getTime() + intervalHours * 3600_000 + jitterMs);
-    return next.toISOString();
-  }
-  // >= 24h : on planifie a un jour futur, a une heure aleatoire (etalement journalier).
-  next.setHours(0, 0, 0, 0);
-  next.setDate(next.getDate() + Math.max(1, Math.round(intervalHours / 24)));
-  next.setHours(
-    Math.floor(Math.random() * 24),
-    Math.floor(Math.random() * 60),
-    Math.floor(Math.random() * 60),
-    0,
-  );
-  return next.toISOString();
-}
-
 function shuffled<T>(items: T[]): T[] {
   const copy = [...items];
   for (let i = copy.length - 1; i > 0; i -= 1) {
@@ -1396,7 +1394,6 @@ function randomSpacingMs(): number {
 
 async function refreshScheduledTracker(
   tracker: TrackerConfig,
-  markSchedule = true,
 ): Promise<void> {
   if (isRefreshing) return;
   if (!proxyAllowsTrackerConnections()) {
@@ -1410,8 +1407,6 @@ async function refreshScheduledTracker(
     return;
   }
 
-  const schedule = getTrackerSchedule(tracker.id);
-  const intervalHours = schedule?.intervalHours ?? 24;
   const fetched = await fetchTrackerBounded(tracker, creds);
   processIncidentStreak(fetched);
   const stat = preserveLastKnownOnTimeout(tracker, fetched);
@@ -1419,63 +1414,130 @@ async function refreshScheduledTracker(
   upsertCachedStat(stat);
   logStatResult(stat);
   if (!stat.stale) saveStatSnapshots([stat]);
-  if (markSchedule) markTrackerScheduleRun(tracker.id, nextRandomRun(intervalHours));
+}
+
+function nextBetaScheduleRun(schedule: BetaScheduleSettings, from = new Date()): string | null {
+  if (!schedule.enabled) return null;
+  const next = new Date(from);
+  next.setSeconds(0, 0);
+
+  if (schedule.mode === 'hours') {
+    next.setTime(from.getTime() + schedule.intervalHours * 3600_000);
+    return next.toISOString();
+  }
+
+  next.setHours(schedule.hour, schedule.minute, 0, 0);
+  if (schedule.mode === 'days') {
+    if (next <= from) next.setDate(next.getDate() + schedule.intervalDays);
+    return next.toISOString();
+  }
+
+  const weekdays = new Set(schedule.weekdays);
+  if (weekdays.size === 0) return null;
+  for (let offset = 0; offset < 8; offset += 1) {
+    const candidate = new Date(next);
+    candidate.setDate(next.getDate() + offset);
+    if (weekdays.has(candidate.getDay()) && candidate > from) return candidate.toISOString();
+  }
+  return null;
+}
+
+async function notifyScheduledResult(
+  settings: BetaSettings,
+  results: TrackerStats[],
+  previousFailures: Set<string>,
+): Promise<void> {
+  const targets = settings.notificationTargets.filter(target => target.enabled && target.url);
+  if (targets.length === 0 || results.length === 0) return;
+
+  const errors = results.filter(result => result.status === 'error');
+  const recovered = results.filter(result => result.status === 'ok' && previousFailures.has(result.id));
+  const prefs = settings.notificationPreferences;
+  let title = '';
+  let lines: string[] = [];
+
+  if (errors.length > 0 && prefs.notifyError) {
+    title = `Tracker Dashboard : ${errors.length} echec(s)`;
+    lines = errors.map(result => `${result.name}: ${result.error || 'erreur inconnue'}`);
+  } else if (recovered.length > 0 && prefs.notifySuccessAfterFailure) {
+    title = 'Tracker Dashboard : retablissement';
+    lines = [`Sites retablis : ${recovered.map(result => result.name).join(', ')}`];
+  } else if (errors.length === 0 && prefs.notifySuccess) {
+    title = 'Tracker Dashboard : cycle termine';
+    lines = ['Tous les trackers configures sont accessibles.'];
+    if (prefs.notifyStats) {
+      lines.push(...results.map(result => `${result.name}: ${Object.entries(result.fields ?? {}).slice(0, 4).map(([key, value]) => `${key}=${String(value)}`).join(', ') || 'OK'}`));
+    }
+  }
+
+  if (!title) return;
+  const deliveries = await Promise.allSettled(targets.map(target => sendBetaNotification(target, lines.join('\n'), title)));
+  deliveries.forEach((delivery, index) => {
+    if (delivery.status === 'rejected') {
+      console.error(`[Beta Notifications] ${targets[index].label}:`, delivery.reason);
+    }
+  });
+}
+
+async function runBetaScheduledCycle(): Promise<void> {
+  if (isRefreshing || pendingScheduledRuns.has('__global__')) return;
+  const settings = loadBetaSettings();
+  if (!settings.schedule.enabled) return;
+
+  const credentials = loadCredentialsFromDb();
+  const trackers = loadTrackerConfigsFromDb().filter(tracker => tracker.enabled !== false && credentials[tracker.id]);
+  const previousFailures = new Set(settings.schedule.lastFailedTrackerIds);
+  pendingScheduledRuns.add('__global__');
+  try {
+    const results = await refresh(trackers);
+    await notifyScheduledResult(settings, results, previousFailures);
+    settings.schedule.lastFailedTrackerIds = results.filter(result => result.status === 'error').map(result => result.id);
+  } finally {
+    const current = loadBetaSettings();
+    current.schedule.lastRunAt = new Date().toISOString();
+    current.schedule.nextRunAt = nextBetaScheduleRun(current.schedule);
+    current.schedule.lastFailedTrackerIds = settings.schedule.lastFailedTrackerIds;
+    setJsonSetting(BETA_SETTINGS_KEY, current);
+    pendingScheduledRuns.delete('__global__');
+  }
 }
 
 function startScheduler(): void {
-  setInterval(() => {
-    const trackers = loadTrackerConfigsFromDb();
-    const now = Date.now();
-    const schedules = listTrackerSchedules().filter(schedule => {
-      if (!schedule.enabled || !schedule.nextRunAt) return false;
-      return new Date(schedule.nextRunAt).getTime() <= now;
-    });
-
-    let delay = 0;
-    for (const schedule of shuffled(schedules)) {
-      if (pendingScheduledRuns.has(schedule.trackerId)) continue;
-      const tracker = trackers.find(t => t.id === schedule.trackerId && t.enabled !== false);
-      if (!tracker) continue;
-      retryStates.delete(tracker.id);
-      pendingScheduledRuns.add(schedule.trackerId);
-      delay += randomSpacingMs();
-      setTimeout(() => {
-        refreshScheduledTracker(tracker)
-          .catch(err => {
-            console.error(`[${tracker.name}] Refresh planifie en erreur :`, err);
-          })
-          .finally(() => {
-            pendingScheduledRuns.delete(schedule.trackerId);
-          });
-      }, delay);
+  const tick = () => {
+    const settings = loadBetaSettings();
+    if (settings.schedule.enabled) {
+      if (!settings.schedule.nextRunAt) {
+        settings.schedule.nextRunAt = nextBetaScheduleRun(settings.schedule);
+        setJsonSetting(BETA_SETTINGS_KEY, settings);
+      } else if (Date.parse(settings.schedule.nextRunAt) <= Date.now()) {
+        void runBetaScheduledCycle().catch(err => console.error('[Beta Scheduler] cycle en erreur :', err));
+      }
     }
 
-    const retries = [...retryStates.entries()]
-      .filter(([, state]) => state.nextRunAt <= now);
+    const trackers = loadTrackerConfigsFromDb();
+    const now = Date.now();
+    let delay = 0;
+    const retries = [...retryStates.entries()].filter(([, state]) => state.nextRunAt <= now);
     for (const [trackerId] of shuffled(retries)) {
       if (pendingScheduledRuns.has(trackerId)) continue;
       if (getIncident(trackerId)?.acknowledged) {
         retryStates.delete(trackerId);
         continue;
       }
-      const tracker = trackers.find(t => t.id === trackerId && t.enabled !== false);
-      if (!tracker) {
-        retryStates.delete(trackerId);
-        continue;
-      }
+      const tracker = trackers.find(item => item.id === trackerId && item.enabled !== false);
+      if (!tracker) continue;
       pendingScheduledRuns.add(trackerId);
       delay += randomSpacingMs();
       setTimeout(() => {
-        refreshScheduledTracker(tracker, false)
-          .catch(err => {
-            console.error(`[${tracker.name}] Retry timeout en erreur :`, err);
-          })
-          .finally(() => {
-            pendingScheduledRuns.delete(trackerId);
-          });
+        refreshScheduledTracker(tracker)
+          .catch(err => console.error(`[${tracker.name}] Retry timeout en erreur :`, err))
+          .finally(() => pendingScheduledRuns.delete(trackerId));
       }, delay);
     }
-  }, 60_000);
+  };
+
+  tick();
+  setInterval(tick, 60_000);
 }
 
 // ─── Prometheus metrics ───────────────────────────────────────────────────────
@@ -1581,6 +1643,24 @@ function defaultBetaSettings(): BetaSettings {
     qbitClients: [],
     announceMappings: [],
     notificationTargets: [],
+    schedule: {
+      enabled: false,
+      mode: 'days',
+      intervalHours: 6,
+      intervalDays: 1,
+      hour: 3,
+      minute: 0,
+      weekdays: [],
+      nextRunAt: null,
+      lastRunAt: null,
+      lastFailedTrackerIds: [],
+    },
+    notificationPreferences: {
+      notifyError: true,
+      notifySuccess: false,
+      notifySuccessAfterFailure: true,
+      notifyStats: false,
+    },
     alertRules: [],
     defaults: {
       ratioEnabled: true,
@@ -1600,6 +1680,11 @@ function loadBetaSettings(): BetaSettings {
     qbitClients: Array.isArray(settings.qbitClients) ? settings.qbitClients : [],
     announceMappings: Array.isArray(settings.announceMappings) ? settings.announceMappings : [],
     notificationTargets: Array.isArray(settings.notificationTargets) ? settings.notificationTargets : [],
+    schedule: { ...defaultBetaSettings().schedule, ...(settings.schedule ?? {}) },
+    notificationPreferences: {
+      ...defaultBetaSettings().notificationPreferences,
+      ...(settings.notificationPreferences ?? {}),
+    },
     alertRules: Array.isArray(settings.alertRules) ? settings.alertRules : [],
   };
 }
@@ -1614,6 +1699,7 @@ function sanitizeBetaSettings(settings: BetaSettings): BetaSettings {
     announceMappings: settings.announceMappings,
     notificationTargets: settings.notificationTargets.map(target => ({
       ...target,
+      urls: target.urls?.map(() => '********'),
       url: target.url ? '••••••••' : '',
     })),
   };
@@ -1653,6 +1739,11 @@ function saveBetaSettingsPayload(raw: unknown): BetaSettings {
       type,
       label: String(target.label || (type === 'discord' ? 'Discord' : 'Apprise')).trim().slice(0, 80),
       url: String(url || '').trim(),
+      urls: Array.isArray(target.urls)
+        ? (target.urls.every(value => value === '********')
+          ? (previous?.urls ?? [])
+          : target.urls.map(value => String(value).trim()).filter(Boolean))
+        : (previous?.urls ?? []),
       enabled: target.enabled !== false,
     };
   }).filter(target => target.url) : current.notificationTargets;
@@ -1687,7 +1778,47 @@ function saveBetaSettingsPayload(raw: unknown): BetaSettings {
     siteDownEnabled: body.defaults?.siteDownEnabled !== false,
   };
 
-  const next = { qbitClients, announceMappings, notificationTargets, alertRules, defaults };
+  const rawSchedule = body.schedule ?? current.schedule;
+  const mode: BetaScheduleSettings['mode'] = ['hours', 'weekdays'].includes(String(rawSchedule.mode))
+    ? rawSchedule.mode as BetaScheduleSettings['mode']
+    : 'days';
+  const schedule: BetaScheduleSettings = {
+    enabled: rawSchedule.enabled === true,
+    mode,
+    intervalHours: Math.min(168, Math.max(1, Number(rawSchedule.intervalHours) || 6)),
+    intervalDays: Math.min(30, Math.max(1, Number(rawSchedule.intervalDays) || 1)),
+    hour: Math.min(23, Math.max(0, Number(rawSchedule.hour) || 0)),
+    minute: Math.min(59, Math.max(0, Number(rawSchedule.minute) || 0)),
+    weekdays: Array.isArray(rawSchedule.weekdays)
+      ? [...new Set(rawSchedule.weekdays.map(Number).filter(day => Number.isInteger(day) && day >= 0 && day <= 6))]
+      : [],
+    nextRunAt: current.schedule.nextRunAt,
+    lastRunAt: current.schedule.lastRunAt,
+    lastFailedTrackerIds: Array.isArray(current.schedule.lastFailedTrackerIds)
+      ? current.schedule.lastFailedTrackerIds
+      : [],
+  };
+  const scheduleChanged = schedule.enabled !== current.schedule.enabled
+    || schedule.mode !== current.schedule.mode
+    || schedule.intervalHours !== current.schedule.intervalHours
+    || schedule.intervalDays !== current.schedule.intervalDays
+    || schedule.hour !== current.schedule.hour
+    || schedule.minute !== current.schedule.minute
+    || schedule.weekdays.join(',') !== current.schedule.weekdays.join(',');
+  if (scheduleChanged || (schedule.enabled && !schedule.nextRunAt)) {
+    schedule.nextRunAt = nextBetaScheduleRun(schedule);
+  }
+  if (!schedule.enabled) schedule.nextRunAt = null;
+
+  const rawPreferences = body.notificationPreferences ?? current.notificationPreferences;
+  const notificationPreferences: BetaNotificationPreferences = {
+    notifyError: rawPreferences.notifyError !== false,
+    notifySuccess: rawPreferences.notifySuccess === true,
+    notifySuccessAfterFailure: rawPreferences.notifySuccessAfterFailure !== false,
+    notifyStats: rawPreferences.notifyStats === true,
+  };
+
+  const next = { qbitClients, announceMappings, notificationTargets, schedule, notificationPreferences, alertRules, defaults };
   setJsonSetting(BETA_SETTINGS_KEY, next);
   return next;
 }
@@ -2133,12 +2264,23 @@ async function refreshBetaQbitStats(settings = loadBetaSettings()): Promise<Qbit
   return results;
 }
 
-async function sendBetaNotification(target: BetaNotificationTarget, message: string): Promise<void> {
+async function sendBetaNotification(
+  target: BetaNotificationTarget,
+  message: string,
+  title = 'Tracker Dashboard Beta',
+): Promise<void> {
   if (target.type === 'discord') {
-    await axios.post(target.url, { content: message }, { timeout: 8000 });
+    const content = `**${title}**\n${message}`.slice(0, 2000);
+    await axios.post(target.url, { content }, { timeout: 8000 });
     return;
   }
-  await axios.post(target.url, { title: 'Tracker Dashboard Beta', body: message }, { timeout: 8000 });
+  if (!target.urls?.length) throw new Error('Aucune URL de destination Apprise configuree');
+  const endpoint = `${target.url.replace(/\/$/, '')}/notify/`;
+  await axios.post(endpoint, {
+    title,
+    body: message,
+    urls: (target.urls ?? []).join('\n'),
+  }, { timeout: 10_000 });
 }
 
 export async function start(): Promise<void> {
@@ -2146,7 +2288,6 @@ export async function start(): Promise<void> {
   importLegacyCredentialsIfNeeded();
   importLegacyTrackersIfNeeded();
   let trackers = normalizeTrackerConfigs();
-  ensureTrackerSchedules(trackers);
 
   const app = express();
   app.use(express.json());
@@ -2277,7 +2418,6 @@ export async function start(): Promise<void> {
 
   app.get('/api/config', (_req, res) => {
     trackers = normalizeTrackerConfigs();
-    const schedules = new Map(listTrackerSchedules().map(s => [s.trackerId, s]));
     const safe = trackers.map(({ id, name, baseUrl, enabled, dashboard, ratioless }) => ({
       id,
       name,
@@ -2285,7 +2425,6 @@ export async function start(): Promise<void> {
       enabled: enabled !== false,
       byteUnit: dashboard?.byteUnit ?? 'binary',
       ratioless: Boolean(ratioless),
-      schedule: schedules.get(id) ?? null,
     }));
     res.json({ trackers: safe });
   });
@@ -2433,7 +2572,6 @@ export async function start(): Promise<void> {
   app.get('/api/tracker-definitions', (_req, res) => {
     importLegacyTrackersIfNeeded();
     trackers = normalizeTrackerConfigs();
-    ensureTrackerSchedules(trackers);
     const configured = new Map(trackers.map(tracker => [tracker.id, tracker]));
     const definitions = listTrackerDefinitionFiles()
       .map(definition => {
@@ -2469,7 +2607,6 @@ export async function start(): Promise<void> {
     tracker.enabled = Boolean(req.body.enabled);
     saveTrackerConfig(tracker);
     trackers = normalizeTrackerConfigs();
-    ensureTrackerSchedules(trackers);
     res.json({ ok: true, tracker });
   });
 
@@ -2481,7 +2618,6 @@ export async function start(): Promise<void> {
       }
       saveTrackerConfig(config);
       trackers = loadTrackerConfigsFromDb();
-      ensureTrackerSchedules(trackers);
       res.json({ ok: true, tracker: config });
     } catch (err: unknown) {
       res.status(400).json({
@@ -2504,10 +2640,6 @@ export async function start(): Promise<void> {
       lastRefresh = new Date().toISOString();
     }
     res.json({ ok: true, enabled });
-  });
-
-  app.get('/api/schedules', (_req, res) => {
-    res.json({ schedules: listTrackerSchedules() });
   });
 
   app.get('/api/credentials', (_req, res) => {
@@ -2565,27 +2697,6 @@ export async function start(): Promise<void> {
     deleteTrackerCredentials(tracker.id);
     invalidateSession(tracker.id);
     res.json({ ok: true });
-  });
-
-  app.post('/api/schedules/:trackerId', (req, res) => {
-    trackers = loadTrackerConfigsFromDb();
-    const tracker = trackers.find(t => t.id === req.params.trackerId);
-    if (!tracker) return res.status(404).json({ ok: false, error: 'Tracker introuvable' });
-
-    const intervalHours = Number(req.body.intervalHours);
-    const allowed = [6, 12, 24, 48, 168, 504];
-    if (!allowed.includes(intervalHours)) {
-      return res.status(400).json({ ok: false, error: 'Intervalle invalide' });
-    }
-
-    const enabled = Boolean(req.body.enabled);
-    saveTrackerSchedule(
-      tracker.id,
-      enabled,
-      intervalHours,
-      enabled ? nextRandomRun(intervalHours) : null,
-    );
-    res.json({ ok: true, schedule: getTrackerSchedule(tracker.id) });
   });
 
   app.get('/api/settings/proxy', (_req, res) => {


### PR DESCRIPTION
## Resume
- remplace la planification par tracker par le calendrier global Autovisit
- ajoute les modes heures, jours et jours de semaine
- ajoute les notifications d'echec, succes, retablissement et statistiques
- prend en charge Apprise et plusieurs webhooks Discord directs
- memorise les echecs entre redemarrages

## Verifications
- npm run build
- syntaxe JavaScript inline valide
- git diff --check