### PR TITLE
refonte: renommer le menu « Scraping » en « AutoVisit »

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1637,7 +1637,7 @@
     <span class="nav-icon">⬇</span> Clients BitTorrent
   </button>
   <button class="nav-item" data-nav="scraping" onclick="showView('scraping')" type="button">
-    <span class="nav-icon">⟳</span> Scraping
+    <span class="nav-icon">⟳</span> AutoVisit
   </button>
   <button class="nav-item" data-nav="notifications" onclick="showView('notifications')" type="button">
     <span class="nav-icon">⚑</span> Notifications
@@ -1896,7 +1896,7 @@
 
   <section class="tab-view" data-view="scraping">
     <section class="beta-panel" style="width:100%">
-      <h3>Planification des logins (scraping)</h3>
+      <h3>Planification des logins (AutoVisit)</h3>
       <p class="beta-note" style="margin-bottom:10px">Planification du scraping des trackers, inspirée d'Autovisit : une planification globale et, plus bas, une fréquence individuelle par tracker. Chaque cycle visite tous les trackers actifs disposant de credentials.</p>
       <div id="beta-schedule-settings"></div>
       <div style="margin-top:10px; display:flex; gap:8px; flex-wrap:wrap">


### PR DESCRIPTION
## Objectif

Renommer le menu « Scraping » de la barre latérale en « AutoVisit ».

## Changements

- Libellé du bouton de navigation : « Scraping » -> « AutoVisit ».
- Titre du panneau : « Planification des logins (scraping) » -> « ... (AutoVisit) ».
- L'identifiant interne de la vue (`data-view="scraping"`, `showView('scraping')`) est **conservé** pour ne pas casser la dernière vue mémorisée localement chez les utilisateurs. Aucun changement backend.

## Validation

- `npm run build` : OK
- `npm run check:integration` : OK
- `git diff --check` : OK
