### PR TITLE
feat: bouton Enregistrer après la configuration globale AutoVisit

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3263,6 +3263,9 @@
         <div class="beta-field"><label>Jours</label><div style="display:flex;gap:8px;flex-wrap:wrap">${dayLabels.map((label, day) => `<label><input type="checkbox" data-beta-weekday="${day}" ${weekdays.has(day) ? 'checked' : ''}> ${label}</label>`).join('')}</div></div>
       </div>
       <p class="beta-note">Prochaine exécution : ${schedule.nextRunAt ? escapeHtml(new Date(schedule.nextRunAt).toLocaleString('fr-FR')) : 'non planifiée'}${schedule.lastRunAt ? ` · Dernière : ${escapeHtml(new Date(schedule.lastRunAt).toLocaleString('fr-FR'))}` : ''}</p>
+      <div style="margin:10px 0 6px; display:flex; gap:8px; flex-wrap:wrap">
+        <button class="beta-icon-btn primary" onclick="saveBetaSettings()" type="button">Enregistrer</button>
+      </div>
       <h4 style="margin:16px 0 8px">Fréquences individuelles</h4>
       <p class="beta-note" style="margin-bottom:8px">Une valeur individuelle remplace la planification globale pour le tracker concerné.</p>
       <div id="beta-schedule-overrides">


### PR DESCRIPTION
## Objectif

Ajouter un bouton « Enregistrer » directement après la **configuration globale** du scraping dans le menu **AutoVisit**.

## Contexte

La vue AutoVisit affiche la planification globale, puis la liste « Fréquences individuelles » (une ligne par tracker), et seulement tout en bas un bouton « Enregistrer la planification ». Sur de nombreux trackers, il fallait faire défiler toute la liste pour enregistrer un changement de la config globale.

## Changement

- Ajout d'un bouton **« Enregistrer »** sous la planification globale (après « Prochaine exécution », avant « Fréquences individuelles »), dans `renderBetaScheduleSettings`.
- Il appelle `saveBetaSettings()` (même action que le bouton du bas, qui est conservé).
- Pur front-end, aucun changement backend.

## Validation

- `npm run build` : OK
- `npm run check:integration` : OK
- `git diff --check` : OK
