### PR TITLE
fix: ratio infini + req. ratio Redacted + grille Nexum (niveau/XP)

### DIFF
--- a/config/trackers/nexum.json
+++ b/config/trackers/nexum.json
@@ -36,7 +36,9 @@
     "fields": {
       "uploadedBytes": { "regex": "user-stat-up[^>]*>[\\s\\S]*?(?<value>\\d[\\d\\s.,]*\\s*(?:[KMGTPE](?:i?B|io|o)|B|o))\\s*</span>", "transform": "bytes" },
       "seedTime":      { "regex": "user-stat-seed24[\\s\\S]{0,120}?</i>\\s*(?<value>[^<]+?)\\s*</span>", "transform": "string" },
-      "dlQuota":       { "regex": "user-stat-dlday[\\s\\S]{0,160}?</i>\\s*(?<value>[^<]+?)\\s*</span>", "transform": "string" }
+      "dlQuota":       { "regex": "user-stat-dlday[\\s\\S]{0,160}?</i>\\s*(?<value>[^<]+?)\\s*</span>", "transform": "string" },
+      "level":         { "regex": "Niveau\\s*(?<value>\\d+)", "transform": "integer" },
+      "xp":            { "regex": "Niveau\\s*\\d+\\s*·\\s*(?<value>[\\d\\s]+?)\\s*XP", "transform": "string" }
     }
   },
   "dashboard": { "byteUnit": "binary" }

--- a/config/trackers/orpheus.json
+++ b/config/trackers/orpheus.json
@@ -29,10 +29,10 @@
     "mode": "browser",
     "responseType": "html",
     "fields": {
-      "downloadedBytes": { "regex": "id=\"stats_leeching\"[^>]*title=\"(?<value>[^\"]+)\"", "transform": "bytes" },
-      "uploadedBytes":   { "regex": "id=\"stats_seeding\"[^>]*title=\"(?<value>[^\"]+)\"",   "transform": "bytes" },
-      "ratio":           { "regex": "id=\"stats_ratio\"[^>]*title=\"(?<value>[^\"]+)\"",     "transform": "number" },
-      "seedBonus":       { "regex": "Bonus \\((?<value>[^)]+)\\)",                           "transform": "string" }
+      "downloadedBytes": { "regex": "id=\"stats_leeching\"[\\s\\S]*?title=\"(?<value>[^\"]+)\"", "transform": "bytes" },
+      "uploadedBytes":   { "regex": "id=\"stats_seeding\"[\\s\\S]*?title=\"(?<value>[^\"]+)\"",  "transform": "bytes" },
+      "ratio":           { "regex": "id=\"stats_ratio\"[\\s\\S]*?title=\"(?<value>[^\"]+)\"",    "transform": "number" },
+      "seedBonus":       { "regex": "Bonus \\((?<value>[^)]+)\\)",                              "transform": "string" }
     }
   },
   "dashboard": { "byteUnit": "binary" }

--- a/config/trackers/redacted.json
+++ b/config/trackers/redacted.json
@@ -31,7 +31,8 @@
     "fields": {
       "downloadedBytes": { "regex": "id=\"stats_leeching\"[^>]*title=\"Downloaded: (?<value>[^\"]+)\"", "transform": "bytes" },
       "uploadedBytes":   { "regex": "id=\"stats_seeding\"[^>]*title=\"Uploaded: (?<value>[^\"]+)\"",     "transform": "bytes" },
-      "ratio":           { "regex": "id=\"stats_ratio\"[^>]*title=\"Ratio: (?<value>[^\"]+)\"",          "transform": "number" }
+      "ratio":           { "regex": "id=\"stats_ratio\"[^>]*title=\"Ratio: (?<value>[^\"]+)\"",          "transform": "number" },
+      "requiredRatio":   { "regex": "id=\"stats_required\"[^>]*title=\"Required Ratio: (?<value>[^\"]+)\"", "transform": "number" }
     }
   },
   "dashboard": { "byteUnit": "binary" }

--- a/public/index.html
+++ b/public/index.html
@@ -2010,13 +2010,43 @@
     return parts.length ? parts.join(' ') : 'qBit';
   }
 
-  // Cellule pleine largeur dediee au seed remonte depuis les clients BitTorrent, distincte du
-  // seeding scrape sur le site. Badge (qBit / Rto / qBit Rto) + infobulle pour signaler la source.
-  function statCellQbitSeeding(value, types) {
+  // Seeding unifie : priorite a la valeur du site (sans badge). A defaut, on utilise le
+  // comptage remonte par les clients BitTorrent (qBittorrent/rTorrent), signale par un badge
+  // de source (qBit / Rto / qBit Rto). Une seule info, un seul endroit, source indiquee.
+  function seedingInfo(stat) {
+    const f = stat.fields || {};
+    if (hasStatValue(f.seeding)) return { value: formatCount(f.seeding), badge: '' };
+    if (hasStatValue(stat.qbitSeeding)) {
+      return { value: formatCount(stat.qbitSeeding), badge: qbitSourceLabel(stat.qbitSeedingTypes) };
+    }
+    return null;
+  }
+
+  function seedingBadgeHtml(badge) {
+    return badge
+      ? ` <span class="stat-source" title="Torrents en seed remontés depuis vos clients BitTorrent">${badge}</span>`
+      : '';
+  }
+
+  // Cellule "Seeding" pour la grille des cartes (inline, 1 colonne).
+  function seedingStatCell(stat) {
+    const info = seedingInfo(stat);
+    return `
+      <div class="stat">
+        <span class="stat-label">Seeding${info ? seedingBadgeHtml(info.badge) : ''}</span>
+        <span class="stat-value">${info ? info.value : '-'}</span>
+      </div>`;
+  }
+
+  // Cellule "Seeding" pleine largeur, pour les cartes dont le slot inline affiche deja autre
+  // chose (ratioless, ou trackers a "Seed time"). Rien si aucune valeur de seeding disponible.
+  function seedingStatCellFull(stat) {
+    const info = seedingInfo(stat);
+    if (!info) return '';
     return `
       <div class="stat stat--qbit">
-        <span class="stat-label">Seeding <span class="stat-source" title="Torrents en seed remontés depuis vos clients BitTorrent">${qbitSourceLabel(types)}</span></span>
-        <span class="stat-value">${formatCount(value)}</span>
+        <span class="stat-label">Seeding${seedingBadgeHtml(info.badge)}</span>
+        <span class="stat-value">${info.value}</span>
       </div>`;
   }
 
@@ -3577,8 +3607,7 @@
         }
         return 0;
       }
-      case 'seeding':  return toNum(f.seeding);
-      case 'qbitseeding': return toNum(stat.qbitSeeding);
+      case 'seeding':  return toNum(hasStatValue(f.seeding) ? f.seeding : stat.qbitSeeding);
       case 'bonus':    return toNum(hasStatValue(f.seedBonus) ? f.seedBonus : f.points);
       case 'status':   return stat.status === 'error' ? 1 : 0; // erreurs regroupees
       default:         return 0;
@@ -3717,8 +3746,8 @@
       const errorOrIncidentBadge = isIncident
         ? '<span class="badge badge-incident" title="Probleme connu signale manuellement">Incident connu</span>'
         : '<span class="badge badge-error">Erreur</span>';
-      const qbitSeeding = hasStatValue(stat.qbitSeeding)
-        ? `<div class="stats">${statCellQbitSeeding(stat.qbitSeeding, stat.qbitSeedingTypes)}</div>`
+      const qbitSeeding = seedingStatCellFull(stat)
+        ? `<div class="stats">${seedingStatCellFull(stat)}</div>`
         : '';
       const badges = `
         ${errorOrIncidentBadge}
@@ -3768,7 +3797,7 @@
       ? `${ratiolessCell1}${ratiolessCell2}`
       : `${hasStatValue(f.seedTimeDays)
           ? statCell('Seed time', [formatCount(f.seedTimeDays), 'j'], '', '')
-          : statCell('Seeding', formatCount(f.seeding), '', '')}
+          : seedingStatCell(stat)}
          ${statCell('Bonus',   formatCount(f.seedBonus), '', '')}`;
 
     return `
@@ -3788,7 +3817,7 @@
           ${statCell('Ratio', hasRatio ? formatRatio(ratio) : '-', '', ratioClass(ratio))}
           ${statCell('Buffer', buffer, '', bufferClass(buffer))}
           ${bottomCells}
-          ${hasStatValue(stat.qbitSeeding) ? statCellQbitSeeding(stat.qbitSeeding, stat.qbitSeedingTypes) : ''}
+          ${(ratioless || hasStatValue(f.seedTimeDays)) ? seedingStatCellFull(stat) : ''}
         </div>
         ${stat.stale ? renderIncidentBox(stat) : ''}
         <div class="card-footer">Derniere connexion : ${lastLoginText(stat)}</div>
@@ -3846,10 +3875,12 @@
       : `<span class="${ratioClass(ratio)}">${hasRatio ? formatRatio(ratio) : '-'}</span>`;
     const buf = isError ? '<span class="cell-muted">—</span>'
       : `<span class="${bufferClass(formatBuffer(f, byteUnit))}">${bufferText(f, byteUnit)}</span>`;
-    const seeding = isError ? '<span class="cell-muted">—</span>' : formatCount(f.seeding);
-    const qbitSeed = !hasStatValue(stat.qbitSeeding)
+    const seedingInf = isError ? null : seedingInfo(stat);
+    const seeding = isError
       ? '<span class="cell-muted">—</span>'
-      : `${formatCount(stat.qbitSeeding)} <span class="stat-source" title="Torrents en seed remontés depuis vos clients BitTorrent">${qbitSourceLabel(stat.qbitSeedingTypes)}</span>`;
+      : (seedingInf
+          ? `${seedingInf.value}${seedingBadgeHtml(seedingInf.badge)}`
+          : '<span class="cell-muted">—</span>');
     // Bonus : seedBonus pour les trackers a ratio, ou Points pour les ratioless
     const bonusRaw = hasStatValue(f.seedBonus) ? f.seedBonus : f.points;
     const bonus   = isError ? '<span class="cell-muted">—</span>' : formatCount(bonusRaw);
@@ -3869,7 +3900,6 @@
         <td class="num">${ratioCell}</td>
         <td class="num">${buf}</td>
         <td class="num">${seeding}</td>
-        <td class="num">${qbitSeed}</td>
         <td class="num">${bonus}</td>
         ${statusCell}
       </tr>`;
@@ -3883,7 +3913,7 @@
       : '';
     const subRow = `
       <tr class="row-expanded">
-        <td colspan="12">
+        <td colspan="11">
           <div class="row-expanded-inner">
             <div class="row-error-msg">
               <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="flex-shrink:0;margin-top:1px">
@@ -3924,7 +3954,6 @@
             ${th('ratio', 'Ratio')}
             ${th('buffer', 'Buffer')}
             ${th('seeding', 'Seeding')}
-            ${th('qbitseeding', 'Seeding client')}
             ${th('bonus', 'Bonus')}
             ${th('status', 'Statut')}
           </tr>

--- a/public/index.html
+++ b/public/index.html
@@ -1575,7 +1575,7 @@
 <div class="content-area">
 <div id="proxy-panel">
   <div class="proxy-panel-inner">
-    <h2>🔀 Proxy</h2>
+    <h2>ߔࠐroxy</h2>
     <div class="proxy-form">
       <label class="toggle-switch" title="Activer le proxy">
         <input type="checkbox" id="proxy-enabled" onchange="syncProxyToggle()">
@@ -2069,7 +2069,10 @@
   }
 
   function computedRatio(fields) {
-    if (hasStatValue(fields.ratio)) return fields.ratio;
+    if (hasStatValue(fields.ratio)) {
+      if (fields.ratio === '∞' || fields.ratio === Infinity) return Infinity;
+      return fields.ratio;
+    }
     if (!hasStatValue(fields.uploadedBytes) || !hasStatValue(fields.downloadedBytes)) return null;
     const downloaded = Number(fields.downloadedBytes);
     const uploaded = Number(fields.uploadedBytes);
@@ -3793,12 +3796,35 @@
       : (hasStatValue(f.dlQuota)
           ? statCell('DL jour', formatCount(f.dlQuota), '', '')
           : statCell('Taux', '-', '', ''));
+    const bonusOrRequired = hasStatValue(f.requiredRatio)
+      ? statCell('Req. ratio', formatRatio(f.requiredRatio), '', '')
+      : statCell('Bonus', formatCount(f.seedBonus), '', '');
     const bottomCells = ratioless
       ? `${ratiolessCell1}${ratiolessCell2}`
       : `${hasStatValue(f.seedTimeDays)
           ? statCell('Seed time', [formatCount(f.seedTimeDays), 'j'], '', '')
           : seedingStatCell(stat)}
-         ${statCell('Bonus',   formatCount(f.seedBonus), '', '')}`;
+         ${bonusOrRequired}`;
+
+    // Grille specifique aux ratioless exposant Niveau + XP (ex: Nexum). Ordre voulu :
+    //   Niveau | Upload        Strictement conditionne a la presence de level/xp : les
+    //   XP     | DL jour       autres ratioless (HDO, etc.) gardent leur grille standard.
+    //   Seeding| Seed 24h
+    const hasXpFields = ratioless && (hasStatValue(f.level) || hasStatValue(f.xp));
+    const xpGrid = `
+          ${statCell('Niveau', formatCount(f.level), '', '')}
+          ${statCell('Upload', formatBytes(f.uploadedBytes, byteUnit), '', '')}
+          ${statCell('XP', formatCount(f.xp), '', '')}
+          ${ratiolessCell2}
+          ${seedingStatCell(stat)}
+          ${ratiolessCell1}`;
+    const standardGrid = `
+          ${statCell('Download', formatBytes(f.downloadedBytes, byteUnit), '', '')}
+          ${statCell('Upload', formatBytes(f.uploadedBytes, byteUnit), '', '')}
+          ${statCell('Ratio', hasRatio ? formatRatio(ratio) : '-', '', ratioClass(ratio))}
+          ${statCell('Buffer', buffer, '', bufferClass(buffer))}
+          ${bottomCells}
+          ${(ratioless || hasStatValue(f.seedTimeDays)) ? seedingStatCellFull(stat) : ''}`;
 
     return `
       <div class="card card--ok"${cardDragAttrs(stat)}>
@@ -3811,13 +3837,7 @@
         </div>
         <div class="card-badges">${staleBadge(stat)}${ratiolessBadge(stat)}</div>
 
-        <div class="stats">
-          ${statCell('Download', formatBytes(f.downloadedBytes, byteUnit), '', '')}
-          ${statCell('Upload', formatBytes(f.uploadedBytes, byteUnit), '', '')}
-          ${statCell('Ratio', hasRatio ? formatRatio(ratio) : '-', '', ratioClass(ratio))}
-          ${statCell('Buffer', buffer, '', bufferClass(buffer))}
-          ${bottomCells}
-          ${(ratioless || hasStatValue(f.seedTimeDays)) ? seedingStatCellFull(stat) : ''}
+        <div class="stats">${hasXpFields ? xpGrid : standardGrid}
         </div>
         ${stat.stale ? renderIncidentBox(stat) : ''}
         <div class="card-footer">Derniere connexion : ${lastLoginText(stat)}</div>
@@ -3881,9 +3901,15 @@
       : (seedingInf
           ? `${seedingInf.value}${seedingBadgeHtml(seedingInf.badge)}`
           : '<span class="cell-muted">—</span>');
-    // Bonus : seedBonus pour les trackers a ratio, ou Points pour les ratioless
+    // Bonus : seedBonus pour les trackers a ratio, ou Points pour les ratioless.
+    // Si le tracker expose un ratio requis (ex: Redacted), on l'affiche a la place, avec un
+    // badge "req." pour lever l'ambiguite sous l'en-tete generique.
     const bonusRaw = hasStatValue(f.seedBonus) ? f.seedBonus : f.points;
-    const bonus   = isError ? '<span class="cell-muted">—</span>' : formatCount(bonusRaw);
+    const bonus   = isError
+      ? '<span class="cell-muted">—</span>'
+      : (hasStatValue(f.requiredRatio)
+          ? `${formatRatio(f.requiredRatio)} <span class="stat-source" title="Ratio requis">req.</span>`
+          : formatCount(bonusRaw));
 
     const statusCell = hasProblem
       ? `<td class="cell-status" onclick="toggleIncidentEditor('${id}')">${rowStatusBadges(stat)}<span class="chevron">›</span></td>`

--- a/public/index.html
+++ b/public/index.html
@@ -3875,12 +3875,10 @@
       : `<span class="${ratioClass(ratio)}">${hasRatio ? formatRatio(ratio) : '-'}</span>`;
     const buf = isError ? '<span class="cell-muted">—</span>'
       : `<span class="${bufferClass(formatBuffer(f, byteUnit))}">${bufferText(f, byteUnit)}</span>`;
-    const seedingInf = isError ? null : seedingInfo(stat);
-    const seeding = isError
-      ? '<span class="cell-muted">—</span>'
-      : (seedingInf
-          ? `${seedingInf.value}${seedingBadgeHtml(seedingInf.badge)}`
-          : '<span class="cell-muted">—</span>');
+    const seedingInf = seedingInfo(stat);
+    const seeding = seedingInf
+      ? `${seedingInf.value}${seedingBadgeHtml(seedingInf.badge)}`
+      : '<span class="cell-muted">—</span>';
     // Bonus : seedBonus pour les trackers a ratio, ou Points pour les ratioless
     const bonusRaw = hasStatValue(f.seedBonus) ? f.seedBonus : f.points;
     const bonus   = isError ? '<span class="cell-muted">—</span>' : formatCount(bonusRaw);

--- a/src/db.ts
+++ b/src/db.ts
@@ -312,6 +312,21 @@ export function loadTrackerDefinitionFile(trackerId: string): TrackerConfig | nu
   return null;
 }
 
+// Lit la definition par defaut EMBARQUEE DANS L'IMAGE (default-trackers/), donc toujours
+// a jour avec la version deployee — contrairement a loadTrackerDefinitionFile qui lit la
+// copie sur le volume (config/trackers/), jamais rafraichie une fois ecrite. A utiliser
+// pour les trackers "canoniques" dont la definition fait autorite cote application.
+export function loadDefaultTrackerDefinition(trackerId: string): TrackerConfig | null {
+  if (!fs.existsSync(DEFAULT_TRACKERS_DIR)) return null;
+  const target = path.join(DEFAULT_TRACKERS_DIR, `${trackerId}.json`);
+  if (!fs.existsSync(target)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(target, 'utf-8')) as TrackerConfig;
+  } catch {
+    return null;
+  }
+}
+
 export function loadTrackerConfigsFromDb(): TrackerConfig[] {
   return getDb()
     .prepare('SELECT config_json FROM tracker_configs ORDER BY name')

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -52,7 +52,11 @@ function applyTransform(raw: unknown, tf?: string): string | number {
   if (raw === undefined || raw === null || raw === '') return '';
   switch (tf) {
     case 'bytes':   return parseBytes(raw);
-    case 'number':  return parseFloat(String(raw).replace(',', '.')) || 0;
+    case 'number': {
+      const s = String(raw).trim();
+      if (/^(infinite|infinity|inf|∞)$/i.test(s)) return '∞';
+      return parseFloat(s.replace(',', '.')) || 0;
+    }
     case 'integer': return parseInt(String(raw), 10) || 0;
     default:        return String(raw);
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -34,6 +34,7 @@ import {
   loadCredentialsFromDb,
   loadTrackerConfigsFromDb,
   loadTrackerDefinitionFile,
+  loadDefaultTrackerDefinition,
   saveStatSnapshots,
   saveTrackerCredentials,
   saveTrackerConfig,
@@ -629,7 +630,11 @@ function normalizeTrackerConfigs(): TrackerConfig[] {
   for (const tracker of trackers) {
     let changed = false;
     if (CANONICAL_CONNECTION_TRACKERS.has(tracker.id)) {
-      const definition = loadTrackerDefinitionFile(tracker.id);
+      // Lire la definition depuis l'image (toujours a jour) plutot que la copie sur le
+      // volume (config/trackers/), qui n'est jamais rafraichie apres la 1re ecriture.
+      // Fallback sur le fichier du volume si l'image ne fournit pas la definition.
+      const definition = loadDefaultTrackerDefinition(tracker.id)
+        ?? loadTrackerDefinitionFile(tracker.id);
       if (definition) {
         if (JSON.stringify(tracker.login) !== JSON.stringify(definition.login)) {
           tracker.login = definition.login;


### PR DESCRIPTION
Trois améliorations de l'affichage des stats, issues d'une session de debug.

## 1. Ratio infini

**Problème** : les trackers affichant un ratio infini (ex: Phoenix Project avec Down=0) 
retournaient `0.00` au lieu de `∞`. Cause : `parseFloat("Infinite") || 0` = 0 dans le 
transform `number`, et `Infinity` ne survit pas à `JSON.stringify`.

**Correctif** :
- `fetcher.ts` : le transform `number` reconnaît `Infinite`/`infinity`/`inf`/`∞` et retourne 
la chaîne `'∞'` (qui survit au JSON)
- `index.html` : `computedRatio` interprète `'∞'` comme `Infinity` → `formatRatio` affiche 
`∞` en vert

## 2. Required Ratio (Redacted)

Redacted expose un "Required Ratio" (`id="stats_required"`) absent des autres trackers. 
La case Bonus (vide pour Redacted) est remplacée par "Req. ratio" quand le champ est présent. 
Générique : tout tracker exposant `requiredRatio` en bénéficie automatiquement.

- `redacted.json` : ajout du champ `requiredRatio` (regex sur `stats_required title`)
- `index.html` : case Bonus → "Req. ratio" en carte ; badge `req.` en vue tableau

## 3. Grille Nexum (Niveau + XP)

Nexum est ratioless et expose des champs spécifiques (niveau, XP) dans le `title` du lien 
`header-xp`. La grille générique laissait Download/Ratio/Buffer vides. On ajoute une grille 
dédiée conditionnée à la présence de `level`/`xp` (les autres ratioless HDOnly etc. ne sont 
pas affectés) :


Niveau  | Upload

XP      | DL jour

Seeding | Seed 24h

- `nexum.json` : ajout champs `level` (integer) et `xp` (string, espace milliers préservé)
- `index.html` : grille `xpGrid` dédiée quand `level`/`xp` présents, `standardGrid` sinon