### PR TITLE
fix: barres Totaux par tracker invisibles (display:block manquant)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -662,6 +662,7 @@
       overflow: hidden;
     }
     .beta-bar-fill {
+      display: block;
       height: 100%;
       min-width: 2px;
       border-radius: inherit;


### PR DESCRIPTION
## Vrai cause

Le remplissage `.beta-bar-fill` est un `<span>` **sans `display`** → **inline**. Un élément inline **ignore `width`/`height`** : la barre colorée n'avait donc aucune boîte, et seule la piste grise (`.beta-bar-track`) s'affichait. D'où « aucune couleur » dans Totaux par tracker, quelle que soit l'image/le navigateur.

Le style calculé rapportait pourtant `width:100%` + fond bleu (valeurs spécifiées), ce qui masquait le bug lors des vérifs par `getComputedStyle` — mais le rendu réel n'avait pas de boîte.

## Correctif

Une ligne : `display: block` sur `.beta-bar-fill`.

## Vérification (rendu réel, pas seulement style calculé)

Largeurs **réellement rendues** sur 8 trackers décroissants, piste = 180 px :
180 / 158 / 135 / 113 / 90 / 68 / 45 / 23 px → proportions 100 / 88 / 75 / 63 / 50 / 38 / 25 / 13 %. Fond `rgb(59,130,246)` (bleu DL) / vert (UP).

- `npm run check:integration` : OK, syntaxe JS : OK.