### PR TITLE
fix: sync définitions canoniques depuis l'image + seeding unifié + regex Orpheus

### DIFF
--- a/config/trackers/orpheus.json
+++ b/config/trackers/orpheus.json
@@ -29,10 +29,10 @@
     "mode": "browser",
     "responseType": "html",
     "fields": {
-      "downloadedBytes": { "regex": "id=\"stats_leeching\"[^>]*title=\"(?<value>[^\"]+)\"", "transform": "bytes" },
-      "uploadedBytes":   { "regex": "id=\"stats_seeding\"[^>]*title=\"(?<value>[^\"]+)\"",   "transform": "bytes" },
-      "ratio":           { "regex": "id=\"stats_ratio\"[^>]*title=\"(?<value>[^\"]+)\"",     "transform": "number" },
-      "seedBonus":       { "regex": "Bonus \\((?<value>[^)]+)\\)",                           "transform": "string" }
+      "downloadedBytes": { "regex": "id=\"stats_leeching\"[\\s\\S]*?title=\"(?<value>[^\"]+)\"", "transform": "bytes" },
+      "uploadedBytes":   { "regex": "id=\"stats_seeding\"[\\s\\S]*?title=\"(?<value>[^\"]+)\"",  "transform": "bytes" },
+      "ratio":           { "regex": "id=\"stats_ratio\"[\\s\\S]*?title=\"(?<value>[^\"]+)\"",    "transform": "number" },
+      "seedBonus":       { "regex": "Bonus \\((?<value>[^)]+)\\)",                              "transform": "string" }
     }
   },
   "dashboard": { "byteUnit": "binary" }

--- a/public/index.html
+++ b/public/index.html
@@ -2010,13 +2010,43 @@
     return parts.length ? parts.join(' ') : 'qBit';
   }
 
-  // Cellule pleine largeur dediee au seed remonte depuis les clients BitTorrent, distincte du
-  // seeding scrape sur le site. Badge (qBit / Rto / qBit Rto) + infobulle pour signaler la source.
-  function statCellQbitSeeding(value, types) {
+  // Seeding unifie : priorite a la valeur du site (sans badge). A defaut, on utilise le
+  // comptage remonte par les clients BitTorrent (qBittorrent/rTorrent), signale par un badge
+  // de source (qBit / Rto / qBit Rto). Une seule info, un seul endroit, source indiquee.
+  function seedingInfo(stat) {
+    const f = stat.fields || {};
+    if (hasStatValue(f.seeding)) return { value: formatCount(f.seeding), badge: '' };
+    if (hasStatValue(stat.qbitSeeding)) {
+      return { value: formatCount(stat.qbitSeeding), badge: qbitSourceLabel(stat.qbitSeedingTypes) };
+    }
+    return null;
+  }
+
+  function seedingBadgeHtml(badge) {
+    return badge
+      ? ` <span class="stat-source" title="Torrents en seed remontés depuis vos clients BitTorrent">${badge}</span>`
+      : '';
+  }
+
+  // Cellule "Seeding" pour la grille des cartes (inline, 1 colonne).
+  function seedingStatCell(stat) {
+    const info = seedingInfo(stat);
+    return `
+      <div class="stat">
+        <span class="stat-label">Seeding${info ? seedingBadgeHtml(info.badge) : ''}</span>
+        <span class="stat-value">${info ? info.value : '-'}</span>
+      </div>`;
+  }
+
+  // Cellule "Seeding" pleine largeur, pour les cartes dont le slot inline affiche deja autre
+  // chose (ratioless, ou trackers a "Seed time"). Rien si aucune valeur de seeding disponible.
+  function seedingStatCellFull(stat) {
+    const info = seedingInfo(stat);
+    if (!info) return '';
     return `
       <div class="stat stat--qbit">
-        <span class="stat-label">Seeding <span class="stat-source" title="Torrents en seed remontés depuis vos clients BitTorrent">${qbitSourceLabel(types)}</span></span>
-        <span class="stat-value">${formatCount(value)}</span>
+        <span class="stat-label">Seeding${seedingBadgeHtml(info.badge)}</span>
+        <span class="stat-value">${info.value}</span>
       </div>`;
   }
 
@@ -3577,8 +3607,7 @@
         }
         return 0;
       }
-      case 'seeding':  return toNum(f.seeding);
-      case 'qbitseeding': return toNum(stat.qbitSeeding);
+      case 'seeding':  return toNum(hasStatValue(f.seeding) ? f.seeding : stat.qbitSeeding);
       case 'bonus':    return toNum(hasStatValue(f.seedBonus) ? f.seedBonus : f.points);
       case 'status':   return stat.status === 'error' ? 1 : 0; // erreurs regroupees
       default:         return 0;
@@ -3717,8 +3746,8 @@
       const errorOrIncidentBadge = isIncident
         ? '<span class="badge badge-incident" title="Probleme connu signale manuellement">Incident connu</span>'
         : '<span class="badge badge-error">Erreur</span>';
-      const qbitSeeding = hasStatValue(stat.qbitSeeding)
-        ? `<div class="stats">${statCellQbitSeeding(stat.qbitSeeding, stat.qbitSeedingTypes)}</div>`
+      const qbitSeeding = seedingStatCellFull(stat)
+        ? `<div class="stats">${seedingStatCellFull(stat)}</div>`
         : '';
       const badges = `
         ${errorOrIncidentBadge}
@@ -3768,7 +3797,7 @@
       ? `${ratiolessCell1}${ratiolessCell2}`
       : `${hasStatValue(f.seedTimeDays)
           ? statCell('Seed time', [formatCount(f.seedTimeDays), 'j'], '', '')
-          : statCell('Seeding', formatCount(f.seeding), '', '')}
+          : seedingStatCell(stat)}
          ${statCell('Bonus',   formatCount(f.seedBonus), '', '')}`;
 
     return `
@@ -3788,7 +3817,7 @@
           ${statCell('Ratio', hasRatio ? formatRatio(ratio) : '-', '', ratioClass(ratio))}
           ${statCell('Buffer', buffer, '', bufferClass(buffer))}
           ${bottomCells}
-          ${hasStatValue(stat.qbitSeeding) ? statCellQbitSeeding(stat.qbitSeeding, stat.qbitSeedingTypes) : ''}
+          ${(ratioless || hasStatValue(f.seedTimeDays)) ? seedingStatCellFull(stat) : ''}
         </div>
         ${stat.stale ? renderIncidentBox(stat) : ''}
         <div class="card-footer">Derniere connexion : ${lastLoginText(stat)}</div>
@@ -3846,10 +3875,12 @@
       : `<span class="${ratioClass(ratio)}">${hasRatio ? formatRatio(ratio) : '-'}</span>`;
     const buf = isError ? '<span class="cell-muted">—</span>'
       : `<span class="${bufferClass(formatBuffer(f, byteUnit))}">${bufferText(f, byteUnit)}</span>`;
-    const seeding = isError ? '<span class="cell-muted">—</span>' : formatCount(f.seeding);
-    const qbitSeed = !hasStatValue(stat.qbitSeeding)
+    const seedingInf = isError ? null : seedingInfo(stat);
+    const seeding = isError
       ? '<span class="cell-muted">—</span>'
-      : `${formatCount(stat.qbitSeeding)} <span class="stat-source" title="Torrents en seed remontés depuis vos clients BitTorrent">${qbitSourceLabel(stat.qbitSeedingTypes)}</span>`;
+      : (seedingInf
+          ? `${seedingInf.value}${seedingBadgeHtml(seedingInf.badge)}`
+          : '<span class="cell-muted">—</span>');
     // Bonus : seedBonus pour les trackers a ratio, ou Points pour les ratioless
     const bonusRaw = hasStatValue(f.seedBonus) ? f.seedBonus : f.points;
     const bonus   = isError ? '<span class="cell-muted">—</span>' : formatCount(bonusRaw);
@@ -3869,7 +3900,6 @@
         <td class="num">${ratioCell}</td>
         <td class="num">${buf}</td>
         <td class="num">${seeding}</td>
-        <td class="num">${qbitSeed}</td>
         <td class="num">${bonus}</td>
         ${statusCell}
       </tr>`;
@@ -3883,7 +3913,7 @@
       : '';
     const subRow = `
       <tr class="row-expanded">
-        <td colspan="12">
+        <td colspan="11">
           <div class="row-expanded-inner">
             <div class="row-error-msg">
               <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="flex-shrink:0;margin-top:1px">
@@ -3924,7 +3954,6 @@
             ${th('ratio', 'Ratio')}
             ${th('buffer', 'Buffer')}
             ${th('seeding', 'Seeding')}
-            ${th('qbitseeding', 'Seeding client')}
             ${th('bonus', 'Bonus')}
             ${th('status', 'Statut')}
           </tr>

--- a/public/index.html
+++ b/public/index.html
@@ -3875,12 +3875,10 @@
       : `<span class="${ratioClass(ratio)}">${hasRatio ? formatRatio(ratio) : '-'}</span>`;
     const buf = isError ? '<span class="cell-muted">—</span>'
       : `<span class="${bufferClass(formatBuffer(f, byteUnit))}">${bufferText(f, byteUnit)}</span>`;
-    const seedingInf = isError ? null : seedingInfo(stat);
-    const seeding = isError
-      ? '<span class="cell-muted">—</span>'
-      : (seedingInf
-          ? `${seedingInf.value}${seedingBadgeHtml(seedingInf.badge)}`
-          : '<span class="cell-muted">—</span>');
+    const seedingInf = seedingInfo(stat);
+    const seeding = seedingInf
+      ? `${seedingInf.value}${seedingBadgeHtml(seedingInf.badge)}`
+      : '<span class="cell-muted">—</span>';
     // Bonus : seedBonus pour les trackers a ratio, ou Points pour les ratioless
     const bonusRaw = hasStatValue(f.seedBonus) ? f.seedBonus : f.points;
     const bonus   = isError ? '<span class="cell-muted">—</span>' : formatCount(bonusRaw);

--- a/src/db.ts
+++ b/src/db.ts
@@ -312,6 +312,21 @@ export function loadTrackerDefinitionFile(trackerId: string): TrackerConfig | nu
   return null;
 }
 
+// Lit la definition par defaut EMBARQUEE DANS L'IMAGE (default-trackers/), donc toujours
+// a jour avec la version deployee — contrairement a loadTrackerDefinitionFile qui lit la
+// copie sur le volume (config/trackers/), jamais rafraichie une fois ecrite. A utiliser
+// pour les trackers "canoniques" dont la definition fait autorite cote application.
+export function loadDefaultTrackerDefinition(trackerId: string): TrackerConfig | null {
+  if (!fs.existsSync(DEFAULT_TRACKERS_DIR)) return null;
+  const target = path.join(DEFAULT_TRACKERS_DIR, `${trackerId}.json`);
+  if (!fs.existsSync(target)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(target, 'utf-8')) as TrackerConfig;
+  } catch {
+    return null;
+  }
+}
+
 export function loadTrackerConfigsFromDb(): TrackerConfig[] {
   return getDb()
     .prepare('SELECT config_json FROM tracker_configs ORDER BY name')

--- a/src/server.ts
+++ b/src/server.ts
@@ -34,6 +34,7 @@ import {
   loadCredentialsFromDb,
   loadTrackerConfigsFromDb,
   loadTrackerDefinitionFile,
+  loadDefaultTrackerDefinition,
   saveStatSnapshots,
   saveTrackerCredentials,
   saveTrackerConfig,
@@ -629,7 +630,11 @@ function normalizeTrackerConfigs(): TrackerConfig[] {
   for (const tracker of trackers) {
     let changed = false;
     if (CANONICAL_CONNECTION_TRACKERS.has(tracker.id)) {
-      const definition = loadTrackerDefinitionFile(tracker.id);
+      // Lire la definition depuis l'image (toujours a jour) plutot que la copie sur le
+      // volume (config/trackers/), qui n'est jamais rafraichie apres la 1re ecriture.
+      // Fallback sur le fichier du volume si l'image ne fournit pas la definition.
+      const definition = loadDefaultTrackerDefinition(tracker.id)
+        ?? loadTrackerDefinitionFile(tracker.id);
       if (definition) {
         if (JSON.stringify(tracker.login) !== JSON.stringify(definition.login)) {
           tracker.login = definition.login;


### PR DESCRIPTION
Trois corrections issues d'une session de debug sur les installations existantes.

## 1. Définitions canoniques périmées (bug principal)

**Problème** : pour les trackers de `CANONICAL_CONNECTION_TRACKERS` (c411, nexum, phoenixproject, torr9), `normalizeTrackerConfigs` relit la définition depuis `config/trackers/*.json` du volume à chaque boot. Or ce fichier n'est jamais rafraîchi après sa première écriture (`syncDefaultTrackerDefinitions` fait `if (existsSync) continue`). Conséquence : une install déployée garde éternellement les vieilles définitions, même après une mise à jour d'image qui les corrige → login cassé (403/419/échec) alors que le code sait gérer les nouveaux champs.

**Correctif** : nouvelle fonction `loadDefaultTrackerDefinition` (db.ts) qui lit la définition depuis `default-trackers/` (embarqué dans l'image, toujours à jour). Les trackers canoniques l'utilisent en priorité, avec fallback sur le fichier volume. Une simple mise à jour d'image propage désormais les corrections, sans migration.

**Limite connue** : ne corrige que les 4 canoniques (les seuls relus depuis le fichier à chaque boot). Les autres trackers restent semés une fois en base. Un assainissement plus large (source de vérité unique) reste à discuter.

## 2. Seeding unifié sur le dashboard

Une seule case « Seeding » par tracker : valeur du site si disponible (sans badge), sinon comptage remonté des clients BitTorrent avec badge de source (qBit / Rto / qBit Rto). Supprime le doublon site/client précédent, en cartes et en vue tableau.

## 3. Regex Orpheus

Correction des regex upload/download/ratio : `[^>]*` (bloqué dans la balise) remplacé par `[\s\S]*?` pour traverser les balises enfants, le `title` étant porté par un `<span>` interne sur OPS.