### PR TITLE
feat(notifications): refonte complète du système de notifications

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,9 +27,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -44,9 +44,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -61,9 +61,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -78,9 +78,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -95,9 +95,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
-      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -112,9 +112,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -129,9 +129,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -146,9 +146,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -163,9 +163,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -180,9 +180,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -197,9 +197,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -214,9 +214,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -231,9 +231,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -248,9 +248,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -265,9 +265,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -282,9 +282,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -299,9 +299,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -316,9 +316,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -333,9 +333,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -350,9 +350,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -367,9 +367,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -384,9 +384,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
-      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -401,9 +401,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -418,9 +418,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -435,9 +435,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -452,9 +452,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -1120,9 +1120,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1133,32 +1133,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.0",
-        "@esbuild/android-arm": "0.28.0",
-        "@esbuild/android-arm64": "0.28.0",
-        "@esbuild/android-x64": "0.28.0",
-        "@esbuild/darwin-arm64": "0.28.0",
-        "@esbuild/darwin-x64": "0.28.0",
-        "@esbuild/freebsd-arm64": "0.28.0",
-        "@esbuild/freebsd-x64": "0.28.0",
-        "@esbuild/linux-arm": "0.28.0",
-        "@esbuild/linux-arm64": "0.28.0",
-        "@esbuild/linux-ia32": "0.28.0",
-        "@esbuild/linux-loong64": "0.28.0",
-        "@esbuild/linux-mips64el": "0.28.0",
-        "@esbuild/linux-ppc64": "0.28.0",
-        "@esbuild/linux-riscv64": "0.28.0",
-        "@esbuild/linux-s390x": "0.28.0",
-        "@esbuild/linux-x64": "0.28.0",
-        "@esbuild/netbsd-arm64": "0.28.0",
-        "@esbuild/netbsd-x64": "0.28.0",
-        "@esbuild/openbsd-arm64": "0.28.0",
-        "@esbuild/openbsd-x64": "0.28.0",
-        "@esbuild/openharmony-arm64": "0.28.0",
-        "@esbuild/sunos-x64": "0.28.0",
-        "@esbuild/win32-arm64": "0.28.0",
-        "@esbuild/win32-ia32": "0.28.0",
-        "@esbuild/win32-x64": "0.28.0"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escape-html": {
@@ -1286,16 +1286,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -1420,9 +1420,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -1808,9 +1808,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/public/index.html
+++ b/public/index.html
@@ -483,10 +483,10 @@
       font-size: 11px;
     }
     .beta-field input,
-    .beta-field select {
+    .beta-field select,
+    .beta-field textarea {
       width: 100%;
       box-sizing: border-box;
-      height: 32px;
       background: var(--bg);
       border: 1px solid var(--border);
       color: var(--text);
@@ -494,8 +494,12 @@
       padding: 0 9px;
       font-size: 12px;
     }
+    .beta-field input,
+    .beta-field select { height: 32px; }
+    .beta-field textarea { padding: 7px 9px; resize: vertical; font-family: inherit; line-height: 1.4; }
     .beta-field input:focus,
-    .beta-field select:focus { outline: none; border-color: var(--blue); }
+    .beta-field select:focus,
+    .beta-field textarea:focus { outline: none; border-color: var(--blue); }
     .beta-list {
       display: grid;
       gap: 6px;
@@ -1692,7 +1696,17 @@
         <div class="nav-sub" id="nav-sub-configure"></div>
       </div>
       <button class="nav-item" data-nav="qbit" onclick="showView('qbit')" type="button"><span class="nav-icon">⬇</span> Clients BitTorrent</button>
-      <button class="nav-item" data-nav="notifications" onclick="showView('notifications')" type="button"><span class="nav-icon">⚑</span> Notifications</button>
+      <div class="nav-group" data-nav-group="notif">
+        <button class="nav-item nav-group-toggle" data-nav="notif" onclick="onNotifNavClick(event)" type="button">
+          <span class="nav-icon">⚑</span> Notifications
+          <span class="nav-caret" onclick="toggleNavGroup(event, 'notif')">▸</span>
+        </button>
+        <div class="nav-sub" id="nav-sub-notif">
+          <button class="nav-sub-item" data-nav="notif-canaux" onclick="showView('notif-canaux')" type="button"><span class="nav-sub-name">Canaux</span></button>
+          <button class="nav-sub-item" data-nav="notif-globales" onclick="showView('notif-globales')" type="button"><span class="nav-sub-name">Notifications globales</span></button>
+          <button class="nav-sub-item" data-nav="notif-tracker" onclick="showView('notif-tracker')" type="button"><span class="nav-sub-name">Par tracker</span></button>
+        </div>
+      </div>
       <button class="nav-item" data-nav="proxies" onclick="showView('proxies')" type="button"><span class="nav-icon">⇄</span> Proxies</button>
       <button class="nav-item" data-nav="scraping" onclick="showView('scraping')" type="button"><span class="nav-icon">⟳</span> Fréquence d'auto visite</button>
     </div>
@@ -1962,28 +1976,40 @@
     </section>
   </section>
 
-  <section class="tab-view" data-view="notifications">
-        <div class="beta-grid-2" style="width:100%">
-          <section class="beta-panel">
-            <h3>Notifications Autovisit / Discord</h3>
-            <div id="beta-notification-preferences"></div>
-            <div id="beta-notification-targets"></div>
-            <div style="margin-top:10px; display:flex; gap:8px; flex-wrap:wrap">
-              <button class="beta-icon-btn" onclick="addBetaNotificationTarget('discord')" type="button">Ajouter Discord</button>
-              <button class="beta-icon-btn" onclick="addBetaNotificationTarget('apprise')" type="button">Ajouter Apprise</button>
-              <button class="beta-icon-btn primary" onclick="saveBetaSettings()" type="button">Enregistrer</button>
-            </div>
-          </section>
-          <section class="beta-panel">
-            <h3>Alertes par tracker</h3>
-            <p class="beta-note" style="margin-bottom:10px">Règles de seuil par tracker qui déclenchent les notifications ci-contre.</p>
-            <div id="beta-alert-rules"></div>
-            <div style="margin-top:10px; display:flex; gap:8px; flex-wrap:wrap">
-              <button class="beta-icon-btn" onclick="addBetaAlertRule()" type="button">Ajouter une alerte</button>
-              <button class="beta-icon-btn primary" onclick="saveBetaSettings()" type="button">Enregistrer</button>
-            </div>
-          </section>
-        </div>
+  <section class="tab-view" data-view="notif-canaux">
+    <section class="beta-panel" style="width:100%">
+      <h3>Canaux de notification</h3>
+      <p class="beta-note" style="margin-bottom:10px">Destinations Apprise et/ou Discord. Les notifications globales et par tracker sont envoyées sur tous les canaux actifs.</p>
+      <div id="beta-notification-targets"></div>
+      <div style="margin-top:10px; display:flex; gap:8px; flex-wrap:wrap">
+        <button class="beta-icon-btn" onclick="addBetaNotificationTarget('discord')" type="button">Ajouter Discord</button>
+        <button class="beta-icon-btn" onclick="addBetaNotificationTarget('apprise')" type="button">Ajouter Apprise</button>
+        <button class="beta-icon-btn primary" onclick="saveBetaSettings()" type="button">Enregistrer</button>
+      </div>
+    </section>
+  </section>
+
+  <section class="tab-view" data-view="notif-globales">
+    <section class="beta-panel" style="width:100%">
+      <h3>Notifications globales</h3>
+      <p class="beta-note" style="margin-bottom:10px">S'appliquent à tous les trackers. Le bouton choisit le mode édité. Les seuils ratio / buffer / session sont communs aux deux modes.</p>
+      <div id="beta-notification-preferences"></div>
+      <div style="margin-top:10px; display:flex; gap:8px; flex-wrap:wrap">
+        <button class="beta-icon-btn primary" onclick="saveBetaSettings()" type="button">Enregistrer</button>
+      </div>
+    </section>
+  </section>
+
+  <section class="tab-view" data-view="notif-tracker">
+    <section class="beta-panel" style="width:100%">
+      <h3>Notifications par tracker</h3>
+      <p class="beta-note" style="margin-bottom:10px">Règles spécifiques à un tracker. Une règle ratio / buffer / session remplace le seuil global pour ce tracker.</p>
+      <div id="beta-alert-rules"></div>
+      <div style="margin-top:10px; display:flex; gap:8px; flex-wrap:wrap">
+        <button class="beta-icon-btn" onclick="addBetaAlertRule()" type="button">Ajouter une alerte tracker</button>
+        <button class="beta-icon-btn primary" onclick="saveBetaSettings()" type="button">Enregistrer</button>
+      </div>
+    </section>
   </section>
 </main>
 
@@ -2410,10 +2436,10 @@
   const expandedIncidents = new Set();
   let viewMode = 'cards'; // 'cards' | 'rows'
   // Vue active pilotée par la barre latérale.
-  // 'dashboard' | 'trackers' | 'proxies' | 'incidents' | 'graphs' | 'qbit' | 'scraping' | 'notifications' | 'fiche'
+  // 'dashboard' | 'trackers' | 'proxies' | 'incidents' | 'graphs' | 'qbit' | 'scraping' | 'notif-canaux' | 'notif-globales' | 'notif-tracker' | 'fiche'
   let currentView = 'dashboard';
   // Vues alimentées par les données bêta (overview + historique).
-  const BETA_VIEWS = ['incidents', 'graphs', 'qbit', 'scraping', 'notifications', 'fiche'];
+  const BETA_VIEWS = ['incidents', 'graphs', 'qbit', 'scraping', 'notif-canaux', 'notif-globales', 'notif-tracker', 'fiche'];
   let betaStatusFilter = 'all'; // 'all' | 'problems' | 'healthy'
   let betaCalendarMonth = new Date();
   let betaOverview = null;
@@ -2807,8 +2833,8 @@
         <div>
           <h3>Notifications configurées</h3>
           <div style="display:grid; grid-template-columns: repeat(3, minmax(0, 1fr)) auto; gap:8px; align-items:end; margin-bottom:8px">
-            <div class="beta-field"><label>Type</label><select id="tracker-alert-kind-${escapeHtml(stat.id)}"><option value="ratio">Ratio</option><option value="buffer">Buffer</option><option value="seedtime">Seedtime</option><option value="cookie">Cookie</option><option value="site">Site HS</option></select></div>
-            <div class="beta-field"><label>Condition</label><select id="tracker-alert-op-${escapeHtml(stat.id)}"><option value="<=">&lt;=</option><option value="<">&lt;</option><option value="soon">bientôt expiré</option><option value="down">HS</option></select></div>
+            <div class="beta-field"><label>Type</label><select id="tracker-alert-kind-${escapeHtml(stat.id)}"><option value="ratio">Ratio</option><option value="buffer">Buffer</option><option value="fail">Échec</option><option value="mp">MP reçu</option><option value="cookie">Session ancienne</option><option value="stats">Statistiques</option></select></div>
+            <div class="beta-field"><label>Condition</label><select id="tracker-alert-op-${escapeHtml(stat.id)}"><option value="<">&lt;</option><option value="<=">&lt;=</option><option value=">=">&gt;=</option><option value=">">&gt;</option></select></div>
             <div class="beta-field"><label>Seuil</label><input id="tracker-alert-threshold-${escapeHtml(stat.id)}" type="number" step="0.01" value="1"></div>
             <button class="beta-icon-btn" onclick="addBetaAlertRuleForTracker('${escapeHtml(stat.id)}')" type="button">Ajouter</button>
           </div>
@@ -2816,7 +2842,10 @@
             <thead><tr><th>Alerte</th><th>Condition</th><th>Destinations</th></tr></thead>
             <tbody>${rules.map(rule => {
               const destinationLabels = (rule.targetIds || []).map(id => targets.get(id)?.label).filter(Boolean);
-              return `<tr><td>${escapeHtml(rule.kind)}${rule.enabled === false ? ' (off)' : ''}</td><td>${escapeHtml(rule.operator)} ${escapeHtml(rule.threshold)}</td><td>${escapeHtml(destinationLabels.join(', ') || 'Toutes actives / non précisé')}</td></tr>`;
+              const kindLabels = { ratio: 'Ratio', buffer: 'Buffer', fail: 'Échec', mp: 'MP reçu', cookie: 'Session ancienne', stats: 'Statistiques' };
+              const usesThreshold = ['ratio', 'buffer', 'cookie'].includes(rule.kind);
+              const condText = usesThreshold ? `${escapeHtml(rule.operator)} ${escapeHtml(rule.threshold)}${rule.kind === 'cookie' ? ' j' : ''}` : '—';
+              return `<tr><td>${escapeHtml(kindLabels[rule.kind] || rule.kind)}${rule.enabled === false ? ' (off)' : ''}</td><td>${condText}</td><td>${escapeHtml(destinationLabels.join(', ') || 'Toutes actives / non précisé')}</td></tr>`;
             }).join('') || '<tr><td colspan="3" class="cell-muted">Aucune alerte individuelle pour ce tracker.</td></tr>'}</tbody>
           </table>
         </div>
@@ -3369,13 +3398,36 @@
   function renderBetaNotificationPreferences() {
     const container = document.getElementById('beta-notification-preferences');
     if (!container) return;
-    const preferences = betaSettings.notificationPreferences || {};
+    const p = betaSettings.notificationPreferences || {};
+    const g = betaSettings.globalAlerts || {};
+    const auto = betaNotifMode === 'auto';
+    const err = auto ? (p.notifyError !== false) : (p.notifyManualError !== false);
+    const suc = auto ? (p.notifySuccess === true) : (p.notifyManualSuccess === true);
+    const sta = auto ? (p.notifyStats === true) : (p.notifyManualStats === true);
+    const mp = auto ? (p.notifyMp !== false) : (p.notifyManualMp !== false);
+    const tab = (label, mode) => `<button type="button" class="beta-icon-btn ${betaNotifMode === mode ? 'primary' : ''}" onclick="setBetaNotifMode('${mode}')">${label}</button>`;
     container.innerHTML = `
-      <div class="beta-form-row" style="grid-template-columns:repeat(2,minmax(0,1fr));margin-bottom:10px">
-        <label><input id="beta-notify-error" type="checkbox" ${preferences.notifyError !== false ? 'checked' : ''}> Échecs</label>
-        <label><input id="beta-notify-success" type="checkbox" ${preferences.notifySuccess ? 'checked' : ''}> Succès</label>
-        <label><input id="beta-notify-recovery" type="checkbox" ${preferences.notifySuccessAfterFailure !== false ? 'checked' : ''}> Rétablissement après échec</label>
-        <label><input id="beta-notify-stats" type="checkbox" ${preferences.notifyStats ? 'checked' : ''}> Inclure les statistiques</label>
+      <div style="display:flex;gap:6px;margin-bottom:12px">${tab('Si automatique', 'auto')}${tab('Si manuel', 'manual')}</div>
+      <div class="beta-form-row" style="grid-template-columns:repeat(2,minmax(0,1fr));margin-bottom:14px">
+        <label><input id="beta-notify-error" type="checkbox" ${err ? 'checked' : ''}> Échecs</label>
+        <label><input id="beta-notify-success" type="checkbox" ${suc ? 'checked' : ''}> Succès</label>
+        <label><input id="beta-notify-stats" type="checkbox" ${sta ? 'checked' : ''}> Inclure les statistiques</label>
+        <label><input id="beta-notify-mp" type="checkbox" ${mp ? 'checked' : ''}> MP non lus</label>
+      </div>
+      <div class="beta-note" style="margin-bottom:6px;font-weight:500">Seuils (communs auto et manuel)</div>
+      <div style="display:grid;gap:8px">
+        <label style="display:flex;align-items:center;gap:8px">
+          <input id="beta-global-ratio-enabled" type="checkbox" ${g.ratioEnabled ? 'checked' : ''}> Ratio inférieur à
+          <input id="beta-global-ratio-threshold" type="number" step="0.01" value="${escapeHtml(g.ratioThreshold ?? 1)}" style="width:80px;height:30px">
+        </label>
+        <label style="display:flex;align-items:center;gap:8px">
+          <input id="beta-global-buffer-enabled" type="checkbox" ${g.bufferEnabled ? 'checked' : ''}> Buffer inférieur à
+          <input id="beta-global-buffer-threshold" type="number" step="1" value="${escapeHtml(g.bufferThresholdGo ?? 100)}" style="width:80px;height:30px"> Go
+        </label>
+        <label style="display:flex;align-items:center;gap:8px">
+          <input id="beta-global-session-enabled" type="checkbox" ${g.sessionEnabled ? 'checked' : ''}> Session ancienne supérieure à
+          <input id="beta-global-session-days" type="number" step="1" value="${escapeHtml(g.sessionDays ?? 30)}" style="width:80px;height:30px"> jours
+        </label>
       </div>
     `;
   }
@@ -3388,8 +3440,8 @@
       <div class="beta-form-row" data-beta-target="${idx}">
         <div class="beta-field"><label>Nom</label><input data-field="label" value="${escapeHtml(target.label || '')}"></div>
         <div class="beta-field"><label>Type</label><select data-field="type" onchange="changeBetaNotificationType(${idx}, this.value)"><option value="discord" ${target.type !== 'apprise' ? 'selected' : ''}>Discord</option><option value="apprise" ${target.type === 'apprise' ? 'selected' : ''}>Apprise</option></select></div>
-        <div class="beta-field" style="grid-column:span 2"><label>${target.type === 'apprise' ? 'URL du serveur Apprise' : 'Webhook Discord'}</label><input data-field="url" value="${escapeHtml(target.url || '')}" placeholder="https://..."></div>
-        ${target.type === 'apprise' ? `<div class="beta-field" style="grid-column:span 2"><label>URLs Apprise (une par ligne)</label><textarea data-field="urls" rows="3" placeholder="pover://...&#10;discord://...">${escapeHtml((target.urls || []).join('\n'))}</textarea></div>` : ''}
+        <div class="beta-field" style="grid-column:1 / -1"><label>${target.type === 'apprise' ? 'URL du serveur Apprise' : 'Webhook Discord'}</label><input data-field="url" value="${escapeHtml(target.url || '')}" placeholder="https://..."></div>
+        ${target.type === 'apprise' ? `<div class="beta-field" style="grid-column:1 / -1"><label>URLs Apprise (une par ligne)</label><textarea data-field="urls" rows="3" placeholder="pover://...&#10;discord://...">${escapeHtml((target.urls || []).join('\n'))}</textarea></div>` : ''}
         <div class="beta-field"><label>Actif</label><select data-field="enabled"><option value="true" ${target.enabled !== false ? 'selected' : ''}>Oui</option><option value="false" ${target.enabled === false ? 'selected' : ''}>Non</option></select></div>
         <div style="display:flex; gap:6px"><button class="beta-icon-btn" onclick="testBetaNotification('${escapeHtml(target.id)}')" type="button">Tester</button><button class="beta-icon-btn" onclick="removeBetaNotificationTarget(${idx})" type="button">X</button></div>
       </div>
@@ -3401,20 +3453,31 @@
     if (!container) return;
     const rules = betaSettings.alertRules || [];
     const trackerOptions = trackerConfig.map(t => `<option value="${escapeHtml(t.id)}">${escapeHtml(t.name)}</option>`).join('');
-    container.innerHTML = rules.map((rule, idx) => `
+    const kindOptions = (selected) => `
+      <option value="ratio" ${selected === 'ratio' ? 'selected' : ''}>Ratio</option>
+      <option value="buffer" ${selected === 'buffer' ? 'selected' : ''}>Buffer</option>
+      <option value="fail" ${selected === 'fail' ? 'selected' : ''}>Échec</option>
+      <option value="mp" ${selected === 'mp' ? 'selected' : ''}>MP reçu</option>
+      <option value="cookie" ${selected === 'cookie' ? 'selected' : ''}>Session ancienne</option>
+      <option value="stats" ${selected === 'stats' ? 'selected' : ''}>Statistiques</option>`;
+    const opOptions = (selected) => `
+      <option value="<" ${selected === '<' ? 'selected' : ''}>&lt;</option>
+      <option value="<=" ${selected === '<=' ? 'selected' : ''}>&lt;=</option>
+      <option value=">=" ${selected === '>=' ? 'selected' : ''}>&gt;=</option>
+      <option value=">" ${selected === '>' ? 'selected' : ''}>&gt;</option>`;
+    const usesThreshold = (kind) => ['ratio', 'buffer', 'cookie'].includes(kind);
+    container.innerHTML = rules.map((rule, idx) => {
+      const needsThreshold = usesThreshold(rule.kind || 'ratio');
+      return `
       <div class="beta-form-row" data-beta-rule="${idx}">
         <div class="beta-field"><label>Tracker</label><select data-field="trackerId">${trackerOptions}</select></div>
-        <div class="beta-field"><label>Type</label><select data-field="kind">
-          <option value="ratio">Ratio</option><option value="buffer">Buffer</option><option value="seedtime">Seedtime</option><option value="cookie">Cookie</option><option value="site">Site HS</option>
-        </select></div>
-        <div class="beta-field"><label>Condition</label><select data-field="operator">
-          <option value="<=">&lt;=</option><option value="<">&lt;</option><option value=">=">&gt;=</option><option value=">">&gt;</option><option value="soon">bientôt expiré</option><option value="expired">expiré</option><option value="down">HS</option>
-        </select></div>
-        <div class="beta-field"><label>Seuil</label><input data-field="threshold" type="number" step="0.01" value="${escapeHtml(rule.threshold ?? 1)}"></div>
+        <div class="beta-field"><label>Type</label><select data-field="kind" onchange="refreshBetaAlertRow(${idx}, this.value)">${kindOptions(rule.kind || 'ratio')}</select></div>
+        <div class="beta-field" style="${needsThreshold ? '' : 'visibility:hidden'}"><label>Condition</label><select data-field="operator">${opOptions(rule.operator || '<')}</select></div>
+        <div class="beta-field" style="${needsThreshold ? '' : 'visibility:hidden'}"><label>${rule.kind === 'cookie' ? 'Jours' : 'Seuil'}</label><input data-field="threshold" type="number" step="0.01" value="${escapeHtml(rule.threshold ?? 1)}"></div>
         <div class="beta-field"><label>Actif</label><select data-field="enabled"><option value="true" ${rule.enabled !== false ? 'selected' : ''}>Oui</option><option value="false" ${rule.enabled === false ? 'selected' : ''}>Non</option></select></div>
         <button class="beta-icon-btn" onclick="removeBetaAlertRule(${idx})" type="button">X</button>
-      </div>
-    `).join('') || '<p class="beta-note">Alertes globales proposées : ratio <= 1 hors ratioless, cookie bientôt expiré, site HS. Ajouter des seuils par tracker ici.</p>';
+      </div>`;
+    }).join('') || '<p class="beta-note">Aucun override. Ajouter ici des règles spécifiques par tracker.</p>';
     rules.forEach((rule, idx) => {
       const row = container.querySelector(`[data-beta-rule="${idx}"]`);
       if (!row) return;
@@ -3423,6 +3486,12 @@
         if (el) el.value = String(rule[field] ?? '');
       });
     });
+  }
+
+  function refreshBetaAlertRow(idx, kind) {
+    betaSettings = collectBetaSettingsFromDom();
+    if (betaSettings.alertRules[idx]) betaSettings.alertRules[idx].kind = kind;
+    renderBetaAlertRules();
   }
 
   function renderBetaLab() {
@@ -3488,12 +3557,22 @@
       minute,
       weekdays: Array.from(document.querySelectorAll('[data-beta-weekday]:checked')).map(input => Number(input.dataset.betaWeekday)),
     };
-    const notificationPreferences = {
-      notifyError: document.getElementById('beta-notify-error')?.checked !== false,
-      notifySuccess: document.getElementById('beta-notify-success')?.checked === true,
-      notifySuccessAfterFailure: document.getElementById('beta-notify-recovery')?.checked !== false,
-      notifyStats: document.getElementById('beta-notify-stats')?.checked === true,
-    };
+    const notificationPreferences = (() => {
+      const prev = betaSettings.notificationPreferences || {};
+      const errEl = document.getElementById('beta-notify-error');
+      const sucEl = document.getElementById('beta-notify-success');
+      const staEl = document.getElementById('beta-notify-stats');
+      const mpEl  = document.getElementById('beta-notify-mp');
+      const result = { ...prev };
+      if (errEl) {
+        const auto = betaNotifMode === 'auto';
+        result[auto ? 'notifyError'   : 'notifyManualError']   = errEl.checked;
+        result[auto ? 'notifySuccess' : 'notifyManualSuccess']  = sucEl?.checked === true;
+        result[auto ? 'notifyStats'   : 'notifyManualStats']    = staEl?.checked === true;
+        result[auto ? 'notifyMp'      : 'notifyManualMp']       = mpEl?.checked === true;
+      }
+      return result;
+    })();
     const scheduleOverrides = Array.from(document.querySelectorAll('[data-beta-schedule-override]')).map(row => {
       const value = row.querySelector('[data-field="scheduleMode"]').value;
       return {
@@ -3502,6 +3581,15 @@
         intervalHours: Number(value) || 24,
       };
     }).filter(override => override.mode !== 'global');
+    const ratioEl = document.getElementById('beta-global-ratio-enabled');
+    const globalAlerts = ratioEl ? {
+      ratioEnabled: ratioEl.checked === true,
+      ratioThreshold: Number(document.getElementById('beta-global-ratio-threshold')?.value || 1),
+      bufferEnabled: document.getElementById('beta-global-buffer-enabled')?.checked === true,
+      bufferThresholdGo: Number(document.getElementById('beta-global-buffer-threshold')?.value || 100),
+      sessionEnabled: document.getElementById('beta-global-session-enabled')?.checked === true,
+      sessionDays: Number(document.getElementById('beta-global-session-days')?.value || 30),
+    } : { ...(betaSettings.globalAlerts || {}) };
     return {
       ...betaSettings,
       qbitClients,
@@ -3511,6 +3599,7 @@
       scheduleOverrides,
       notificationPreferences,
       alertRules,
+      globalAlerts,
     };
   }
 
@@ -3573,7 +3662,7 @@
       trackerId: selectedBetaTracker()?.id || trackerConfig[0]?.id || '',
       enabled: true,
       kind: 'ratio',
-      operator: '<=',
+      operator: '<',
       threshold: 1,
       targetIds: [],
     });
@@ -3588,7 +3677,7 @@
       trackerId,
       enabled: true,
       kind: document.getElementById(`tracker-alert-kind-${trackerId}`)?.value || 'ratio',
-      operator: document.getElementById(`tracker-alert-op-${trackerId}`)?.value || '<=',
+      operator: document.getElementById(`tracker-alert-op-${trackerId}`)?.value || '<',
       threshold: Number(document.getElementById(`tracker-alert-threshold-${trackerId}`)?.value || 1),
       targetIds: activeTargets,
     });
@@ -3676,7 +3765,7 @@
     alert(data.ok ? 'Notification envoyée' : `Notification KO: ${data.error}`);
   }
 
-  const ALL_VIEWS = ['dashboard', 'trackers', 'proxies', 'incidents', 'graphs', 'qbit', 'scraping', 'notifications', 'fiche'];
+  const ALL_VIEWS = ['dashboard', 'trackers', 'proxies', 'incidents', 'graphs', 'qbit', 'scraping', 'notif-canaux', 'notif-globales', 'notif-tracker', 'fiche'];
 
   // Affiche la vue demandée : bascule les sections de <main>, le panneau proxy
   // (sibling de <main>) et l'état actif de la barre latérale.
@@ -3695,6 +3784,7 @@
     document.querySelectorAll('.sidebar [data-nav]').forEach(btn => {
       btn.classList.toggle('active', btn.getAttribute('data-nav') === currentView);
     });
+    if (currentView.startsWith('notif-')) setNavGroupOpen('notif', true);
 
     if (isBetaView()) loadBetaData();
     renderGrid();
@@ -3719,6 +3809,19 @@
     if (event) event.stopPropagation();
     const group = document.querySelector(`.nav-group[data-nav-group="${name}"]`);
     if (group) group.classList.toggle('open');
+  }
+
+  function onNotifNavClick(event) {
+    setNavGroupOpen('notif', true);
+    showView('notif-canaux');
+  }
+
+  let betaNotifMode = 'auto'; // 'auto' | 'manual'
+
+  function setBetaNotifMode(mode) {
+    betaSettings = collectBetaSettingsFromDom();
+    betaNotifMode = mode === 'manual' ? 'manual' : 'auto';
+    renderBetaNotificationPreferences();
   }
 
   function loadBetaSettings() {

--- a/src/server.ts
+++ b/src/server.ts
@@ -152,6 +152,11 @@ interface BetaNotificationPreferences {
   notifySuccess: boolean;
   notifySuccessAfterFailure: boolean;
   notifyStats: boolean;
+  notifyMp: boolean;
+  notifyManualError: boolean;
+  notifyManualSuccess: boolean;
+  notifyManualStats: boolean;
+  notifyManualMp: boolean;
 }
 
 interface BetaTrackerScheduleOverride {
@@ -162,14 +167,28 @@ interface BetaTrackerScheduleOverride {
   lastRunAt: string | null;
 }
 
+// Alerte par tracker (override). 'kind' = metrique surveillee.
+// ratio/buffer/cookie : comparaison numerique via operator + threshold.
+// fail : tracker en echec. mp : MP non lus > 0. stats : envoie la ligne stats.
 interface BetaAlertRule {
   id: string;
   trackerId: string;
   enabled: boolean;
-  kind: 'ratio' | 'buffer' | 'seedtime' | 'cookie' | 'site';
-  operator: '<=' | '<' | '>=' | '>' | 'expired' | 'soon' | 'down';
+  kind: 'ratio' | 'buffer' | 'fail' | 'mp' | 'cookie' | 'stats';
+  operator: '<=' | '<' | '>=' | '>';
   threshold: number;
   targetIds: string[];
+}
+
+// Alertes globales numeriques communes aux deux modes (auto et manuel).
+// Echec et MP sont geres par les preferences (notifyError/notifyMp).
+interface BetaGlobalAlerts {
+  ratioEnabled: boolean;
+  ratioThreshold: number;
+  bufferEnabled: boolean;
+  bufferThresholdGo: number;
+  sessionEnabled: boolean;
+  sessionDays: number;
 }
 
 interface BetaAnnounceMapping {
@@ -185,6 +204,7 @@ interface BetaSettings {
   scheduleOverrides: BetaTrackerScheduleOverride[];
   notificationPreferences: BetaNotificationPreferences;
   alertRules: BetaAlertRule[];
+  globalAlerts: BetaGlobalAlerts;
   defaults: {
     ratioEnabled: boolean;
     ratioThreshold: number;
@@ -1481,41 +1501,220 @@ function nextBetaScheduleRun(schedule: BetaScheduleSettings, from = new Date()):
   return null;
 }
 
+function unreadMessagesCount(stat: TrackerStats): number {
+  const raw = (stat.fields ?? {}).unreadMessages;
+  if (raw === undefined || raw === null || raw === '') return 0;
+  const n = Number(raw);
+  if (Number.isFinite(n)) return n > 0 ? n : 0;
+  return String(raw).trim().length > 0 ? 1 : 0;
+}
+
+function formatBytesForNotif(bytes: number | string, byteUnit: 'binary' | 'decimal' = 'binary'): string {
+  const b = Number(bytes);
+  if (!Number.isFinite(b)) return String(bytes);
+  const sign = b < 0 ? '-' : '';
+  const abs = Math.abs(b);
+  if (byteUnit === 'decimal') {
+    if (abs >= 1e12) return `${sign}${(abs / 1e12).toFixed(2)} To`;
+    if (abs >= 1e9) return `${sign}${(abs / 1e9).toFixed(2)} Go`;
+    if (abs >= 1e6) return `${sign}${(abs / 1e6).toFixed(2)} Mo`;
+    if (abs >= 1e3) return `${sign}${(abs / 1e3).toFixed(2)} Ko`;
+    return `${sign}${abs.toFixed(0)} o`;
+  }
+  if (abs >= 1024 ** 4) return `${sign}${(abs / 1024 ** 4).toFixed(2)} Tio`;
+  if (abs >= 1024 ** 3) return `${sign}${(abs / 1024 ** 3).toFixed(2)} Gio`;
+  if (abs >= 1024 ** 2) return `${sign}${(abs / 1024 ** 2).toFixed(2)} Mio`;
+  if (abs >= 1024) return `${sign}${(abs / 1024).toFixed(2)} Kio`;
+  return `${sign}${abs.toFixed(0)} o`;
+}
+
+function formatStatLine(stat: TrackerStats): string {
+  const fields = stat.fields ?? {};
+  const byteUnit = stat.byteUnit ?? 'binary';
+  const parts: string[] = [];
+  let ratioDisplay: string | null = null;
+  if (fields.ratio !== undefined && fields.ratio !== null && fields.ratio !== '') {
+    const n = Number(fields.ratio);
+    ratioDisplay = Number.isFinite(n) ? n.toFixed(2) : String(fields.ratio);
+  } else if (fields.uploadedBytes !== undefined && fields.downloadedBytes !== undefined) {
+    const up = Number(fields.uploadedBytes);
+    const down = Number(fields.downloadedBytes);
+    if (!Number.isNaN(up) && !Number.isNaN(down)) {
+      ratioDisplay = down === 0 ? (up > 0 ? '∞' : null) : (up / down).toFixed(2);
+    }
+  }
+  if (ratioDisplay !== null) parts.push(`Ratio ${ratioDisplay}`);
+  if (fields.uploadedBytes !== undefined && fields.uploadedBytes !== '') {
+    parts.push(`Up ${formatBytesForNotif(fields.uploadedBytes, byteUnit)}`);
+  }
+  if (fields.downloadedBytes !== undefined && fields.downloadedBytes !== '') {
+    parts.push(`Down ${formatBytesForNotif(fields.downloadedBytes, byteUnit)}`);
+  }
+  return parts.join(' - ');
+}
+
+function computeRatio(stat: TrackerStats): number | null {
+  const fields = stat.fields ?? {};
+  if (fields.ratio !== undefined && fields.ratio !== null && fields.ratio !== '') {
+    if (fields.ratio === '∞' || fields.ratio === Infinity) return Infinity;
+    const n = Number(fields.ratio);
+    if (Number.isFinite(n)) return n;
+  }
+  const up = Number(fields.uploadedBytes);
+  const down = Number(fields.downloadedBytes);
+  if (Number.isNaN(up) || Number.isNaN(down)) return null;
+  if (down === 0) return up > 0 ? Infinity : null;
+  return up / down;
+}
+
+function compareNumber(value: number, operator: '<=' | '<' | '>=' | '>', threshold: number): boolean {
+  switch (operator) {
+    case '<=': return value <= threshold;
+    case '<': return value < threshold;
+    case '>=': return value >= threshold;
+    case '>': return value > threshold;
+    default: return false;
+  }
+}
+
+function evaluateTrackerAlerts(settings: BetaSettings, results: TrackerStats[]): string[] {
+  const global = settings.globalAlerts;
+  const overrides = settings.alertRules.filter(rule => rule.enabled);
+  const messages: string[] = [];
+  for (const stat of results) {
+    const trackerOverrides = overrides.filter(rule => rule.trackerId === stat.id);
+    const overriddenKinds = new Set(trackerOverrides.map(rule => rule.kind));
+    const ratioOverride = trackerOverrides.find(rule => rule.kind === 'ratio');
+    if (ratioOverride) {
+      const ratio = computeRatio(stat);
+      if (ratio !== null && Number.isFinite(ratio) && compareNumber(ratio, ratioOverride.operator, ratioOverride.threshold)) {
+        messages.push(`${stat.name} : ratio ${ratio.toFixed(2)} ${ratioOverride.operator} ${ratioOverride.threshold}`);
+      }
+    } else if (global.ratioEnabled && stat.status === 'ok') {
+      const ratio = computeRatio(stat);
+      if (ratio !== null && Number.isFinite(ratio) && ratio < global.ratioThreshold) {
+        messages.push(`${stat.name} : ratio ${ratio.toFixed(2)} < ${global.ratioThreshold}`);
+      }
+    }
+    const bufferOverride = trackerOverrides.find(rule => rule.kind === 'buffer');
+    const up = Number((stat.fields ?? {}).uploadedBytes);
+    const down = Number((stat.fields ?? {}).downloadedBytes);
+    const bufferKnown = !Number.isNaN(up) && !Number.isNaN(down);
+    if (bufferOverride) {
+      if (bufferKnown) {
+        const buffer = up - down;
+        if (compareNumber(buffer, bufferOverride.operator, bufferOverride.threshold)) {
+          messages.push(`${stat.name} : buffer ${formatBytesForNotif(buffer, stat.byteUnit)} ${bufferOverride.operator} ${formatBytesForNotif(bufferOverride.threshold, stat.byteUnit)}`);
+        }
+      }
+    } else if (global.bufferEnabled && stat.status === 'ok' && bufferKnown) {
+      const buffer = up - down;
+      const thresholdBytes = global.bufferThresholdGo * 1e9;
+      if (buffer < thresholdBytes) {
+        messages.push(`${stat.name} : buffer ${formatBytesForNotif(buffer, stat.byteUnit)} < ${global.bufferThresholdGo} Go`);
+      }
+    }
+    if (overriddenKinds.has('fail') && stat.status === 'error') {
+      const reason = stat.error || stat.siteReachability?.reason || 'erreur inconnue';
+      messages.push(`${stat.name} : échec — ${reason}`);
+    }
+    if (overriddenKinds.has('mp') && stat.status === 'ok') {
+      const mp = unreadMessagesCount(stat);
+      if (mp > 0) messages.push(`${stat.name} : ${mp} MP non lu${mp > 1 ? 's' : ''}`);
+    }
+    const cookieOverride = trackerOverrides.find(rule => rule.kind === 'cookie');
+    const sessionDays = cookieOverride ? cookieOverride.threshold : global.sessionDays;
+    const sessionApplies = cookieOverride ? true : (global.sessionEnabled && !overriddenKinds.has('cookie'));
+    if (sessionApplies && stat.lastLoginAt) {
+      const ageDays = (Date.now() - Date.parse(stat.lastLoginAt)) / 86_400_000;
+      if (Number.isFinite(ageDays) && ageDays > sessionDays) {
+        messages.push(`${stat.name} : session ancienne (${Math.floor(ageDays)} j, seuil ${sessionDays} j)`);
+      }
+    }
+    if (overriddenKinds.has('stats') && stat.status === 'ok') {
+      const statLine = formatStatLine(stat);
+      messages.push(`${stat.name} : ${statLine || 'OK'}`);
+    }
+  }
+  return messages;
+}
+
 async function notifyScheduledResult(
   settings: BetaSettings,
   results: TrackerStats[],
   previousFailures: Set<string>,
+  manual = false,
 ): Promise<void> {
   const targets = settings.notificationTargets.filter(target => target.enabled && target.url);
   if (targets.length === 0 || results.length === 0) return;
 
-  const errors = results.filter(result => result.status === 'error');
-  const recovered = results.filter(result => result.status === 'ok' && previousFailures.has(result.id));
-  const prefs = settings.notificationPreferences;
-  let title = '';
-  let lines: string[] = [];
+  const isUnconfigured = (result: TrackerStats) =>
+    result.status === 'error' && result.error?.startsWith('Credentials manquants');
+  const relevant = results.filter(result => !isUnconfigured(result));
+  if (relevant.length === 0) return;
 
-  if (errors.length > 0 && prefs.notifyError) {
-    title = `Tracker Dashboard : ${errors.length} echec(s)`;
-    lines = errors.map(result => `${result.name}: ${result.error || 'erreur inconnue'}`);
-  } else if (recovered.length > 0 && prefs.notifySuccessAfterFailure) {
-    title = 'Tracker Dashboard : retablissement';
-    lines = [`Sites retablis : ${recovered.map(result => result.name).join(', ')}`];
-  } else if (errors.length === 0 && prefs.notifySuccess) {
-    title = 'Tracker Dashboard : cycle termine';
-    lines = ['Tous les trackers configures sont accessibles.'];
-    if (prefs.notifyStats) {
-      lines.push(...results.map(result => `${result.name}: ${Object.entries(result.fields ?? {}).slice(0, 4).map(([key, value]) => `${key}=${String(value)}`).join(', ') || 'OK'}`));
-    }
+  const errors = relevant.filter(result => result.status === 'error');
+  const ok = relevant.filter(result => result.status === 'ok');
+  const recovered = ok.filter(result => previousFailures.has(result.id));
+  const prefs = settings.notificationPreferences;
+  const notifications: Array<{ title: string; lines: string[] }> = [];
+
+  const wantError = manual ? prefs.notifyManualError : prefs.notifyError;
+  const wantSuccess = manual ? prefs.notifyManualSuccess : prefs.notifySuccess;
+  const wantStats = manual ? prefs.notifyManualStats : prefs.notifyStats;
+  const wantMp = manual ? prefs.notifyManualMp : prefs.notifyMp;
+  const plural = (n: number, word: string) => `${n} ${word}${n > 1 ? 's' : ''}`;
+
+  const totalMp = wantMp ? ok.reduce((sum, result) => sum + unreadMessagesCount(result), 0) : 0;
+  const titleParts: string[] = [];
+  if (ok.length > 0) titleParts.push(`${ok.length} succès`);
+  if (errors.length > 0) titleParts.push(plural(errors.length, 'échec'));
+  if (totalMp > 0) titleParts.push(plural(totalMp, 'MP'));
+  const sharedTitle = `TD : ${titleParts.join(' - ')}`;
+
+  if (errors.length > 0 && wantError) {
+    notifications.push({
+      title: sharedTitle,
+      lines: errors.map(result => `- ${result.name} : ${result.error || 'erreur inconnue'}`),
+    });
   }
 
-  if (!title) return;
-  const deliveries = await Promise.allSettled(targets.map(target => sendBetaNotification(target, lines.join('\n'), title)));
-  deliveries.forEach((delivery, index) => {
-    if (delivery.status === 'rejected') {
-      console.error(`[Beta Notifications] ${targets[index].label}:`, delivery.reason);
+  if (ok.length > 0 && wantSuccess) {
+    const lines: string[] = [];
+    if (recovered.length > 0) {
+      lines.push(`Sites rétablis : ${recovered.map(result => result.name).join(', ')}`, '');
     }
-  });
+    if (wantStats) {
+      ok.forEach((result, index) => {
+        const statLine = formatStatLine(result);
+        const mp = wantMp ? unreadMessagesCount(result) : 0;
+        const mpSuffix = mp > 0 ? ` - ${mp} MP non lu${mp > 1 ? 's' : ''}` : '';
+        lines.push(`- ${result.name}${mpSuffix}`);
+        lines.push(statLine || 'OK');
+        if (index < ok.length - 1) lines.push('');
+      });
+    } else {
+      lines.push(ok.map(result => `- ${result.name}`).join('\n'));
+    }
+    notifications.push({ title: sharedTitle, lines });
+  }
+
+  const alertMessages = evaluateTrackerAlerts(settings, relevant);
+  if (alertMessages.length > 0) {
+    notifications.push({
+      title: `TD : ${plural(alertMessages.length, 'alerte')}`,
+      lines: alertMessages.map(message => `- ${message}`),
+    });
+  }
+
+  for (const { title, lines } of notifications) {
+    const deliveries = await Promise.allSettled(targets.map(target => sendBetaNotification(target, lines.join('\n'), title)));
+    deliveries.forEach((delivery, index) => {
+      if (delivery.status === 'rejected') {
+        console.error(`[Beta Notifications] ${targets[index].label}:`, delivery.reason);
+      }
+    });
+  }
 }
 
 async function runBetaScheduledCycle(): Promise<void> {
@@ -1748,8 +1947,21 @@ function defaultBetaSettings(): BetaSettings {
       notifySuccess: false,
       notifySuccessAfterFailure: true,
       notifyStats: false,
+      notifyMp: true,
+      notifyManualError: true,
+      notifyManualSuccess: false,
+      notifyManualStats: false,
+      notifyManualMp: true,
     },
     alertRules: [],
+    globalAlerts: {
+      ratioEnabled: false,
+      ratioThreshold: 1,
+      bufferEnabled: false,
+      bufferThresholdGo: 100,
+      sessionEnabled: false,
+      sessionDays: 30,
+    },
     defaults: {
       ratioEnabled: true,
       ratioThreshold: 1,
@@ -1775,6 +1987,7 @@ function loadBetaSettings(): BetaSettings {
       ...(settings.notificationPreferences ?? {}),
     },
     alertRules: Array.isArray(settings.alertRules) ? settings.alertRules : [],
+    globalAlerts: { ...defaultBetaSettings().globalAlerts, ...(settings.globalAlerts ?? {}) },
   };
 }
 
@@ -1852,8 +2065,8 @@ function saveBetaSettingsPayload(raw: unknown): BetaSettings {
       id: typeof rule.id === 'string' && rule.id ? rule.id : crypto.randomUUID(),
       trackerId: String(rule.trackerId || '').trim(),
       enabled: rule.enabled !== false,
-      kind: ['buffer', 'seedtime', 'cookie', 'site'].includes(String(rule.kind)) ? rule.kind as BetaAlertRule['kind'] : 'ratio',
-      operator: ['<=', '<', '>=', '>', 'expired', 'soon', 'down'].includes(String(rule.operator)) ? rule.operator as BetaAlertRule['operator'] : '<=',
+      kind: ['ratio', 'buffer', 'fail', 'mp', 'cookie', 'stats'].includes(String(rule.kind)) ? rule.kind as BetaAlertRule['kind'] : 'ratio',
+      operator: ['<=', '<', '>=', '>'].includes(String(rule.operator)) ? rule.operator as BetaAlertRule['operator'] : '<',
       threshold: Number.isFinite(Number(rule.threshold)) ? Number(rule.threshold) : 1,
       targetIds: Array.isArray(rule.targetIds) ? rule.targetIds.filter((id): id is string => typeof id === 'string') : [],
     };
@@ -1931,9 +2144,24 @@ function saveBetaSettingsPayload(raw: unknown): BetaSettings {
     notifySuccess: rawPreferences.notifySuccess === true,
     notifySuccessAfterFailure: rawPreferences.notifySuccessAfterFailure !== false,
     notifyStats: rawPreferences.notifyStats === true,
+    notifyMp: rawPreferences.notifyMp !== false,
+    notifyManualError: rawPreferences.notifyManualError !== false,
+    notifyManualSuccess: rawPreferences.notifyManualSuccess === true,
+    notifyManualStats: rawPreferences.notifyManualStats === true,
+    notifyManualMp: rawPreferences.notifyManualMp !== false,
   };
 
-  const next = { qbitClients, announceMappings, notificationTargets, schedule, scheduleOverrides, notificationPreferences, alertRules, defaults };
+  const rawGlobal = (body.globalAlerts ?? current.globalAlerts) as Partial<BetaGlobalAlerts>;
+  const globalAlerts: BetaGlobalAlerts = {
+    ratioEnabled: rawGlobal.ratioEnabled === true,
+    ratioThreshold: Number.isFinite(Number(rawGlobal.ratioThreshold)) ? Number(rawGlobal.ratioThreshold) : 1,
+    bufferEnabled: rawGlobal.bufferEnabled === true,
+    bufferThresholdGo: Number.isFinite(Number(rawGlobal.bufferThresholdGo)) ? Number(rawGlobal.bufferThresholdGo) : 100,
+    sessionEnabled: rawGlobal.sessionEnabled === true,
+    sessionDays: Number.isFinite(Number(rawGlobal.sessionDays)) ? Number(rawGlobal.sessionDays) : 30,
+  };
+
+  const next = { qbitClients, announceMappings, notificationTargets, schedule, scheduleOverrides, notificationPreferences, alertRules, globalAlerts, defaults };
   setJsonSetting(BETA_SETTINGS_KEY, next);
   return next;
 }
@@ -2579,7 +2807,11 @@ export async function start(): Promise<void> {
       lastRefresh = new Date().toISOString();
       return res.json({ ok: true, presentationMode: true });
     }
-    refresh(trackers);
+    const settings = loadBetaSettings();
+    const previousFailures = new Set(settings.schedule.lastFailedTrackerIds);
+    refresh(trackers).then(results => {
+      void notifyScheduledResult(settings, results, previousFailures, true);
+    }).catch(err => console.error('[Manual Refresh] erreur:', err));
     res.json({ ok: true });
   });
 
@@ -2592,7 +2824,10 @@ export async function start(): Promise<void> {
     }
     const tracker = trackers.find(t => t.id === req.params.trackerId && t.enabled !== false);
     if (!tracker) return res.status(404).json({ ok: false, error: 'Tracker introuvable' });
+    const settings = loadBetaSettings();
+    const previousFailures = new Set(settings.schedule.lastFailedTrackerIds);
     const stat = await refreshOneTracker(tracker);
+    void notifyScheduledResult(settings, [stat], previousFailures, true);
     res.json({ ok: true, stat });
   });
 


### PR DESCRIPTION
- Sous-menu Notifications à 3 pages (Canaux / Globales / Par tracker)
- Notifications globales fusionnées avec bascule Auto/Manuel
- Seuils ratio/buffer/session communs aux deux modes
- Notifs indépendantes : échecs, succès+stats, MP, alertes par tracker
- Stats formatées en Go/To, ratio calculé si absent
- MP non lus affichables
- Notifications sur refresh manuel (préférences dédiées)
- Alertes par tracker réellement évaluées (ratio/buffer/fail/mp/session/stats)
- Alertes globales numériques (ratio/buffer/session)
- Exclusion des sites non configurés (credentials manquants)
- Fix textarea Apprise + webhook Discord pleine largeur