### PR TITLE
CI : autoriser la mise à jour des branches de PR

### DIFF
--- a/.github/workflows/pr-auto-integration.yml
+++ b/.github/workflows/pr-auto-integration.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   prepare:


### PR DESCRIPTION
## Résumé

- accorde au workflow de préparation le droit d'écrire sur les pull requests
- évite l'erreur 403 lors de la synchronisation d'une branche interne avec main`n
## Validation

- modification limitée aux permissions du workflow