### PR TITLE
feat: rafraîchissement automatique des clients BitTorrent (par client)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1870,6 +1870,7 @@
         <div class="beta-stack" style="width:100%">
           <section class="beta-panel">
             <h3>Clients BitTorrent</h3>
+            <p class="beta-note" style="margin-bottom:10px">Le champ « Auto (min) » de chaque client définit son rafraîchissement automatique en arrière-plan (0 = désactivé). Le bouton ci-dessous force une synchronisation immédiate de tous les clients.</p>
             <div class="beta-actions" style="margin-bottom:10px">
               <button id="beta-refresh-clients" class="beta-icon-btn" onclick="refreshBetaQbit()" type="button">Synchroniser les clients BitTorrent</button>
             </div>
@@ -3179,13 +3180,14 @@
     if (!container) return;
     const clients = betaSettings.qbitClients || [];
     container.innerHTML = clients.map((client, idx) => `
-      <div class="beta-form-row" data-beta-qbit="${idx}" style="grid-template-columns: 130px minmax(0,1fr) minmax(0,2fr) minmax(0,1fr) minmax(0,1fr) 80px auto">
+      <div class="beta-form-row" data-beta-qbit="${idx}" style="grid-template-columns: 130px minmax(0,1fr) minmax(0,2fr) minmax(0,1fr) minmax(0,1fr) 80px 96px auto">
         <div class="beta-field"><label>Type</label><select data-field="type"><option value="qbittorrent" ${client.type !== 'rutorrent' ? 'selected' : ''}>qBittorrent</option><option value="rutorrent" ${client.type === 'rutorrent' ? 'selected' : ''}>ruTorrent / rTorrent</option></select></div>
         <div class="beta-field"><label>Nom</label><input data-field="label" value="${escapeHtml(client.label || '')}" placeholder="Seedbox principale"></div>
         <div class="beta-field"><label>URL API</label><input data-field="baseUrl" value="${escapeHtml(client.baseUrl || '')}" placeholder="qBit: https://qb.example · ruTorrent: https://rt.example/RPC2"></div>
         <div class="beta-field"><label>Utilisateur</label><input data-field="username" value="${escapeHtml(client.username || '')}"></div>
         <div class="beta-field"><label>Mot de passe</label><input data-field="password" type="password" value="${escapeHtml(client.password || '')}"></div>
         <div class="beta-field"><label>Actif</label><select data-field="enabled"><option value="true" ${client.enabled !== false ? 'selected' : ''}>Oui</option><option value="false" ${client.enabled === false ? 'selected' : ''}>Non</option></select></div>
+        <div class="beta-field"><label title="Rafraîchissement automatique de ce client, en minutes. 0 = désactivé.">Auto (min)</label><input data-field="refreshMinutes" type="number" min="0" max="1440" step="1" value="${Number(client.refreshMinutes) || 0}" title="0 = pas de rafraîchissement automatique"></div>
         <div style="display:flex; gap:6px; align-items:flex-end"><button class="beta-icon-btn" onclick="testBetaQbitClient(${idx})" type="button">Tester</button><button class="beta-icon-btn" onclick="removeBetaQbitClient(${idx})" type="button">X</button></div>
       </div>
     `).join('') || '<p class="beta-note">Ajouter un ou plusieurs clients qBittorrent ou ruTorrent/rTorrent pour comparer les stats locales aux stats des sites.</p>';
@@ -3364,6 +3366,7 @@
       username: row.querySelector('[data-field="username"]').value.trim(),
       password: row.querySelector('[data-field="password"]').value,
       enabled: row.querySelector('[data-field="enabled"]').value === 'true',
+      refreshMinutes: Math.max(0, Math.min(1440, Math.floor(Number(row.querySelector('[data-field="refreshMinutes"]')?.value) || 0))),
     })).filter(client => client.baseUrl);
     const announceMappings = Array.from(document.querySelectorAll('[data-beta-mapping]')).map((row) => ({
       announceHost: row.querySelector('[data-field="announceHost"]').value.trim(),
@@ -3425,7 +3428,7 @@
 
   function addBetaQbitClient() {
     betaSettings = collectBetaSettingsFromDom();
-    betaSettings.qbitClients.push({ id: genId(), type: 'qbittorrent', label: 'qBittorrent', baseUrl: '', username: '', password: '', enabled: true });
+    betaSettings.qbitClients.push({ id: genId(), type: 'qbittorrent', label: 'qBittorrent', baseUrl: '', username: '', password: '', enabled: true, refreshMinutes: 15 });
     renderBetaQbitClients();
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -118,6 +118,10 @@ interface BetaQbitClient {
   username?: string;
   password?: string;
   enabled: boolean;
+  // Intervalle de rafraîchissement automatique en minutes (par client).
+  // 0 (ou absent) = pas de rescan automatique ; sinon le scheduler rescanne ce
+  // client toutes les N minutes. Plafonné à 1440 (24 h) à l'enregistrement.
+  refreshMinutes?: number;
 }
 
 interface BetaNotificationTarget {
@@ -215,6 +219,9 @@ interface QbitTrackerAggregate {
 const BETA_SETTINGS_KEY = 'beta_settings';
 let betaQbitStats: QbitTrackerAggregate[] = [];
 let betaQbitLastRefresh: string | null = null;
+// Horodatage (epoch ms) du dernier scan par client, pour piloter le
+// rafraîchissement automatique par intervalle (en mémoire, comme betaQbitStats).
+const qbitClientLastScan = new Map<string, number>();
 
 const unit3dFields = knownUnit3dFields();
 const gazelleStatsFields = knownGazelleStatsFields();
@@ -1578,6 +1585,21 @@ function startScheduler(): void {
       }
     }
 
+    // Rafraîchissement automatique des clients BitTorrent, par client et selon
+    // l'intervalle configuré (refreshMinutes). Granularité = ce tick (60 s).
+    const nowQbit = Date.now();
+    for (const client of settings.qbitClients) {
+      if (!client.enabled) continue;
+      const minutes = Math.floor(Number(client.refreshMinutes) || 0);
+      if (minutes < 1) continue;
+      const last = qbitClientLastScan.get(client.id) ?? 0;
+      if (nowQbit - last < minutes * 60_000) continue;
+      // Marquer l'échéance immédiatement pour éviter un double déclenchement
+      // pendant que le scan (asynchrone) est en cours.
+      qbitClientLastScan.set(client.id, nowQbit);
+      void refreshSingleQbitClient(client);
+    }
+
     const trackers = loadTrackerConfigsFromDb();
     const now = Date.now();
     let delay = 0;
@@ -1791,6 +1813,7 @@ function saveBetaSettingsPayload(raw: unknown): BetaSettings {
       username: String(client.username || '').trim(),
       password,
       enabled: client.enabled !== false,
+      refreshMinutes: Math.max(0, Math.min(1440, Math.floor(Number(client.refreshMinutes) || 0))),
     };
   }).filter(client => client.baseUrl) : current.qbitClients;
 
@@ -2380,12 +2403,31 @@ async function refreshBetaQbitStats(settings = loadBetaSettings()): Promise<Qbit
   }
   betaQbitStats = results;
   betaQbitLastRefresh = new Date().toISOString();
+  // Un scan complet remet à zéro l'échéance auto de tous les clients actifs.
+  const now = Date.now();
+  for (const client of enabled) qbitClientLastScan.set(client.id, now);
   const torrentCount = results.reduce((sum, item) => sum + item.torrentCount, 0);
   betaLog(`refresh termine: ${torrentCount} torrent(s), ${results.length} hote(s) d'annonce`);
   if (enabled.length > 0 && torrentCount === 0) {
     throw new Error('Aucun torrent recupere depuis les clients BitTorrent actifs. Les logs [Beta BitTorrent] indiquent quel endpoint repond vide ou invalide.');
   }
   return results;
+}
+
+// Rescanne un seul client BitTorrent et fusionne son résultat dans betaQbitStats
+// (remplace uniquement les agrégats de ce client). Best-effort : une erreur ne
+// touche pas les données des autres clients. Utilisé par le rafraîchissement
+// automatique par intervalle (voir startScheduler).
+async function refreshSingleQbitClient(client: BetaQbitClient): Promise<void> {
+  try {
+    const clientResults = await fetchTorrentClient(client);
+    betaQbitStats = betaQbitStats.filter(stat => stat.clientId !== client.id).concat(clientResults);
+    betaQbitLastRefresh = new Date().toISOString();
+    const torrentCount = clientResults.reduce((sum, item) => sum + item.torrentCount, 0);
+    betaLog(`auto-refresh ${betaClientLogName(client)}: ${torrentCount} torrent(s), ${clientResults.length} hote(s)`);
+  } catch (err: unknown) {
+    betaWarn(`auto-refresh ${betaClientLogName(client)} KO - ${err instanceof Error ? err.message : String(err)}`);
+  }
 }
 
 async function sendBetaNotification(


### PR DESCRIPTION
## Objectif

Ajouter un **rafraîchissement automatique des clients BitTorrent, configurable par client**. Jusqu'ici, les données des clients (qBittorrent / ruTorrent) n'étaient rescannées qu'au démarrage du serveur (une fois) ou via la synchronisation manuelle — aucun rescan périodique n'existait.

## Comportement

- Chaque client a un champ **« Auto (min) »** : intervalle de rescan automatique en minutes. **0 = désactivé.** Plafonné à 1440 (24 h).
- Le planificateur existant (tick toutes les 60 s) rescanne chaque client actif quand son intervalle est écoulé. Granularité : la minute.
- Best-effort : l'échec d'un client n'affecte ni les autres clients ni les trackers ; le résultat d'un client remplace uniquement ses propres agrégats dans `betaQbitStats`.
- Un scan complet (démarrage ou bouton « Synchroniser ») réinitialise les échéances de tous les clients.
- Les nouveaux clients sont créés avec un défaut de **15 min**.

## Détails techniques

**`src/server.ts`**
- `BetaQbitClient.refreshMinutes` (+ assainissement/clamp à l'enregistrement).
- `refreshSingleQbitClient()` : rescan d'un seul client, fusion dans `betaQbitStats` par `clientId`.
- Déclenchement par intervalle dans `startScheduler()` ; suivi des échéances en mémoire (`qbitClientLastScan`).

**`public/index.html`**
- Champ « Auto (min) » par client, collecte + clamp côté front, note explicative.

## Effet sur WebUI / Prometheus

Les données rescannées sont reprises par le polling WebUI existant (vue Clients BitTorrent) et exposées telles quelles à Prometheus via les métriques `tracker_qbit_*` (inchangées).

## Validation

- `npm run build` : OK
- `npm run check:integration` : OK
- `git diff --check` : OK
- Contrôle visuel : champ « Auto (min) » affiché (défaut 15), collecte de la valeur et clamp à 1440 vérifiés, note présente.
