### PR TITLE
feat: seeding client BitTorrent sur dashboard (cartes + tableau)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1006,6 +1006,13 @@
     .stat-label { font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: .5px; }
     .stat-value { font-size: 18px; font-weight: 700; color: var(--text); }
     .stat-unit  { font-size: 11px; color: var(--muted); font-weight: 400; }
+    .stat--qbit { grid-column: 1 / -1; }
+    .stat-source {
+      display: inline-block; margin-left: 5px; padding: 0 5px;
+      font-size: 9px; font-weight: 700; line-height: 14px; letter-spacing: .3px;
+      border-radius: 4px; background: var(--border); color: var(--muted);
+      vertical-align: middle; cursor: help; text-transform: none;
+    }
 
     .col-good   { color: var(--green);  }
     .col-warn   { color: var(--yellow); }
@@ -1991,6 +1998,25 @@
       <div class="stat">
         <span class="stat-label">${label}</span>
         <span class="stat-value ${colorClass ?? ''}">${val ?? '-'}${u ? ' ' : ''}<span class="stat-unit">${u}</span></span>
+      </div>`;
+  }
+
+  // Etiquette de source selon les types de clients ayant contribue : qBit / Rto / qBit Rto.
+  function qbitSourceLabel(types) {
+    const set = new Set(Array.isArray(types) ? types : []);
+    const parts = [];
+    if (set.has('qbittorrent')) parts.push('qBit');
+    if (set.has('rutorrent')) parts.push('Rto');
+    return parts.length ? parts.join(' ') : 'qBit';
+  }
+
+  // Cellule pleine largeur dediee au seed remonte depuis les clients BitTorrent, distincte du
+  // seeding scrape sur le site. Badge (qBit / Rto / qBit Rto) + infobulle pour signaler la source.
+  function statCellQbitSeeding(value, types) {
+    return `
+      <div class="stat stat--qbit">
+        <span class="stat-label">Seeding <span class="stat-source" title="Torrents en seed remontés depuis vos clients BitTorrent">${qbitSourceLabel(types)}</span></span>
+        <span class="stat-value">${formatCount(value)}</span>
       </div>`;
   }
 
@@ -3552,6 +3578,7 @@
         return 0;
       }
       case 'seeding':  return toNum(f.seeding);
+      case 'qbitseeding': return toNum(stat.qbitSeeding);
       case 'bonus':    return toNum(hasStatValue(f.seedBonus) ? f.seedBonus : f.points);
       case 'status':   return stat.status === 'error' ? 1 : 0; // erreurs regroupees
       default:         return 0;
@@ -3757,6 +3784,7 @@
           ${statCell('Ratio', hasRatio ? formatRatio(ratio) : '-', '', ratioClass(ratio))}
           ${statCell('Buffer', buffer, '', bufferClass(buffer))}
           ${bottomCells}
+          ${hasStatValue(stat.qbitSeeding) ? statCellQbitSeeding(stat.qbitSeeding, stat.qbitSeedingTypes) : ''}
         </div>
         ${stat.stale ? renderIncidentBox(stat) : ''}
         <div class="card-footer">Derniere connexion : ${lastLoginText(stat)}</div>
@@ -3815,6 +3843,9 @@
     const buf = isError ? '<span class="cell-muted">—</span>'
       : `<span class="${bufferClass(formatBuffer(f, byteUnit))}">${bufferText(f, byteUnit)}</span>`;
     const seeding = isError ? '<span class="cell-muted">—</span>' : formatCount(f.seeding);
+    const qbitSeed = isError || !hasStatValue(stat.qbitSeeding)
+      ? '<span class="cell-muted">—</span>'
+      : `${formatCount(stat.qbitSeeding)} <span class="stat-source" title="Torrents en seed remontés depuis vos clients BitTorrent">${qbitSourceLabel(stat.qbitSeedingTypes)}</span>`;
     // Bonus : seedBonus pour les trackers a ratio, ou Points pour les ratioless
     const bonusRaw = hasStatValue(f.seedBonus) ? f.seedBonus : f.points;
     const bonus   = isError ? '<span class="cell-muted">—</span>' : formatCount(bonusRaw);
@@ -3834,6 +3865,7 @@
         <td class="num">${ratioCell}</td>
         <td class="num">${buf}</td>
         <td class="num">${seeding}</td>
+        <td class="num">${qbitSeed}</td>
         <td class="num">${bonus}</td>
         ${statusCell}
       </tr>`;
@@ -3847,7 +3879,7 @@
       : '';
     const subRow = `
       <tr class="row-expanded">
-        <td colspan="11">
+        <td colspan="12">
           <div class="row-expanded-inner">
             <div class="row-error-msg">
               <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="flex-shrink:0;margin-top:1px">
@@ -3888,6 +3920,7 @@
             ${th('ratio', 'Ratio')}
             ${th('buffer', 'Buffer')}
             ${th('seeding', 'Seeding')}
+            ${th('qbitseeding', 'Seeding client')}
             ${th('bonus', 'Bonus')}
             ${th('status', 'Statut')}
           </tr>

--- a/public/index.html
+++ b/public/index.html
@@ -3717,6 +3717,9 @@
       const errorOrIncidentBadge = isIncident
         ? '<span class="badge badge-incident" title="Probleme connu signale manuellement">Incident connu</span>'
         : '<span class="badge badge-error">Erreur</span>';
+      const qbitSeeding = hasStatValue(stat.qbitSeeding)
+        ? `<div class="stats">${statCellQbitSeeding(stat.qbitSeeding, stat.qbitSeedingTypes)}</div>`
+        : '';
       const badges = `
         ${errorOrIncidentBadge}
         ${offlineBadge}
@@ -3740,6 +3743,7 @@
             ${stat.error ?? 'Erreur inconnue'}
           </div>
           ${reachabilityLine}
+          ${qbitSeeding}
           ${incidentBox}
           <div class="card-footer">Derniere connexion : ${lastLoginText(stat)}</div>
         </div>`;
@@ -3843,7 +3847,7 @@
     const buf = isError ? '<span class="cell-muted">—</span>'
       : `<span class="${bufferClass(formatBuffer(f, byteUnit))}">${bufferText(f, byteUnit)}</span>`;
     const seeding = isError ? '<span class="cell-muted">—</span>' : formatCount(f.seeding);
-    const qbitSeed = isError || !hasStatValue(stat.qbitSeeding)
+    const qbitSeed = !hasStatValue(stat.qbitSeeding)
       ? '<span class="cell-muted">—</span>'
       : `${formatCount(stat.qbitSeeding)} <span class="stat-source" title="Torrents en seed remontés depuis vos clients BitTorrent">${qbitSourceLabel(stat.qbitSeedingTypes)}</span>`;
     // Bonus : seedBonus pour les trackers a ratio, ou Points pour les ratioless

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -851,6 +851,16 @@ export async function fetchTracker(
       if (!postRes) { console.log(`  [${tracker.name}] curl: POST login null`); return null; }
       console.log(`  [${tracker.name}] curl: POST status=${postRes.status} len=${postRes.body.length} 2fa=${isTwoFactorPage(postRes.body)}`);
 
+      if (!isJson && !cfg.mfaStep && hasFailurePattern(postRes.body, cfg.failurePatterns)) {
+        const dumpPath = writeLoginDebugDump(tracker, loginUrl, postRes.body, {
+          reason: 'curl-login-failed',
+          status: postRes.status,
+          bodyFieldNames: Object.keys(bodyObj),
+        });
+        console.log(`  [${tracker.name}] curl: login échoué (formulaire de login retourné) - dump: ${dumpPath}`);
+        return null;
+      }
+
       // Flux JSON multi-etapes (MFA TOTP / jeton Bearer) : reponse API pure,
       // pas de page HTML a parser.
       if (isJson && (cfg.mfaStep || cfg.successField || cfg.tokenField)) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1926,6 +1926,39 @@ function betaClientLogName(client: BetaQbitClient): string {
   return `${client.label || client.id || 'Client BitTorrent'} (${client.type === 'rutorrent' ? 'ruTorrent/rTorrent' : 'qBittorrent'})`;
 }
 
+// Agrege le nombre de torrents en seed remonte par les clients BitTorrent, par trackerId, en
+// sommant tous les clients (qBittorrent et/ou rTorrent). On collecte aussi l'ensemble des types
+// de clients ayant contribue, pour l'etiquette (qBit / Rto / qBit Rto). On reutilise le meme
+// matching host d'annonce -> tracker que l'onglet beta (mappings manuels + heuristique).
+// Retourne une map vide si aucune synchro BitTorrent n'a encore tourne (betaQbitStats en memoire).
+function qbitSeedingByTrackerId(trackers: TrackerConfig[]): Map<string, { count: number; types: Set<string> }> {
+  const result = new Map<string, { count: number; types: Set<string> }>();
+  if (betaQbitStats.length === 0) return result;
+  const settings = loadBetaSettings();
+  const clientType = new Map(settings.qbitClients.map(client => [client.id, client.type === 'rutorrent' ? 'rutorrent' : 'qbittorrent']));
+  const trackerHosts = new Map<string, string>();
+  for (const tracker of trackers) {
+    const host = trackerHost(tracker.baseUrl);
+    trackerHosts.set(host, tracker.id);
+    trackerHosts.set(hostDomainKey(host), tracker.id);
+  }
+  for (const mapping of settings.announceMappings) {
+    const host = trackerHost(mapping.announceHost);
+    trackerHosts.set(host, mapping.trackerId);
+    trackerHosts.set(hostDomainKey(host), mapping.trackerId);
+  }
+  for (const item of betaQbitStats) {
+    const trackerId = betaTrackerIdForAnnounceHost(item.trackerHost, trackerHosts, trackers);
+    if (!trackerId) continue;
+    const entry = result.get(trackerId) ?? { count: 0, types: new Set<string>() };
+    entry.count += item.seedingCount;
+    const type = clientType.get(item.clientId);
+    if (type) entry.types.add(type);
+    result.set(trackerId, entry);
+  }
+  return result;
+}
+
 function betaLog(message: string): void {
   console.log(`[Beta BitTorrent] ${message}`);
 }
@@ -2430,7 +2463,16 @@ export async function start(): Promise<void> {
       });
     }
     trackers = normalizeTrackerConfigs();
-    res.json({ stats: visibleStats(trackers), lastRefresh, isRefreshing });
+    const qbitSeeding = qbitSeedingByTrackerId(trackers);
+    const stats = visibleStats(trackers).map(stat => {
+      const entry = qbitSeeding.get(stat.id);
+      return {
+        ...stat,
+        qbitSeeding: entry ? entry.count : null,
+        qbitSeedingTypes: entry ? [...entry.types] : [],
+      };
+    });
+    res.json({ stats, lastRefresh, isRefreshing });
   });
 
   app.post('/api/refresh', (_req, res) => {
@@ -3080,6 +3122,24 @@ export async function start(): Promise<void> {
       })
       .catch(() => { /* best-effort */ });
   }, 30_000);
+
+  // Synchro automatique des clients BitTorrent (beta) au demarrage. betaQbitStats etant
+  // en memoire, la liste est vide a chaque restart tant qu'aucune synchro manuelle n'a
+  // tourne. On la repeuple automatiquement, sans bloquer le boot et en best-effort. Petit
+  // delai pour ne pas concurrencer le refresh des stats trackers au tout debut.
+  setTimeout(() => {
+    const enabledClients = loadBetaSettings().qbitClients.filter(client => client.enabled);
+    if (enabledClients.length === 0) {
+      return;
+    }
+    betaLog(`synchro automatique au demarrage: ${enabledClients.length} client(s) actif(s)`);
+    refreshBetaQbitStats()
+      .then(stats => {
+        const torrentCount = stats.reduce((sum, item) => sum + item.torrentCount, 0);
+        betaLog(`synchro automatique terminee: ${torrentCount} torrent(s), ${stats.length} hote(s)`);
+      })
+      .catch(err => betaWarn(`synchro automatique au demarrage KO - ${err instanceof Error ? err.message : String(err)}`));
+  }, 15_000);
 
   startScheduler();
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -152,6 +152,10 @@ export interface TrackerStats {
   lastLoginAt?: string;
   byteUnit: 'binary' | 'decimal';
   fields: Record<string, string | number>;
+  /** Nombre de torrents en seed remonte depuis qBittorrent (host d'annonce -> tracker). null si pas de client mappe. */
+  qbitSeeding?: number | null;
+  /** Types de clients BitTorrent ayant contribue au seeding ('qbittorrent' | 'rutorrent'), pour l'etiquette. */
+  qbitSeedingTypes?: string[];
   /** Incident "connu" manuellement signale par l'utilisateur (auto-clear sur status=ok) */
   incident?: { acknowledged: boolean; note: string };
   /** Dernieres donnees OK conservees apres un timeout ponctuel du refresh courant. */


### PR DESCRIPTION
- types.ts : ajout qbitSeeding et qbitSeedingTypes sur TrackerStats
- server.ts : helper qbitSeedingByTrackerId (sommation multi-clients, collecte des types qBit/Rto), annotation dans /api/stats, synchro auto qBittorrent au démarrage (15s)
- index.html : cellule Seeding client (cartes pleine largeur + colonne tableau), badge dynamique qBit / Rto / qBit Rto avec infobulle, triable