### PR TITLE
feat: login avancé C411, Nexum, Torr9 + corrections HDForever, PhoenixProject et UIAmelioration login

### DIFF
--- a/config/trackers/c411.json
+++ b/config/trackers/c411.json
@@ -4,32 +4,42 @@
   "baseUrl": "https://c411.org",
   "enabled": true,
   "login": {
-    "url": "login?redirect=/",
+    "url": "login",
+    "postUrl": "api/auth/login",
     "method": "POST",
-    "contentType": "form",
+    "contentType": "json",
+    "preStep": {
+      "url": "login",
+      "extract": {
+        "_csrf": { "regex": "<meta name=\"csrf-token\" content=\"(?<value>[^\"]+)\"" }
+      }
+    },
+    "preVisitUrls": ["api/settings/public"],
+    "csrfHeader": "csrf-token",
     "body": {
       "username": "{{username}}",
-      "email": "{{username}}",
       "password": "{{password}}"
     },
+    "mfaStep": {
+      "url": "api/auth/mfa/totp",
+      "triggerField": "mfaRequired",
+      "codeField": "code",
+      "successField": "success"
+    },
+    "successField": "authenticated",
     "failurePatterns": [
-      "type=\"password\"",
-      "name=\"password\""
+      "\"message\":\"Unauthenticated",
+      "\"authenticated\":false"
     ]
   },
   "fetch": {
-    "url": "user/profile",
-    "mode": "browser",
-    "responseType": "html",
+    "url": "api/auth/me",
+    "mode": "http",
+    "responseType": "json",
     "fields": {
-      "uploadedBytes": {
-        "regex": "(?<value>\\d[\\d\\s.,]*\\s*(?:[KMGTPE](?:i?B|io|o)|B|o))[\\s\\S]{0,260}?Envoy",
-        "transform": "bytes"
-      },
-      "downloadedBytes": {
-        "regex": "(?<value>\\d[\\d\\s.,]*\\s*(?:[KMGTPE](?:i?B|io|o)|B|o))[\\s\\S]{0,260}?T(?:?l?|ele|[?e]l[?e])charg",
-        "transform": "bytes"
-      }
+      "downloadedBytes": { "path": "user.downloaded", "transform": "bytes" },
+      "uploadedBytes":   { "path": "user.uploaded",   "transform": "bytes" },
+      "ratio":           { "path": "user.ratio",      "transform": "number" }
     }
   },
   "dashboard": {

--- a/config/trackers/hdforever.json
+++ b/config/trackers/hdforever.json
@@ -30,19 +30,19 @@
     "responseType": "html",
     "fields": {
       "uploadedBytes": {
-        "regex": "(?:class=\"stat tooltip up\"[^>]*>|Envoy[ée]\\s*:[\\s\\S]{0,160}?)(?<value>[\\d\\s.,]+\\s*(?:[KMGTPE](?:i?B|io|o)|B|o))",
+        "regex": "class=\"stat tooltip up\" title=\"(?<value>[^\"]+)\"",
         "transform": "bytes"
       },
       "downloadedBytes": {
-        "regex": "(?:class=\"stat tooltip dl\"[^>]*>|Re[çc]u\\s*:[\\s\\S]{0,160}?)(?<value>[\\d\\s.,]+\\s*(?:[KMGTPE](?:i?B|io|o)|B|o))",
+        "regex": "class=\"stat tooltip dl\" title=\"(?<value>[^\"]+)\"",
         "transform": "bytes"
       },
       "ratio": {
-        "regex": "(?:class=\"tooltip r\\d+\"[^>]*>|Ratio\\s*:[\\s\\S]{0,120}?)(?<value>\\d[\\d\\s.,]*)",
+        "regex": "stats_ratio[^>]*>Ratio[^<]*<[^>]*><span class=\"tooltip r\\d+\" title=\"(?<value>[^\"]+)\"",
         "transform": "number"
       },
       "seedBonus": {
-        "regex": "(?:action=rate[^>]+>|Magasin\\s*:[\\s\\S]{0,120}?)(?<value>\\d[\\d\\s.,]*)",
+        "regex": "action=rate[^>]+>(?<value>[\\d,]+)<",
         "transform": "string"
       }
     }

--- a/config/trackers/nexum.json
+++ b/config/trackers/nexum.json
@@ -8,9 +8,20 @@
     "method": "POST",
     "contentType": "form",
     "body": {
+      "_token": "{{_token}}",
       "username": "{{username}}",
       "email": "{{username}}",
       "password": "{{password}}"
+    },
+    "preStep": {
+      "url": "login",
+      "extract": {
+        "_token": { "regex": "name=\"_token\"\\s+value=\"(?<value>[^\"]+)\"" }
+      }
+    },
+    "otpStep": {
+      "urlContains": "login/2fa",
+      "field": "code"
     },
     "failurePatterns": [
       "type=\"password\"",
@@ -20,7 +31,7 @@
   "ratioless": true,
   "fetch": {
     "url": "activity",
-    "mode": "browser",
+    "mode": "http",
     "responseType": "html",
     "fields": {
       "uploadedBytes": { "regex": "user-stat-up[^>]*>[\\s\\S]*?(?<value>\\d[\\d\\s.,]*\\s*(?:[KMGTPE](?:i?B|io|o)|B|o))\\s*</span>", "transform": "bytes" },

--- a/config/trackers/phoenixproject.json
+++ b/config/trackers/phoenixproject.json
@@ -2,17 +2,22 @@
   "id": "phoenixproject",
   "name": "Phoenix Project",
   "baseUrl": "https://phoenixproject.app",
-  "enabled": false,
+  "enabled": true,
   "login": {
     "url": "login.php",
     "method": "POST",
     "contentType": "form",
+    "mode": "browser",
     "body": {
       "username": "{{username}}",
-      "password": "{{password}}"
+      "password": "{{password}}",
+      "twofa": "{{totp}}",
+      "login": "Log in"
     },
-    "failurePatterns": ["login.php", "This is a mirage"],
-    "cookieOnly": true
+    "failurePatterns": [
+      "This is a mirage",
+      "Enter</a>"
+    ]
   },
   "fetch": {
     "url": "index.php",
@@ -20,19 +25,19 @@
     "responseType": "html",
     "fields": {
       "uploadedBytes": {
-        "regex": "stats_seeding[\\s\\S]{0,200}?title=\"(?<value>[\\d.]+ (?:TiB|GiB|MiB|KiB))\"",
+        "regex": "id=\"stats_seeding\"[\\s\\S]{0,200}?title=\"(?<value>[^\"]+)\"",
         "transform": "bytes"
       },
       "downloadedBytes": {
-        "regex": "stats_leeching[\\s\\S]{0,200}?title=\"(?<value>[\\d.]+ (?:TiB|GiB|MiB|KiB))\"",
+        "regex": "id=\"stats_leeching\"[\\s\\S]{0,200}?title=\"(?<value>[^\"]+)\"",
         "transform": "bytes"
       },
       "ratio": {
-        "regex": "stats_ratio[\\s\\S]{0,200}?title=\"(?<value>[\\d.]+)\"",
+        "regex": "id=\"stats_ratio\"[\\s\\S]{0,200}?title=\"(?<value>[^\"]+)\"",
         "transform": "number"
       },
       "seedBonus": {
-        "regex": "nav_bonus[\\s\\S]{0,200}?Bonus \\((?<value>[\\d,]+)\\)",
+        "regex": "Bonus \\((?<value>[^)]+)\\)",
         "transform": "string"
       }
     }

--- a/config/trackers/torr9.json
+++ b/config/trackers/torr9.json
@@ -4,30 +4,29 @@
   "baseUrl": "https://torr9.net",
   "enabled": true,
   "login": {
-    "url": "login?redirect=%2Fstats",
+    "url": "https://torr9.net/login",
+    "postUrl": "https://api.torr9.net/api/v1/auth/login",
     "method": "POST",
-    "contentType": "form",
+    "contentType": "json",
     "body": {
       "username": "{{username}}",
-      "email": "{{username}}",
       "password": "{{password}}"
     },
+    "successField": "token",
+    "tokenField": "token",
     "failurePatterns": [
-      "type=\"password\"",
-      "name=\"password\"",
-      "Bon Retour",
-      "Nom d'utilisateur ou adresse mail"
+      "\"message\":\"Unauthorized",
+      "\"statusCode\":401"
     ]
   },
   "fetch": {
-    "url": "stats",
-    "mode": "browser",
-    "responseType": "html",
+    "url": "https://api.torr9.net/api/v1/users/me",
+    "mode": "http",
+    "responseType": "json",
     "fields": {
-      "ratio":           { "regex": "Ratio[\\s\\S]{0,320}?>\\s*(?<value>\\d[\\d\\s.,]*)\\s*<",                              "transform": "number" },
-      "uploadedBytes":   { "regex": "Upload total[\\s\\S]{0,420}?>\\s*(?<value>\\d[\\d\\s.,]*\\s*(?:[KMGTPE](?:i?B|io|o)))\\s*<",   "transform": "bytes" },
-      "downloadedBytes": { "regex": "Download total[\\s\\S]{0,420}?>\\s*(?<value>\\d[\\d\\s.,]*\\s*(?:[KMGTPE](?:i?B|io|o)))\\s*<", "transform": "bytes" },
-      "seedBonus":       { "regex": "Score\\s*(?<value>[\\d\\s.,]+)",                                                   "transform": "string" }
+      "downloadedBytes": { "path": "total_downloaded_bytes", "transform": "bytes" },
+      "uploadedBytes":   { "path": "total_uploaded_bytes",   "transform": "bytes" },
+      "seedBonus":       { "path": "jeton_balance",          "transform": "integer" }
     }
   },
   "dashboard": { "byteUnit": "decimal" }

--- a/public/index.html
+++ b/public/index.html
@@ -1805,7 +1805,9 @@
 
 <footer class="site-footer">
   <span>Aerya</span>
-  <img src="/avatar.webp" alt="Avatar Aerya" />
+  <img src="/aerya.webp" alt="Avatar Aerya" />
+  <span>Zup</span>
+  <img src="/zup.jpg" alt="Avatar Zup" />
   <a href="https://github.com/Tracker-Dashboard/tracker-dashboard" target="_blank" rel="noreferrer noopener">GitHub</a>
   <a href="https://upandclear.org" target="_blank" rel="noreferrer noopener">Blog</a>
   <a href="https://ko-fi.com/upandclear" target="_blank" rel="noreferrer noopener">Ko-fi</a>

--- a/public/index.html
+++ b/public/index.html
@@ -3468,13 +3468,32 @@
     const sourceId = dragSourceTrackerId;
     if (!sourceId || sourceId === targetId) return;
 
-    const fromIndex = latestSortedStats.findIndex(s => s.id === sourceId);
-    const toIndex = latestSortedStats.findIndex(s => s.id === targetId);
+    // Travailler uniquement sur les stats affichées
+    const displayed = dashboardStats();
+    const fromIndex = displayed.findIndex(s => s.id === sourceId);
+    const toIndex = displayed.findIndex(s => s.id === targetId);
     if (fromIndex === -1 || toIndex === -1) return;
 
-    const [moved] = latestSortedStats.splice(fromIndex, 1);
-    latestSortedStats.splice(toIndex, 0, moved);
-    renderGrid();
+    // Réordonner les stats affichées
+    const [moved] = displayed.splice(fromIndex, 1);
+    displayed.splice(toIndex, 0, moved);
+
+    // Reconstruire latestSortedStats sans toucher aux non-affichés
+    const displayedIds = new Set(displayed.map(s => s.id));
+    const rest = latestSortedStats.filter(s => !displayedIds.has(s.id));
+    latestSortedStats = [...displayed, ...rest];
+
+    // Déplacer le nœud DOM directement sans re-render
+    const grid = getActiveGrid();
+    const sourceEl = grid.querySelector(`[data-tracker-id="${sourceId}"]`);
+    const targetEl = grid.querySelector(`[data-tracker-id="${targetId}"]`);
+    if (sourceEl && targetEl) {
+      const allCards = [...grid.children];
+      const si = allCards.indexOf(sourceEl);
+      const ti = allCards.indexOf(targetEl);
+      if (si < ti) targetEl.after(sourceEl);
+      else targetEl.before(sourceEl);
+    }
 
     try {
       await fetch('/api/settings/tracker-order', {

--- a/src/curlImpersonate.ts
+++ b/src/curlImpersonate.ts
@@ -14,9 +14,9 @@ import { getJsonSetting } from './db.js';
 
 const STATUS_MARKER = '\n__CURL_HTTP_STATUS__:';
 
-function binaryName(): string {
+function binaryName(override?: string): string {
   // Wrapper par defaut fourni par curl-impersonate (positionne ciphers + en-tetes).
-  return process.env.CURL_IMPERSONATE_BIN || 'curl_chrome116';
+  return override || process.env.CURL_IMPERSONATE_BIN || 'curl_chrome116';
 }
 
 /** Fast-path actif ? (reglage global, defaut: actif) */
@@ -110,6 +110,8 @@ export interface CurlRequestOptions {
   /** Corps brut (deja encode : form-urlencoded ou JSON selon Content-Type). */
   data?: string;
   timeoutMs?: number;
+  /** 0 = ne pas suivre les redirections (equivalent maxRedirects:0 axios). Par defaut, suit (-L). */
+  maxRedirects?: number;
 }
 
 /**
@@ -121,9 +123,11 @@ export interface CurlRequestOptions {
 export class CurlSession {
   private readonly trackerId: string;
   private readonly jarPath: string;
+  private readonly binary?: string;
 
-  constructor(trackerId: string) {
+  constructor(trackerId: string, binary?: string) {
     this.trackerId = trackerId;
+    this.binary = binary;
     this.jarPath = path.join(os.tmpdir(), `td-curl-${trackerId}-${process.pid}-${Date.now()}.jar`);
   }
 
@@ -134,18 +138,35 @@ export class CurlSession {
   async request(url: string, opts: CurlRequestOptions = {}): Promise<{ status: number; body: string } | null> {
     if (!(await checkAvailable())) return null;
     const timeoutMs = opts.timeoutMs ?? 30_000;
+    const bin = binaryName(this.binary);
     const args = [
-      '-sS', '-L', '--max-time', String(Math.ceil(timeoutMs / 1000)),
+      '-sS', '--max-time', String(Math.ceil(timeoutMs / 1000)),
       '-c', this.jarPath, '-b', this.jarPath,
       '-w', `${STATUS_MARKER}%{http_code}`,
     ];
+    if (opts.maxRedirects !== 0) args.push('-L');
     if (opts.method === 'POST') args.push('-X', 'POST');
     for (const [k, v] of Object.entries(opts.headers ?? {})) args.push('-H', `${k}: ${v}`);
     if (opts.data != null) args.push('--data-raw', opts.data);
     const proxy = curlProxyArg(this.trackerId);
     if (proxy) args.push('--proxy', proxy);
     args.push(url);
-    return execCurl(args, timeoutMs);
+    return new Promise(resolve => {
+      execFile(
+        bin,
+        args,
+        { timeout: timeoutMs + 2_000, maxBuffer: 20 * 1024 * 1024, encoding: 'utf8' },
+        (err, stdout) => {
+          const out = typeof stdout === 'string' ? stdout : '';
+          if (err && !out) { resolve(null); return; }
+          const idx = out.lastIndexOf(STATUS_MARKER);
+          if (idx === -1) { resolve({ status: 0, body: out }); return; }
+          const body = out.slice(0, idx);
+          const status = Number.parseInt(out.slice(idx + STATUS_MARKER.length).trim(), 10) || 0;
+          resolve({ status, body });
+        },
+      );
+    });
   }
 
   dispose(): void {

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -278,6 +278,8 @@ interface Session {
   client: AxiosInstance;
   jar: CookieJar;
   loggedInAt: number;
+  /** Jeton "Authorization: Bearer" recupere au login (cf. login.tokenField) */
+  bearerToken?: string;
 }
 
 // Sessions gardées en mémoire — une par tracker
@@ -424,8 +426,18 @@ async function doLogin(
     }
   }
 
+  // ── 1bis. GET preliminaires (cookies anti-bot/session, best-effort) ─────────
+  for (const preVisitUrl of cfg.preVisitUrls ?? []) {
+    try {
+      const r = await client.get<string>(resolveUrl(base, preVisitUrl), { responseType: 'text' });
+      await storeResponseCookies(jar, r);
+    } catch {
+      // best-effort uniquement
+    }
+  }
+
   // ── 2. POST login ───────────────────────────────────────────────────────────
-  const loginUrl = resolveUrl(base, cfg.url);
+  const loginUrl = resolveUrl(base, cfg.postUrl ?? cfg.url);
   const bodyObj: Record<string, string> = { ...hiddenInputs };
   for (const [k, v] of Object.entries(cfg.body)) {
     bodyObj[k] = interpolate(v, vars);
@@ -435,17 +447,70 @@ async function doLogin(
     bodyObj[cfg.otpField] = vars.otp;
   }
 
+  const jsonHeaders: Record<string, string> = {
+    'Content-Type': 'application/json',
+    'Origin': new URL(base).origin,
+    'Referer': refererUrl,
+  };
+  if (cfg.csrfHeader && vars._csrf) jsonHeaders[cfg.csrfHeader] = vars._csrf;
+
   let loginRes;
   if ((cfg.contentType ?? 'form') === 'json') {
     loginRes = await client.post<string>(loginUrl, bodyObj, {
       responseType: 'text',
       maxRedirects: 0,
-      headers: {
-        'Content-Type': 'application/json',
-        'Origin': new URL(base).origin,
-        'Referer': refererUrl,
-      },
+      headers: jsonHeaders,
     });
+    await storeResponseCookies(jar, loginRes);
+
+    // ── 2bis. Login API JSON (C411/Torr9-style) : MFA en 2 etapes, champ de
+    // succes, et jeton Bearer eventuel — flux entierement distinct du HTML.
+    let resultJson: any = null;
+    try { resultJson = JSON.parse(loginRes.data); } catch { resultJson = null; }
+
+    if (cfg.mfaStep && resultJson?.[cfg.mfaStep.triggerField]) {
+      if (!vars.otp) {
+        const dumpPath = writeLoginDebugDump(tracker, loginUrl, loginRes.data, { reason: 'mfa-no-secret' });
+        const suffix = dumpPath ? ` - dump: ${dumpPath}` : '';
+        throw new Error(`2FA requise par le tracker mais aucun secret TOTP enregistre — renseigne le secret 2FA dans Options avancees${suffix}`);
+      }
+      const mfaUrl = resolveUrl(base, cfg.mfaStep.url);
+      const mfaRes = await client.post<string>(mfaUrl, { [cfg.mfaStep.codeField]: vars.otp }, {
+        responseType: 'text',
+        maxRedirects: 0,
+        headers: jsonHeaders,
+      });
+      await storeResponseCookies(jar, mfaRes);
+      try { resultJson = JSON.parse(mfaRes.data); } catch { resultJson = null; }
+      const mfaSuccessField = cfg.mfaStep.successField ?? 'success';
+      if (!resultJson?.[mfaSuccessField]) {
+        const dumpPath = writeLoginDebugDump(tracker, mfaUrl, mfaRes.data, {
+          status: mfaRes.status,
+          reason: `champ JSON "${mfaSuccessField}" absent/false apres MFA`,
+        });
+        const suffix = dumpPath ? ` - dump: ${dumpPath}` : '';
+        throw new Error(`Login échoué — MFA: champ JSON "${mfaSuccessField}" absent/false${suffix}`);
+      }
+    } else if (cfg.successField) {
+      if (!resultJson?.[cfg.successField]) {
+        const dumpPath = writeLoginDebugDump(tracker, loginUrl, loginRes.data, {
+          status: loginRes.status,
+          reason: `champ JSON "${cfg.successField}" absent/false`,
+        });
+        const suffix = dumpPath ? ` - dump: ${dumpPath}` : '';
+        throw new Error(`Login échoué — champ JSON "${cfg.successField}" absent/false${suffix}`);
+      }
+    } else if (loginRes.status >= 400) {
+      throw new Error(`Login échoué — HTTP ${loginRes.status}`);
+    }
+
+    if (cfg.tokenField && resultJson?.[cfg.tokenField]) {
+      session.bearerToken = String(resultJson[cfg.tokenField]);
+    }
+
+    session.loggedInAt = Date.now();
+    console.log(`  [${tracker.name}] Login OK`);
+    return;
   } else {
     loginRes = await client.post<string>(
       loginUrl,
@@ -508,6 +573,45 @@ async function doLogin(
       await storeResponseCookies(jar, after2faRes);
       verificationHtml = after2faRes.data;
     }
+  } else if (cfg.otpStep && landedUrl.includes(cfg.otpStep.urlContains)) {
+    // ── 3ter. 2FA via page dediee (Nexum: /login/2fa) ─────────────────────────
+    if (!vars.otp) {
+      const dumpPath = writeLoginDebugDump(tracker, landedUrl, verificationHtml, { reason: 'otpStep-no-secret' });
+      const suffix = dumpPath ? ` - dump: ${dumpPath}` : '';
+      throw new Error(`2FA requise par le tracker mais aucun secret TOTP enregistre — renseigne le secret 2FA dans Options avancees${suffix}`);
+    }
+    const otpToken = extractCsrfToken(verificationHtml);
+    const otpBody: Record<string, string> = { ...extractHiddenInputs(verificationHtml) };
+    otpBody[cfg.otpStep.field] = vars.otp;
+    if (otpToken) otpBody['_token'] = otpToken;
+    const otpRes = await client.post<string>(landedUrl, new URLSearchParams(otpBody).toString(), {
+      responseType: 'text',
+      maxRedirects: 0,
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'Origin': new URL(base).origin,
+        'Referer': landedUrl,
+      },
+    });
+    await storeResponseCookies(jar, otpRes);
+    verificationHtml = otpRes.data;
+    const otpLoc = otpRes.headers.location;
+    if (otpRes.status >= 300 && otpRes.status < 400 && otpLoc) {
+      landedUrl = resolveUrl(landedUrl, Array.isArray(otpLoc) ? otpLoc[0] : otpLoc);
+      const afterOtpRes = await client.get<string>(landedUrl, { responseType: 'text', maxRedirects: 0 });
+      await storeResponseCookies(jar, afterOtpRes);
+      verificationHtml = afterOtpRes.data;
+    }
+    if (landedUrl.includes(cfg.otpStep.urlContains)) {
+      const dumpPath = writeLoginDebugDump(tracker, landedUrl, verificationHtml, {
+        reason: 'otpStep-2fa-refusee',
+        otp: vars.otp,
+        status: otpRes.status,
+        location: otpRes.headers.location ?? null,
+      });
+      const suffix = dumpPath ? ` - dump: ${dumpPath}` : '';
+      throw new Error(`Login échoué — 2FA refusée (code TOTP invalide/expiré ou tentatives bloquées)${suffix}`);
+    }
   }
 
   const failed = hasFailurePattern(verificationHtml, cfg.failurePatterns);
@@ -521,7 +625,6 @@ async function doLogin(
     });
     const suffix = dumpPath ? ` - dump: ${dumpPath}` : '';
     throw new Error(`Login échoué — "${failed}" trouvé dans la réponse${suffix}`);
-    throw new Error(`Login échoué — "${failed}" trouvé dans la réponse`);
   }
   if (loginRes.status >= 400 && loginRes.status !== 302) {
     const dumpPath = writeLoginDebugDump(tracker, loginUrl, verificationHtml, {
@@ -532,7 +635,6 @@ async function doLogin(
     });
     const suffix = dumpPath ? ` - dump: ${dumpPath}` : '';
     throw new Error(`Login échoué — HTTP ${loginRes.status}${suffix}`);
-    throw new Error(`Login échoué — HTTP ${loginRes.status}`);
   }
 
   session.loggedInAt = Date.now();
@@ -686,18 +788,25 @@ export async function fetchTracker(
   // Rejoue tout le flux (page CSRF -> POST -> stats) avec un jar de cookies. En cas
   // d'echec/binaire absent -> null, et la voie axios prouvee prend le relais.
   const attemptHttpViaCurl = async (): Promise<TrackerStats | null> => {
-    if (!fastFetchEnabled()) return null;
-    if (!(await CurlSession.available())) return null;
+    if (!fastFetchEnabled()) { console.log(`  [${tracker.name}] curl: fast-fetch désactivé`); return null; }
+    if (!(await CurlSession.available())) { console.log(`  [${tracker.name}] curl: binaire indisponible`); return null; }
     const cfg = tracker.login;
+    // 2FA via page dediee (Nexum) : non reproduit ici, on laisse la voie axios
+    // (doLogin) gerer ce cas.
+    if (cfg.otpStep) return null;
+    console.log(`  [${tracker.name}] curl: tentative login via ${(tracker as any).curlBinary || 'curl_chrome116'}`);
     const base = tracker.baseUrl;
     const cvars: Record<string, string> = { username: creds.username, password: creds.password };
     const totpSecret = getTrackerTotpSecret(tracker.id);
     if (totpSecret) {
       const code = generateTotp(totpSecret);
-      if (code) cvars.otp = code;
+      if (code) {
+        cvars.otp = code;
+        cvars.totp = code; // alias pour {{totp}} dans le body
+      }
     }
 
-    const sess = new CurlSession(tracker.id);
+    const sess = new CurlSession(tracker.id, (tracker as any).curlBinary);
     try {
       let referer = resolveUrl(base, cfg.url);
       let hiddenInputs: Record<string, string> = {};
@@ -706,34 +815,108 @@ export async function fetchTracker(
         const preUrl = resolveUrl(base, cfg.preStep.url);
         referer = preUrl;
         const pre = await sess.request(preUrl, { timeoutMs: 30_000 });
-        if (!pre || pre.status >= 400 || !pre.body) return null;
-        if (isAntiBotPage(pre.body)) return null; // bloque meme en Chrome TLS -> laisse axios gerer
+        if (!pre || pre.status >= 400 || !pre.body) { console.log(`  [${tracker.name}] curl: preStep échoué status=${pre?.status}`); return null; }
+        console.log(`  [${tracker.name}] curl: preStep OK status=${pre.status} len=${pre.body.length} antibot=${isAntiBotPage(pre.body)} body=${pre.body.slice(0,300)}`);
+        if (isAntiBotPage(pre.body)) { console.log(`  [${tracker.name}] curl: preStep anti-bot`); return null; }
         if (cfg.preStep.includeHiddenInputs) hiddenInputs = extractHiddenInputs(pre.body);
         for (const [key, ext] of Object.entries(cfg.preStep.extract)) {
           const m = new RegExp(ext.regex, 's').exec(pre.body);
           cvars[key] = m?.groups?.['value'] ?? m?.[1] ?? '';
-          if (!cvars[key]) return null; // token introuvable -> repli axios (dump + message clair)
+          console.log(`  [${tracker.name}] curl: preStep extract key=${key} found=${!!cvars[key]}`);
+          if (!cvars[key]) { console.log(`  [${tracker.name}] curl: preStep token '${key}' introuvable`); return null; }
         }
+      }
+
+      for (const preVisitUrl of cfg.preVisitUrls ?? []) {
+        await sess.request(resolveUrl(base, preVisitUrl), { timeoutMs: 30_000 }).catch(() => null);
       }
 
       const bodyObj: Record<string, string> = { ...hiddenInputs };
       for (const [k, v] of Object.entries(cfg.body)) bodyObj[k] = interpolate(v, cvars);
       if (cvars.otp && cfg.otpField && !(cfg.otpField in bodyObj)) bodyObj[cfg.otpField] = cvars.otp;
 
-      const loginUrl = resolveUrl(base, cfg.url);
+      const loginUrl = resolveUrl(base, cfg.postUrl ?? cfg.url);
       const isJson = (cfg.contentType ?? 'form') === 'json';
       const data = isJson ? JSON.stringify(bodyObj) : new URLSearchParams(bodyObj).toString();
+      const postHeaders: Record<string, string> = {
+        'Content-Type': isJson ? 'application/json' : 'application/x-www-form-urlencoded',
+        'Origin': new URL(base).origin,
+        'Referer': referer,
+      };
+      if (cfg.csrfHeader && cvars._csrf) postHeaders[cfg.csrfHeader] = cvars._csrf;
       const postRes = await sess.request(loginUrl, {
         method: 'POST',
         data,
-        headers: {
-          'Content-Type': isJson ? 'application/json' : 'application/x-www-form-urlencoded',
-          'Origin': new URL(base).origin,
-          'Referer': referer,
-        },
+        headers: postHeaders,
         timeoutMs: 30_000,
+        maxRedirects: isJson ? 0 : undefined,
       });
-      if (!postRes) return null;
+      if (!postRes) { console.log(`  [${tracker.name}] curl: POST login null`); return null; }
+      console.log(`  [${tracker.name}] curl: POST status=${postRes.status} len=${postRes.body.length} 2fa=${isTwoFactorPage(postRes.body)} body=${postRes.body.slice(0,300)}`);
+
+      // Flux JSON multi-etapes (MFA TOTP / jeton Bearer) : reponse API pure,
+      // pas de page HTML a parser.
+      if (isJson && (cfg.mfaStep || cfg.successField || cfg.tokenField)) {
+        let resultJson: any = null;
+        try { resultJson = JSON.parse(postRes.body); } catch { resultJson = null; }
+
+        if (cfg.mfaStep && resultJson?.[cfg.mfaStep.triggerField]) {
+          if (!cvars.otp) { console.log(`  [${tracker.name}] curl: MFA requise mais pas de TOTP configuré`); return null; }
+          const mfaUrl = resolveUrl(base, cfg.mfaStep.url);
+          const mfaHeaders: Record<string, string> = {
+            'Content-Type': 'application/json',
+            'Origin': new URL(base).origin,
+            'Referer': referer,
+          };
+          if (cfg.csrfHeader && cvars._csrf) mfaHeaders[cfg.csrfHeader] = cvars._csrf;
+          const mfaRes = await sess.request(mfaUrl, {
+            method: 'POST',
+            data: JSON.stringify({ [cfg.mfaStep.codeField]: cvars.otp }),
+            headers: mfaHeaders,
+            timeoutMs: 30_000,
+            maxRedirects: 0,
+          });
+          if (!mfaRes) { console.log(`  [${tracker.name}] curl: MFA POST null`); return null; }
+          console.log(`  [${tracker.name}] curl: MFA status=${mfaRes.status} len=${mfaRes.body.length} body=${mfaRes.body.slice(0,300)}`);
+          try { resultJson = JSON.parse(mfaRes.body); } catch { resultJson = null; }
+          const mfaSuccessField = cfg.mfaStep.successField ?? 'success';
+          if (!resultJson?.[mfaSuccessField]) {
+            console.log(`  [${tracker.name}] curl: MFA échouée, champ "${mfaSuccessField}" absent/false - body=${mfaRes.body.slice(0,300)}`);
+            return null;
+          }
+        }
+
+        let bearerToken: string | undefined;
+        if (cfg.tokenField && resultJson?.[cfg.tokenField]) bearerToken = String(resultJson[cfg.tokenField]);
+
+        const url = resolveUrl(base, interpolate(tracker.fetch.url, cvars));
+        const fetchHeaders: Record<string, string> = { Referer: loginUrl };
+        if (bearerToken) {
+          fetchHeaders['Authorization'] = `Bearer ${bearerToken}`;
+          fetchHeaders['Accept'] = 'application/json';
+        }
+        const fetchRes = await sess.request(url, { headers: fetchHeaders, timeoutMs: 30_000 });
+        if (!fetchRes || fetchRes.status >= 400 || !fetchRes.body) { console.log(`  [${tracker.name}] curl: fetch échoué status=${fetchRes?.status}`); return null; }
+        console.log(`  [${tracker.name}] curl: fetch OK status=${fetchRes.status} bodyLen=${fetchRes.body.length}`);
+        if (hasFailurePattern(fetchRes.body, cfg.failurePatterns)) { console.log(`  [${tracker.name}] curl: failure pattern détecté - début body: ${fetchRes.body.slice(0,300)}`); return null; }
+
+        if (cfg.successField) {
+          let fetchJson: any = null;
+          try { fetchJson = JSON.parse(fetchRes.body); } catch { fetchJson = null; }
+          if (!fetchJson?.[cfg.successField]) {
+            console.log(`  [${tracker.name}] curl: champ JSON "${cfg.successField}" absent/false sur fetch - body=${fetchRes.body.slice(0,300)}`);
+            return null;
+          }
+        }
+
+        try {
+          const stats = buildStatsFromHtml(url, fetchRes.body);
+          console.log(`  [${tracker.name}] Login+fetch via curl-impersonate OK (JSON/MFA)`);
+          return stats;
+        } catch {
+          return null;
+        }
+      }
 
       // 2FA en deux etapes (Fortify/UNIT3D) : si on a atterri sur la page de challenge
       if (isTwoFactorPage(postRes.body)) {
@@ -758,8 +941,9 @@ export async function fetchTracker(
 
       const url = resolveUrl(base, interpolate(tracker.fetch.url, cvars));
       const fetchRes = await sess.request(url, { headers: { Referer: loginUrl }, timeoutMs: 30_000 });
-      if (!fetchRes || fetchRes.status >= 400 || !fetchRes.body) return null;
-      if (hasFailurePattern(fetchRes.body, cfg.failurePatterns)) return null; // login KO -> repli axios
+      if (!fetchRes || fetchRes.status >= 400 || !fetchRes.body) { console.log(`  [${tracker.name}] curl: fetch échoué status=${fetchRes?.status}`); return null; }
+      console.log(`  [${tracker.name}] curl: fetch OK status=${fetchRes.status} bodyLen=${fetchRes.body.length}`);
+      if (hasFailurePattern(fetchRes.body, cfg.failurePatterns)) { console.log(`  [${tracker.name}] curl: failure pattern détecté - début body: ${fetchRes.body.slice(0,300)}`); return null; }
       if (isAnubisChallenge(fetchRes.body)) return null;
 
       try {
@@ -781,6 +965,10 @@ export async function fetchTracker(
       if (!isRetry) {
         const fast = await tryCurlFastPath();
         if (fast) return fast;
+        // Si pas de cookie sauvegardé, tenter le login complet via curl-impersonate
+        // avant de lancer le navigateur (plus léger, contourne Cloudflare passif)
+        const viaCurlFull = await attemptHttpViaCurl();
+        if (viaCurlFull) return viaCurlFull;
       }
       const browserResult = await fetchWithBrowser(tracker, creds);
       // Si on a confirme la session via un indicateur DOM specifique (TR4KER : RATIO/UPLOAD/DOWNLOAD
@@ -822,16 +1010,43 @@ export async function fetchTracker(
 
     // Fetch des stats
     const url = resolveUrl(tracker.baseUrl, interpolate(tracker.fetch.url, vars));
-    const res  = await session.client.get<string>(url, { responseType: 'text' });
+    const fetchHeaders: Record<string, string> = {};
+    if (session.bearerToken) {
+      fetchHeaders['Authorization'] = `Bearer ${session.bearerToken}`;
+      fetchHeaders['Accept'] = 'application/json';
+    }
+    const res  = await session.client.get<string>(url, { responseType: 'text', headers: fetchHeaders });
 
     if (res.status >= 400) {
       throw new Error(`HTTP ${res.status} lors du fetch de ${url}`);
     }
 
+    // Pour les logins API JSON multi-etapes (C411) : le champ de succes
+    // ("authenticated") se verifie sur la reponse du fetch, pas sur celle du login.
+    if (tracker.login.mfaStep && tracker.login.successField) {
+      let fetchJson: any = null;
+      try { fetchJson = JSON.parse(res.data); } catch { fetchJson = null; }
+      if (!fetchJson?.[tracker.login.successField]) {
+        if (isRetry) {
+          const dumpPath = writeDebugDump(tracker, url, res.data, {}, 'fetch-not-authenticated');
+          const suffix = dumpPath ? ` - dump: ${dumpPath}` : '';
+          throw new Error(`Session expirée même après re-login — vérifier les credentials${suffix}`);
+        }
+        console.log(`  [${tracker.name}] Session expirée, re-login...`);
+        invalidateSession(tracker.id);
+        session = getSession(tracker.id);
+        return attempt(true);
+      }
+    }
+
     // Détection session expirée après le fetch
     const failed = hasFailurePattern(res.data, tracker.login.failurePatterns);
     if (failed) {
-      if (isRetry) throw new Error(`Session expirée même après re-login — vérifier les credentials`);
+      if (isRetry) {
+        const dumpPath = writeDebugDump(tracker, url, res.data, {}, 'fetch-still-expired');
+        const suffix = dumpPath ? ` - dump: ${dumpPath}` : '';
+        throw new Error(`Session expirée même après re-login — vérifier les credentials${suffix}`);
+      }
       console.log(`  [${tracker.name}] Session expirée, re-login...`);
       invalidateSession(tracker.id);
       session = getSession(tracker.id);

--- a/src/server.ts
+++ b/src/server.ts
@@ -61,6 +61,7 @@ const PUBLIC_DIR = path.join(__dirname, '..', 'public');
 const SESSION_COOKIE = 'tracker_dashboard_session';
 const TRACKER_DEFINITIONS_SEEN_KEY = 'trackerDefinitionsSeen';
 const PRESENTATION_MODE_KEY = 'presentationMode';
+const TRACKER_ORDER_KEY = 'trackerOrder';
 
 function readAppVersion(): string {
   try {
@@ -381,26 +382,6 @@ const knownTrackerFields: Record<string, {
       },
     },
   },
-  nexum: {
-    fetchUrl: 'activity',
-    mode: 'browser',
-    byteUnit: 'binary',
-    ratioless: true,
-    fields: {
-      uploadedBytes: {
-        regex: 'user-stat-up[^>]*>[\\s\\S]*?(?<value>\\d[\\d\\s.,]*\\s*(?:[KMGTPE](?:i?B|io|o)|B|o))\\s*</span>',
-        transform: 'bytes',
-      },
-      seedTime: {
-        regex: 'user-stat-seed24[\\s\\S]{0,120}?</i>\\s*(?<value>[^<]+?)\\s*</span>',
-        transform: 'string',
-      },
-      dlQuota: {
-        regex: 'user-stat-dlday[\\s\\S]{0,160}?</i>\\s*(?<value>[^<]+?)\\s*</span>',
-        transform: 'string',
-      },
-    },
-  },
   yggreborn: {
     fetchUrl: 'account/',
     mode: 'browser',
@@ -469,44 +450,6 @@ const knownTrackerFields: Record<string, {
       },
       seedBonus: {
         regex: 'Crazy Bonus\\s*<a[^>]*>\\s*(?<value>[\\d\\s.,]+)',
-        transform: 'string',
-      },
-    },
-  },
-  c411: {
-    fetchUrl: 'user/profile',
-    mode: 'browser',
-    byteUnit: 'decimal',
-    fields: {
-      uploadedBytes: {
-        regex: '(?<value>\\d[\\d\\s.,]*\\s*(?:[KMGTPE](?:i?B|io|o)|B|o))[\\s\\S]{0,260}?Envoy',
-        transform: 'bytes',
-      },
-      downloadedBytes: {
-        regex: '(?<value>\\d[\\d\\s.,]*\\s*(?:[KMGTPE](?:i?B|io|o)|B|o))[\\s\\S]{0,260}?T(?:élé|ele|[ée]l[ée])charg',
-        transform: 'bytes',
-      },
-    },
-  },
-  torr9: {
-    fetchUrl: 'stats',
-    mode: 'browser',
-    byteUnit: 'decimal',
-    fields: {
-      ratio: {
-        regex: 'Ratio[\\s\\S]{0,320}?>\\s*(?<value>\\d[\\d\\s.,]*)\\s*<',
-        transform: 'number',
-      },
-      uploadedBytes: {
-        regex: 'Upload total[\\s\\S]{0,420}?>\\s*(?<value>\\d[\\d\\s.,]*\\s*(?:[KMGTPE](?:i?B|io|o)))\\s*<',
-        transform: 'bytes',
-      },
-      downloadedBytes: {
-        regex: 'Download total[\\s\\S]{0,420}?>\\s*(?<value>\\d[\\d\\s.,]*\\s*(?:[KMGTPE](?:i?B|io|o)))\\s*<',
-        transform: 'bytes',
-      },
-      seedBonus: {
-        regex: 'Score\\s*(?<value>[\\d\\s.,]+)',
         transform: 'string',
       },
     },
@@ -752,21 +695,6 @@ function normalizeTrackerConfigs(): TrackerConfig[] {
           'href="/login"',
           'aria-label="Connexion"',
           'Inscription',
-        ]),
-      ];
-      changed = true;
-    }
-    if (tracker.id === 'torr9') {
-      if (tracker.login.url !== 'login?redirect=%2Fstats') {
-        tracker.login.url = 'login?redirect=%2Fstats';
-      }
-      tracker.login.failurePatterns = [
-        ...new Set([
-          ...tracker.login.failurePatterns,
-          'Bon Retour',
-          'Nom d\'utilisateur ou adresse mail',
-          'type="password"',
-          'name="password"',
         ]),
       ];
       changed = true;
@@ -1070,6 +998,26 @@ function upsertCachedStat(stat: TrackerStats): void {
   lastRefresh = new Date().toISOString();
 }
 
+// Applique l'ordre de tuiles personnalise par l'utilisateur (drag & drop sur le
+// dashboard). Les trackers absents de l'ordre enregistre conservent leur position
+// relative et sont places apres ceux presents dans l'ordre.
+function applyTrackerOrder(stats: TrackerStats[]): TrackerStats[] {
+  const order = getJsonSetting<string[]>(TRACKER_ORDER_KEY, []);
+  if (!order.length) return stats;
+  const rank = new Map(order.map((id, i) => [id, i]));
+  return stats
+    .map((stat, index) => ({ stat, index }))
+    .sort((a, b) => {
+      const ra = rank.get(a.stat.id);
+      const rb = rank.get(b.stat.id);
+      if (ra !== undefined && rb !== undefined) return ra - rb;
+      if (ra !== undefined) return -1;
+      if (rb !== undefined) return 1;
+      return a.index - b.index;
+    })
+    .map(({ stat }) => stat);
+}
+
 function visibleStats(trackers: TrackerConfig[]): TrackerStats[] {
   const cached = new Map(cachedStats.map(stat => [stat.id, stat]));
   return trackers
@@ -1099,6 +1047,7 @@ function logStatResult(stat: TrackerStats): void {
     return;
   }
 
+  if (stat.error?.startsWith('Credentials manquants')) return;
   console.log(`  [${stat.name}] Stats ERREUR - ${stat.error ?? 'Erreur inconnue'}`);
 }
 
@@ -1308,7 +1257,7 @@ async function refresh(trackers: TrackerConfig[]): Promise<void> {
     const ok  = results.filter(s => s.status === 'ok').length;
     const err = results.filter(s => s.status === 'error').length;
     console.log(`  ✅ ${ok} ok  ❌ ${err} erreur(s)`);
-    results.filter(s => s.status === 'error')
+    results.filter(s => s.status === 'error' && !s.error?.startsWith('Credentials manquants'))
       .forEach(s => console.log(`  ⚠️  ${s.name}: ${s.error}`));
   } finally {
     isRefreshing = false;
@@ -2241,14 +2190,14 @@ export async function start(): Promise<void> {
   app.get('/api/stats', (_req, res) => {
     if (isPresentationMode()) {
       return res.json({
-        stats: fakeStatsForPresentation(),
+        stats: applyTrackerOrder(fakeStatsForPresentation()),
         lastRefresh: new Date().toISOString(),
         isRefreshing: false,
         presentationMode: true,
       });
     }
     trackers = normalizeTrackerConfigs();
-    res.json({ stats: visibleStats(trackers), lastRefresh, isRefreshing });
+    res.json({ stats: applyTrackerOrder(visibleStats(trackers)), lastRefresh, isRefreshing });
   });
 
   app.post('/api/refresh', (_req, res) => {
@@ -2504,6 +2453,19 @@ export async function start(): Promise<void> {
       lastRefresh = new Date().toISOString();
     }
     res.json({ ok: true, enabled });
+  });
+
+  // ── Ordre des tuiles (drag & drop dashboard) ───────────────────────────────
+  app.get('/api/settings/tracker-order', (_req, res) => {
+    res.json({ order: getJsonSetting<string[]>(TRACKER_ORDER_KEY, []) });
+  });
+
+  app.post('/api/settings/tracker-order', (req, res) => {
+    const order = Array.isArray(req.body?.order)
+      ? req.body.order.filter((id: unknown): id is string => typeof id === 'string')
+      : [];
+    setJsonSetting(TRACKER_ORDER_KEY, order);
+    res.json({ ok: true, order });
   });
 
   app.get('/api/schedules', (_req, res) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,12 @@ export interface PreLoginStep {
 
 export interface LoginConfig {
   url: string;
+  /**
+   * Cible du POST de login si différente de `url` (ex: page HTML de login vs
+   * endpoint API). Si absent, on poste sur `url`. `url` reste utilisé comme
+   * Referer/CSRF.
+   */
+  postUrl?: string;
   method?: 'POST' | 'GET';
   /** 'form' = application/x-www-form-urlencoded  |  'json' = application/json */
   contentType?: 'form' | 'json';
@@ -19,6 +25,49 @@ export interface LoginConfig {
    * et {{nomClé}} pour les valeurs extraites dans preStep (ex: {{_csrf}}).
    */
   body: Record<string, string>;
+  /**
+   * GET préliminaires (best-effort) avant le login, pour initialiser des cookies
+   * (anti-bot, session). Ex: la page de login HTML, un endpoint public.
+   */
+  preVisitUrls?: string[];
+  /**
+   * Login API JSON en 2 étapes (ex: C411) : si la réponse JSON du login
+   * contient `triggerField` à une valeur truthy, on poste le code TOTP en JSON
+   * vers `url` dans le champ `codeField`.
+   */
+  mfaStep?: {
+    url: string;
+    triggerField: string;
+    codeField: string;
+    /** Nom du champ indiquant le succès dans la réponse JSON du POST MFA (défaut: "success"). */
+    successField?: string;
+  };
+  /**
+   * Pour les logins API JSON (contentType: 'json') : nom du champ dans la
+   * réponse JSON du fetch (`fetch.url`) indiquant que la session est
+   * authentifiée. Si absent ou falsy, le login est considéré en échec.
+   */
+  successField?: string;
+  /**
+   * Nom du header HTTP à envoyer (sur le POST de login et l'éventuel POST MFA)
+   * contenant la valeur extraite par `preStep` dans la variable `_csrf`
+   * (ex: "csrf-token" pour C411, extrait de <meta name="csrf-token" content="...">).
+   */
+  csrfHeader?: string;
+  /**
+   * Nom du champ dans la réponse JSON de login (après mfaStep le cas échéant)
+   * contenant un jeton à injecter en "Authorization: Bearer <jeton>" pour le fetch.
+   */
+  tokenField?: string;
+  /**
+   * 2FA en 2 étapes via une page dédiée (ex: Nexum /login/2fa). Si l'URL
+   * atteinte après le POST de login contient `urlContains`, on injecte le code
+   * TOTP dans le champ `field` (+ token CSRF si présent) et on repost cette page.
+   */
+  otpStep?: {
+    urlContains: string;
+    field: string;
+  };
   /**
    * Nom du champ de formulaire recevant le code 2FA (TOTP).
    * Si défini et qu'un secret TOTP est enregistré pour le tracker, le code


### PR DESCRIPTION
## Nouveaux sites fonctionnels sans nécessiter de cookies
- **C411** : login JSON + header CSRF + MFA TOTP + vérification `authenticated` sur `api/auth/me`
- **Nexum** : login formulaire + 2FA via page dédiée `/login/2fa`
- **Torr9** : login JSON API + réutilisation du Bearer token

## Améliorations du moteur de login (`src/types.ts` + `src/fetcher.ts`)
- Ajout `LoginConfig.csrfHeader` (header CSRF à envoyer sur le login + MFA POST)
- Ajout `LoginConfig.mfaStep.successField` (champ de succès vérifié sur la réponse du fetch, pas du login)
- Ajout `LoginConfig.otpStep` (2FA via page dédiée, type `/login/2fa`)
- Nouveau flux JSON multi-étapes : login → MFA TOTP → fetch avec successField/Bearer token (curl-impersonate et axios)
- Nouveau flux 2FA page dédiée : récupération du `_token`, POST du code TOTP, vérification session
- Vérification `successField` sur la réponse du fetch avec re-login automatique si absente
- `preStep` exécuté avant `preVisitUrls` (cohérence avec Autovisit)

## Corrections
- **HDForever** : correction des regex upload/download/ratio/seedBonus
- **PhoenixProject** : ajout TOTP, passage en mode browser, correction regex

## UI
- Réparation avatar Aerya en bas de page
- Ajout avatar Zup en bas de page