### PR TITLE
feat: login avancé C411, Nexum, Torr9 + corrections HDForever et Phoe…

### DIFF
--- a/config/trackers/phoenixproject.json
+++ b/config/trackers/phoenixproject.json
@@ -8,6 +8,7 @@
     "url": "login.php",
     "method": "POST",
     "contentType": "form",
+    "mode": "browser",
     "body": {
       "username": "{{username}}",
       "password": "{{password}}",

--- a/src/curlImpersonate.ts
+++ b/src/curlImpersonate.ts
@@ -145,6 +145,7 @@ export class CurlSession {
   async request(url: string, opts: CurlRequestOptions = {}): Promise<{ status: number; body: string } | null> {
     if (!(await checkAvailable(this.binary))) return null;
     const timeoutMs = opts.timeoutMs ?? 30_000;
+    const bin = binaryName(this.binary);
     const args = [
       '-sS', '--max-time', String(Math.ceil(timeoutMs / 1000)),
       '-c', this.jarPath, '-b', this.jarPath,

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -480,7 +480,9 @@ async function doLogin(
 
     if (cfg.mfaStep && resultJson?.[cfg.mfaStep.triggerField]) {
       if (!vars.otp) {
-        throw new Error('2FA requise par le tracker mais aucun secret TOTP enregistre — renseigne le secret 2FA dans Options avancees');
+        const dumpPath = writeLoginDebugDump(tracker, loginUrl, loginRes.data, { reason: 'mfa-no-secret' });
+        const suffix = dumpPath ? ` - dump: ${dumpPath}` : '';
+        throw new Error(`2FA requise par le tracker mais aucun secret TOTP enregistre — renseigne le secret 2FA dans Options avancees${suffix}`);
       }
       const mfaUrl = resolveUrl(base, cfg.mfaStep.url);
       const mfaRes = await client.post<string>(mfaUrl, { [cfg.mfaStep.codeField]: vars.otp }, {
@@ -492,11 +494,21 @@ async function doLogin(
       resultJson = parseJsonRecord(mfaRes.data);
       const mfaSuccessField = cfg.mfaStep.successField ?? 'success';
       if (!resultJson?.[mfaSuccessField]) {
-        throw new Error(`Login échoué — MFA: champ JSON "${mfaSuccessField}" absent/false`);
+        const dumpPath = writeLoginDebugDump(tracker, mfaUrl, mfaRes.data, {
+          status: mfaRes.status,
+          reason: `champ JSON "${mfaSuccessField}" absent/false apres MFA`,
+        });
+        const suffix = dumpPath ? ` - dump: ${dumpPath}` : '';
+        throw new Error(`Login échoué — MFA: champ JSON "${mfaSuccessField}" absent/false${suffix}`);
       }
     } else if (cfg.successField) {
       if (!resultJson?.[cfg.successField]) {
-        throw new Error(`Login échoué — champ JSON "${cfg.successField}" absent/false`);
+        const dumpPath = writeLoginDebugDump(tracker, loginUrl, loginRes.data, {
+          status: loginRes.status,
+          reason: `champ JSON "${cfg.successField}" absent/false`,
+        });
+        const suffix = dumpPath ? ` - dump: ${dumpPath}` : '';
+        throw new Error(`Login échoué — champ JSON "${cfg.successField}" absent/false${suffix}`);
       }
     } else if (loginRes.status >= 400) {
       throw new Error(`Login échoué — HTTP ${loginRes.status}`);
@@ -603,6 +615,7 @@ async function doLogin(
     if (landedUrl.includes(cfg.otpStep.urlContains)) {
       const dumpPath = writeLoginDebugDump(tracker, landedUrl, verificationHtml, {
         reason: 'otpStep-2fa-refusee',
+        otp: vars.otp,
         status: otpRes.status,
         location: otpRes.headers.location ?? null,
       });
@@ -785,13 +798,14 @@ export async function fetchTracker(
   // Rejoue tout le flux (page CSRF -> POST -> stats) avec un jar de cookies. En cas
   // d'echec/binaire absent -> null, et la voie axios prouvee prend le relais.
   const attemptHttpViaCurl = async (): Promise<TrackerStats | null> => {
-    if (!fastFetchEnabled()) return null;
+    if (!fastFetchEnabled()) { console.log(`  [${tracker.name}] curl: fast-fetch désactivé`); return null; }
     const cfg = tracker.login;
     // 2FA via page dediee (Nexum) : non reproduit ici, on laisse la voie axios
     // (doLogin) gerer ce cas.
     if (cfg.otpStep) return null;
     if (cfg.cookieOnly) return null;
-    if (!(await CurlSession.available(tracker.curlBinary))) return null;
+    if (!(await CurlSession.available(tracker.curlBinary))) { console.log(`  [${tracker.name}] curl: binaire indisponible`); return null; }
+    console.log(`  [${tracker.name}] curl: tentative login via ${tracker.curlBinary || 'curl_chrome116'}`);
     const base = tracker.baseUrl;
     const cvars: Record<string, string> = { username: creds.username, password: creds.password };
     const totpSecret = getTrackerTotpSecret(tracker.id);
@@ -813,7 +827,7 @@ export async function fetchTracker(
         referer = preUrl;
         const pre = await sess.request(preUrl, { timeoutMs: 30_000 });
         if (!pre || pre.status >= 400 || !pre.body) { console.log(`  [${tracker.name}] curl: preStep échoué status=${pre?.status}`); return null; }
-        console.log(`  [${tracker.name}] curl: preStep OK status=${pre.status} len=${pre.body.length} antibot=${isAntiBotPage(pre.body)}`);
+        console.log(`  [${tracker.name}] curl: preStep OK status=${pre.status} len=${pre.body.length} antibot=${isAntiBotPage(pre.body)} body=${pre.body.slice(0,300)}`);
         if (isAntiBotPage(pre.body)) { console.log(`  [${tracker.name}] curl: preStep anti-bot`); return null; }
         if (cfg.preStep.includeHiddenInputs) hiddenInputs = extractHiddenInputs(pre.body);
         for (const [key, ext] of Object.entries(cfg.preStep.extract)) {
@@ -849,7 +863,7 @@ export async function fetchTracker(
         maxRedirects: isJson ? 0 : undefined,
       });
       if (!postRes) { console.log(`  [${tracker.name}] curl: POST login null`); return null; }
-      console.log(`  [${tracker.name}] curl: POST status=${postRes.status} len=${postRes.body.length} 2fa=${isTwoFactorPage(postRes.body)}`);
+      console.log(`  [${tracker.name}] curl: POST status=${postRes.status} len=${postRes.body.length} 2fa=${isTwoFactorPage(postRes.body)} body=${postRes.body.slice(0,300)}`);
 
       if (!isJson && !cfg.mfaStep && hasFailurePattern(postRes.body, cfg.failurePatterns)) {
         const dumpPath = writeLoginDebugDump(tracker, loginUrl, postRes.body, {
@@ -883,11 +897,11 @@ export async function fetchTracker(
             maxRedirects: 0,
           });
           if (!mfaRes) { console.log(`  [${tracker.name}] curl: MFA POST null`); return null; }
-          console.log(`  [${tracker.name}] curl: MFA status=${mfaRes.status} len=${mfaRes.body.length}`);
+          console.log(`  [${tracker.name}] curl: MFA status=${mfaRes.status} len=${mfaRes.body.length} body=${mfaRes.body.slice(0,300)}`);
           resultJson = parseJsonRecord(mfaRes.body);
           const mfaSuccessField = cfg.mfaStep.successField ?? 'success';
           if (!resultJson?.[mfaSuccessField]) {
-            console.log(`  [${tracker.name}] curl: MFA échouée, champ "${mfaSuccessField}" absent/false`);
+            console.log(`  [${tracker.name}] curl: MFA échouée, champ "${mfaSuccessField}" absent/false - body=${mfaRes.body.slice(0,300)}`);
             return null;
           }
         }
@@ -904,12 +918,12 @@ export async function fetchTracker(
         const fetchRes = await sess.request(url, { headers: fetchHeaders, timeoutMs: 30_000 });
         if (!fetchRes || fetchRes.status >= 400 || !fetchRes.body) { console.log(`  [${tracker.name}] curl: fetch échoué status=${fetchRes?.status}`); return null; }
         console.log(`  [${tracker.name}] curl: fetch OK status=${fetchRes.status} bodyLen=${fetchRes.body.length}`);
-        if (hasFailurePattern(fetchRes.body, cfg.failurePatterns)) { console.log(`  [${tracker.name}] curl: failure pattern détecté`); return null; }
+        if (hasFailurePattern(fetchRes.body, cfg.failurePatterns)) { console.log(`  [${tracker.name}] curl: failure pattern détecté - début body: ${fetchRes.body.slice(0,300)}`); return null; }
 
         if (cfg.successField) {
           const fetchJson = parseJsonRecord(fetchRes.body);
           if (!fetchJson?.[cfg.successField]) {
-            console.log(`  [${tracker.name}] curl: champ JSON "${cfg.successField}" absent/false sur fetch`);
+            console.log(`  [${tracker.name}] curl: champ JSON "${cfg.successField}" absent/false sur fetch - body=${fetchRes.body.slice(0,300)}`);
             return null;
           }
         }
@@ -948,7 +962,7 @@ export async function fetchTracker(
       const fetchRes = await sess.request(url, { headers: { Referer: loginUrl }, timeoutMs: 30_000 });
       if (!fetchRes || fetchRes.status >= 400 || !fetchRes.body) { console.log(`  [${tracker.name}] curl: fetch échoué status=${fetchRes?.status}`); return null; }
       console.log(`  [${tracker.name}] curl: fetch OK status=${fetchRes.status} bodyLen=${fetchRes.body.length}`);
-      if (hasFailurePattern(fetchRes.body, cfg.failurePatterns)) { console.log(`  [${tracker.name}] curl: failure pattern détecté`); return null; }
+      if (hasFailurePattern(fetchRes.body, cfg.failurePatterns)) { console.log(`  [${tracker.name}] curl: failure pattern détecté - début body: ${fetchRes.body.slice(0,300)}`); return null; }
       if (isAnubisChallenge(fetchRes.body)) return null;
 
       try {

--- a/src/server.ts
+++ b/src/server.ts
@@ -30,6 +30,7 @@ import {
   listStatSnapshots,
   listTrackerCredentialSummaries,
   listTrackerDefinitionFiles,
+  listTrackerSchedules,
   loadCredentialsFromDb,
   loadTrackerConfigsFromDb,
   loadTrackerDefinitionFile,
@@ -1057,6 +1058,26 @@ function upsertCachedStat(stat: TrackerStats): void {
     annotated,
   ];
   lastRefresh = new Date().toISOString();
+}
+
+// Applique l'ordre de tuiles personnalise par l'utilisateur (drag & drop sur le
+// dashboard). Les trackers absents de l'ordre enregistre conservent leur position
+// relative et sont places apres ceux presents dans l'ordre.
+function applyTrackerOrder(stats: TrackerStats[]): TrackerStats[] {
+  const order = getJsonSetting<string[]>(TRACKER_ORDER_KEY, []);
+  if (!order.length) return stats;
+  const rank = new Map(order.map((id, i) => [id, i]));
+  return stats
+    .map((stat, index) => ({ stat, index }))
+    .sort((a, b) => {
+      const ra = rank.get(a.stat.id);
+      const rb = rank.get(b.stat.id);
+      if (ra !== undefined && rb !== undefined) return ra - rb;
+      if (ra !== undefined) return -1;
+      if (rb !== undefined) return 1;
+      return a.index - b.index;
+    })
+    .map(({ stat }) => stat);
 }
 
 function visibleStats(trackers: TrackerConfig[]): TrackerStats[] {
@@ -2456,7 +2477,7 @@ export async function start(): Promise<void> {
   app.get('/api/stats', (_req, res) => {
     if (isPresentationMode()) {
       return res.json({
-        stats: fakeStatsForPresentation(),
+        stats: applyTrackerOrder(fakeStatsForPresentation()),
         lastRefresh: new Date().toISOString(),
         isRefreshing: false,
         presentationMode: true,
@@ -2464,7 +2485,7 @@ export async function start(): Promise<void> {
     }
     trackers = normalizeTrackerConfigs();
     const qbitSeeding = qbitSeedingByTrackerId(trackers);
-    const stats = visibleStats(trackers).map(stat => {
+    const stats = applyTrackerOrder(visibleStats(trackers)).map(stat => {
       const entry = qbitSeeding.get(stat.id);
       return {
         ...stat,
@@ -2735,6 +2756,23 @@ export async function start(): Promise<void> {
       lastRefresh = new Date().toISOString();
     }
     res.json({ ok: true, enabled });
+  });
+
+  // ── Ordre des tuiles (drag & drop dashboard) ───────────────────────────────
+  app.get('/api/settings/tracker-order', (_req, res) => {
+    res.json({ order: getJsonSetting<string[]>(TRACKER_ORDER_KEY, []) });
+  });
+
+  app.post('/api/settings/tracker-order', (req, res) => {
+    const order = Array.isArray(req.body?.order)
+      ? req.body.order.filter((id: unknown): id is string => typeof id === 'string')
+      : [];
+    setJsonSetting(TRACKER_ORDER_KEY, order);
+    res.json({ ok: true, order });
+  });
+
+  app.get('/api/schedules', (_req, res) => {
+    res.json({ schedules: listTrackerSchedules() });
   });
 
   app.get('/api/credentials', (_req, res) => {


### PR DESCRIPTION
Corrections de login pour rendre fonctionnels plusieurs trackers (testées sur l'environnement de dev).

## Sites fonctionnels sans cookie
- **C411** : login JSON + header CSRF + MFA TOTP + vérification `authenticated` sur `api/auth/me`
- **Nexum** : login formulaire + 2FA via page dédiée `/login/2fa`
- **Torr9** : login JSON API + réutilisation du Bearer token

## Moteur de login (`src/types.ts`, `src/fetcher.ts`, `src/curlImpersonate.ts`)
- Ajout `csrfHeader`, `mfaStep.successField`, `otpStep`
- Flux JSON multi-étapes (MFA TOTP + Bearer token) — voies axios et curl-impersonate
- Flux 2FA page dédiée (`otpStep`), vérification `successField` avec re-login auto
- `preStep` exécuté avant `preVisitUrls`

## Corrections
- **HDForever** : regex upload/download/ratio/seedBonus
- **PhoenixProject** : TOTP, `curlBinary: curl_firefox135`, `cookieOnly` désactivé, regex

## Conflits résolus
Rebase sur `main` : conservation de `parseJsonRecord` + dumps de debug, fusion avec `applyTrackerOrder` / qbitSeeding / endpoints schedules.