### PR TITLE
Ajouter les fréquences globales et individuelles de login

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2230,6 +2230,7 @@
     notificationTargets: [],
     notificationPreferences: {},
     schedule: {},
+    scheduleOverrides: [],
     alertRules: [],
     defaults: {},
   };
@@ -3084,6 +3085,19 @@
         <div class="beta-field"><label>Jours</label><div style="display:flex;gap:8px;flex-wrap:wrap">${dayLabels.map((label, day) => `<label><input type="checkbox" data-beta-weekday="${day}" ${weekdays.has(day) ? 'checked' : ''}> ${label}</label>`).join('')}</div></div>
       </div>
       <p class="beta-note">Prochaine exécution : ${schedule.nextRunAt ? escapeHtml(new Date(schedule.nextRunAt).toLocaleString('fr-FR')) : 'non planifiée'}${schedule.lastRunAt ? ` · Dernière : ${escapeHtml(new Date(schedule.lastRunAt).toLocaleString('fr-FR'))}` : ''}</p>
+      <h4 style="margin:16px 0 8px">Fréquences individuelles</h4>
+      <p class="beta-note" style="margin-bottom:8px">Une valeur individuelle remplace la planification globale pour le tracker concerné.</p>
+      <div id="beta-schedule-overrides">
+        ${trackerConfig.filter(tracker => tracker.enabled !== false).map(tracker => {
+          const override = (betaSettings.scheduleOverrides || []).find(item => item.trackerId === tracker.id) || { mode: 'global', intervalHours: 24 };
+          const value = override.mode === 'interval' ? String(override.intervalHours) : override.mode;
+          const next = override.nextRunAt ? ` · prochaine ${escapeHtml(new Date(override.nextRunAt).toLocaleString('fr-FR'))}` : '';
+          return `<div class="beta-form-row" data-beta-schedule-override="${escapeHtml(tracker.id)}" style="grid-template-columns:2fr 1fr">
+            <div class="beta-field"><label>${escapeHtml(tracker.name)}</label><span class="beta-note">${value === 'global' ? 'Suit le calendrier global' : value === 'disabled' ? 'Login planifié désactivé' : `Toutes les ${value}h${next}`}</span></div>
+            <div class="beta-field"><label>Fréquence</label><select data-field="scheduleMode"><option value="global" ${value === 'global' ? 'selected' : ''}>Global</option><option value="disabled" ${value === 'disabled' ? 'selected' : ''}>Désactivé</option>${[6,12,24,48,168,504].map(hours => `<option value="${hours}" ${value === String(hours) ? 'selected' : ''}>${hours < 168 ? `${hours}h` : `${hours / 24}j`}</option>`).join('')}</select></div>
+          </div>`;
+        }).join('') || '<p class="beta-note">Aucun tracker actif.</p>'}
+      </div>
     `;
     updateBetaScheduleMode();
   }
@@ -3223,12 +3237,21 @@
       notifySuccessAfterFailure: document.getElementById('beta-notify-recovery')?.checked !== false,
       notifyStats: document.getElementById('beta-notify-stats')?.checked === true,
     };
+    const scheduleOverrides = Array.from(document.querySelectorAll('[data-beta-schedule-override]')).map(row => {
+      const value = row.querySelector('[data-field="scheduleMode"]').value;
+      return {
+        trackerId: row.dataset.betaScheduleOverride,
+        mode: value === 'global' || value === 'disabled' ? value : 'interval',
+        intervalHours: Number(value) || 24,
+      };
+    }).filter(override => override.mode !== 'global');
     return {
       ...betaSettings,
       qbitClients,
       announceMappings,
       notificationTargets,
       schedule,
+      scheduleOverrides,
       notificationPreferences,
       alertRules,
     };

--- a/src/server.ts
+++ b/src/server.ts
@@ -146,6 +146,14 @@ interface BetaNotificationPreferences {
   notifyStats: boolean;
 }
 
+interface BetaTrackerScheduleOverride {
+  trackerId: string;
+  mode: 'global' | 'disabled' | 'interval';
+  intervalHours: number;
+  nextRunAt: string | null;
+  lastRunAt: string | null;
+}
+
 interface BetaAlertRule {
   id: string;
   trackerId: string;
@@ -166,6 +174,7 @@ interface BetaSettings {
   announceMappings: BetaAnnounceMapping[];
   notificationTargets: BetaNotificationTarget[];
   schedule: BetaScheduleSettings;
+  scheduleOverrides: BetaTrackerScheduleOverride[];
   notificationPreferences: BetaNotificationPreferences;
   alertRules: BetaAlertRule[];
   defaults: {
@@ -1485,7 +1494,10 @@ async function runBetaScheduledCycle(): Promise<void> {
   if (!settings.schedule.enabled) return;
 
   const credentials = loadCredentialsFromDb();
-  const trackers = loadTrackerConfigsFromDb().filter(tracker => tracker.enabled !== false && credentials[tracker.id]);
+  const overridden = new Set(settings.scheduleOverrides.map(override => override.trackerId));
+  const trackers = loadTrackerConfigsFromDb().filter(tracker => (
+    tracker.enabled !== false && credentials[tracker.id] && !overridden.has(tracker.id)
+  ));
   const previousFailures = new Set(settings.schedule.lastFailedTrackerIds);
   pendingScheduledRuns.add('__global__');
   try {
@@ -1502,6 +1514,28 @@ async function runBetaScheduledCycle(): Promise<void> {
   }
 }
 
+async function runBetaTrackerSchedule(override: BetaTrackerScheduleOverride): Promise<void> {
+  if (isRefreshing || pendingScheduledRuns.has(override.trackerId)) return;
+  const settings = loadBetaSettings();
+  const tracker = loadTrackerConfigsFromDb().find(item => item.id === override.trackerId && item.enabled !== false);
+  if (!tracker || !loadCredentialsFromDb()[tracker.id]) return;
+  const previousFailures = new Set(cachedStats.filter(stat => stat.status === 'error').map(stat => stat.id));
+  pendingScheduledRuns.add(tracker.id);
+  try {
+    const result = await refreshOneTracker(tracker);
+    await notifyScheduledResult(settings, [result], previousFailures);
+  } finally {
+    const current = loadBetaSettings();
+    const saved = current.scheduleOverrides.find(item => item.trackerId === override.trackerId);
+    if (saved?.mode === 'interval') {
+      saved.lastRunAt = new Date().toISOString();
+      saved.nextRunAt = new Date(Date.now() + saved.intervalHours * 3600_000).toISOString();
+      setJsonSetting(BETA_SETTINGS_KEY, current);
+    }
+    pendingScheduledRuns.delete(tracker.id);
+  }
+}
+
 function startScheduler(): void {
   const tick = () => {
     const settings = loadBetaSettings();
@@ -1511,6 +1545,14 @@ function startScheduler(): void {
         setJsonSetting(BETA_SETTINGS_KEY, settings);
       } else if (Date.parse(settings.schedule.nextRunAt) <= Date.now()) {
         void runBetaScheduledCycle().catch(err => console.error('[Beta Scheduler] cycle en erreur :', err));
+      }
+    }
+
+    for (const override of settings.scheduleOverrides) {
+      if (override.mode === 'interval' && override.nextRunAt && Date.parse(override.nextRunAt) <= Date.now()) {
+        void runBetaTrackerSchedule(override).catch(err => {
+          console.error(`[Beta Scheduler] ${override.trackerId} en erreur :`, err);
+        });
       }
     }
 
@@ -1643,6 +1685,7 @@ function defaultBetaSettings(): BetaSettings {
     qbitClients: [],
     announceMappings: [],
     notificationTargets: [],
+    scheduleOverrides: [],
     schedule: {
       enabled: false,
       mode: 'days',
@@ -1680,6 +1723,7 @@ function loadBetaSettings(): BetaSettings {
     qbitClients: Array.isArray(settings.qbitClients) ? settings.qbitClients : [],
     announceMappings: Array.isArray(settings.announceMappings) ? settings.announceMappings : [],
     notificationTargets: Array.isArray(settings.notificationTargets) ? settings.notificationTargets : [],
+    scheduleOverrides: Array.isArray(settings.scheduleOverrides) ? settings.scheduleOverrides : [],
     schedule: { ...defaultBetaSettings().schedule, ...(settings.schedule ?? {}) },
     notificationPreferences: {
       ...defaultBetaSettings().notificationPreferences,
@@ -1810,6 +1854,31 @@ function saveBetaSettingsPayload(raw: unknown): BetaSettings {
   }
   if (!schedule.enabled) schedule.nextRunAt = null;
 
+  const previousOverrides = new Map(current.scheduleOverrides.map(override => [override.trackerId, override]));
+  const scheduleOverrides: BetaTrackerScheduleOverride[] = Array.isArray(body.scheduleOverrides)
+    ? body.scheduleOverrides.map(rawOverride => {
+      const override = rawOverride as Partial<BetaTrackerScheduleOverride>;
+      const trackerId = String(override.trackerId || '').trim();
+      const previous = previousOverrides.get(trackerId);
+      const overrideMode: BetaTrackerScheduleOverride['mode'] = ['disabled', 'interval'].includes(String(override.mode))
+        ? override.mode as BetaTrackerScheduleOverride['mode']
+        : 'global';
+      const intervalHours = [6, 12, 24, 48, 168, 504].includes(Number(override.intervalHours))
+        ? Number(override.intervalHours)
+        : 24;
+      const changed = !previous || previous.mode !== overrideMode || previous.intervalHours !== intervalHours;
+      return {
+        trackerId,
+        mode: overrideMode,
+        intervalHours,
+        nextRunAt: overrideMode === 'interval'
+          ? (changed || !previous?.nextRunAt ? new Date(Date.now() + intervalHours * 3600_000).toISOString() : previous.nextRunAt)
+          : null,
+        lastRunAt: previous?.lastRunAt ?? null,
+      };
+    }).filter(override => override.trackerId && override.mode !== 'global')
+    : current.scheduleOverrides;
+
   const rawPreferences = body.notificationPreferences ?? current.notificationPreferences;
   const notificationPreferences: BetaNotificationPreferences = {
     notifyError: rawPreferences.notifyError !== false,
@@ -1818,7 +1887,7 @@ function saveBetaSettingsPayload(raw: unknown): BetaSettings {
     notifyStats: rawPreferences.notifyStats === true,
   };
 
-  const next = { qbitClients, announceMappings, notificationTargets, schedule, notificationPreferences, alertRules, defaults };
+  const next = { qbitClients, announceMappings, notificationTargets, schedule, scheduleOverrides, notificationPreferences, alertRules, defaults };
   setJsonSetting(BETA_SETTINGS_KEY, next);
   return next;
 }


### PR DESCRIPTION
## Résumé
- conserve la planification globale Autovisit
- ajoute une fréquence individuelle par tracker
- permet Global, Désactivé, 6h, 12h, 24h, 48h, 7j ou 21j
- exclut les trackers individualisés du cycle global pour éviter les doubles logins
- affiche les contrôles dans Bêta > Alertes

## Vérifications
- npm run build
- syntaxe JavaScript inline
- vérification visuelle locale dans Bêta > Alertes
- git diff --check