### PR TITLE
feat(notifications): refonte par tracker, type mail, corrections UI

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -500,6 +500,24 @@
     .beta-field input:focus,
     .beta-field select:focus,
     .beta-field textarea:focus { outline: none; border-color: var(--blue); }
+    input.beta-num {
+      width: 72px; height: 28px;
+      background: var(--bg); border: 1px solid var(--border); border-radius: 6px;
+      color: var(--text); font-size: 12px; padding: 0 7px;
+      -moz-appearance: textfield;
+    }
+    input.beta-num::-webkit-outer-spin-button,
+    input.beta-num::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }
+    input.beta-num:focus { outline: none; border-color: var(--blue); }
+    input.beta-port {
+      width: 54px; height: 28px;
+      background: var(--bg); border: 1px solid var(--border); border-radius: 6px;
+      color: var(--text); font-size: 12px; padding: 0 7px;
+      -moz-appearance: textfield;
+    }
+    input.beta-port::-webkit-outer-spin-button,
+    input.beta-port::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }
+    input.beta-port:focus { outline: none; border-color: var(--blue); }
     .beta-list {
       display: grid;
       gap: 6px;
@@ -2005,11 +2023,16 @@
   <section class="tab-view" data-view="notif-canaux">
     <section class="beta-panel" style="width:100%">
       <h3>Canaux de notification</h3>
-      <p class="beta-note" style="margin-bottom:10px">Destinations Apprise et/ou Discord. Les notifications globales et par tracker sont envoyées sur tous les canaux actifs.</p>
+      <p class="beta-note" style="margin-bottom:10px">Chaque canal est une destination indépendante. Les notifications sont envoyées sur tous les canaux actifs.<br><br>
+        <strong>Discord</strong> — coller l'URL du webhook (Paramètres salon → Intégrations → Webhooks).<br>
+        <strong>Apprise</strong> — URL de votre serveur Apprise + une ou plusieurs URLs de service (Pushover, Telegram…).<br>
+        <strong>Mail</strong> — envoi via votre serveur Apprise. Nécessite un canal Apprise actif.
+      </p>
       <div id="beta-notification-targets"></div>
       <div style="margin-top:10px; display:flex; gap:8px; flex-wrap:wrap">
-        <button class="beta-icon-btn" onclick="addBetaNotificationTarget('discord')" type="button">Ajouter Discord</button>
-        <button class="beta-icon-btn" onclick="addBetaNotificationTarget('apprise')" type="button">Ajouter Apprise</button>
+        <button class="beta-icon-btn" onclick="addBetaNotificationTarget('discord')" type="button">+ Discord</button>
+        <button class="beta-icon-btn" onclick="addBetaNotificationTarget('apprise')" type="button">+ Apprise</button>
+        <button class="beta-icon-btn" onclick="addBetaNotificationTarget('mail')" type="button">+ Mail</button>
         <button class="beta-icon-btn primary" onclick="saveBetaSettings()" type="button">Enregistrer</button>
       </div>
     </section>
@@ -2029,10 +2052,9 @@
   <section class="tab-view" data-view="notif-tracker">
     <section class="beta-panel" style="width:100%">
       <h3>Notifications par tracker</h3>
-      <p class="beta-note" style="margin-bottom:10px">Règles spécifiques à un tracker. Une règle ratio / buffer / session remplace le seuil global pour ce tracker.</p>
-      <div id="beta-alert-rules"></div>
+      <p class="beta-note" style="margin-bottom:10px">Notifications spécifiques à un tracker, envoyées dans une notification distincte de la globale. Sélectionnez un tracker, puis activez les options voulues (mêmes options que les notifications globales).</p>
+      <div id="beta-tracker-alerts"></div>
       <div style="margin-top:10px; display:flex; gap:8px; flex-wrap:wrap">
-        <button class="beta-icon-btn" onclick="addBetaAlertRule()" type="button">Ajouter une alerte tracker</button>
         <button class="beta-icon-btn primary" onclick="saveBetaSettings()" type="button">Enregistrer</button>
       </div>
     </section>
@@ -2475,7 +2497,7 @@
     notificationPreferences: {},
     schedule: {},
     scheduleOverrides: [],
-    alertRules: [],
+    trackerAlerts: {},
     defaults: {},
   };
   let betaHistory = [];
@@ -2859,8 +2881,7 @@
     const recentErrors = allErrors.filter(row => (Date.parse(row.capturedAt) || 0) >= sevenDaysAgo);
     const currentlyInError = stat.status === 'error' || Boolean(stat.stale);
     const currentErrorMsg = stat.stale?.error || stat.error || '';
-    const rules = (betaSettings.alertRules || []).filter(rule => rule.trackerId === stat.id);
-    const targets = new Map((betaSettings.notificationTargets || []).map(target => [target.id, target]));
+    const trackerAlert = (betaSettings.trackerAlerts || {})[stat.id];
 
     container.innerHTML = `
       <div class="beta-detail-grid">
@@ -2899,22 +2920,21 @@
         </div>
         <div>
           <h3>Notifications configurées</h3>
-          <div style="display:grid; grid-template-columns: repeat(3, minmax(0, 1fr)) auto; gap:8px; align-items:end; margin-bottom:8px">
-            <div class="beta-field"><label>Type</label><select id="tracker-alert-kind-${escapeHtml(stat.id)}"><option value="ratio">Ratio</option><option value="buffer">Buffer</option><option value="fail">Échec</option><option value="mp">MP reçu</option><option value="cookie">Session ancienne</option><option value="stats">Statistiques</option></select></div>
-            <div class="beta-field"><label>Condition</label><select id="tracker-alert-op-${escapeHtml(stat.id)}"><option value="<">&lt;</option><option value="<=">&lt;=</option><option value=">=">&gt;=</option><option value=">">&gt;</option></select></div>
-            <div class="beta-field"><label>Seuil</label><input id="tracker-alert-threshold-${escapeHtml(stat.id)}" type="number" step="0.01" value="1"></div>
-            <button class="beta-icon-btn" onclick="addBetaAlertRuleForTracker('${escapeHtml(stat.id)}')" type="button">Ajouter</button>
-          </div>
-          <table class="beta-mini-table">
-            <thead><tr><th>Alerte</th><th>Condition</th><th>Destinations</th></tr></thead>
-            <tbody>${rules.map(rule => {
-              const destinationLabels = (rule.targetIds || []).map(id => targets.get(id)?.label).filter(Boolean);
-              const kindLabels = { ratio: 'Ratio', buffer: 'Buffer', fail: 'Échec', mp: 'MP reçu', cookie: 'Session ancienne', stats: 'Statistiques' };
-              const usesThreshold = ['ratio', 'buffer', 'cookie'].includes(rule.kind);
-              const condText = usesThreshold ? `${escapeHtml(rule.operator)} ${escapeHtml(rule.threshold)}${rule.kind === 'cookie' ? ' j' : ''}` : '—';
-              return `<tr><td>${escapeHtml(kindLabels[rule.kind] || rule.kind)}${rule.enabled === false ? ' (off)' : ''}</td><td>${condText}</td><td>${escapeHtml(destinationLabels.join(', ') || 'Toutes actives / non précisé')}</td></tr>`;
-            }).join('') || '<tr><td colspan="3" class="cell-muted">Aucune alerte individuelle pour ce tracker.</td></tr>'}</tbody>
-          </table>
+          ${(() => {
+            const ta = trackerAlert;
+            const editBtn = `<div style="margin-top:8px"><button class="beta-icon-btn" onclick="openTrackerNotif('${escapeHtml(stat.id)}')" type="button">Configurer les notifications de ce tracker</button></div>`;
+            if (!ta) return `<p class="beta-note">Ce tracker suit les notifications globales.</p>${editBtn}`;
+            const active = [];
+            if (ta.notifyError || ta.notifyManualError) active.push('Échecs');
+            if (ta.notifySuccess || ta.notifyManualSuccess) active.push('Succès');
+            if (ta.notifyStats || ta.notifyManualStats) active.push('Statistiques');
+            if (ta.notifyMp || ta.notifyManualMp) active.push('MP non lus');
+            if (ta.ratioEnabled) active.push(`Ratio &lt; ${escapeHtml(ta.ratioThreshold)}`);
+            if (ta.bufferEnabled) active.push(`Buffer &lt; ${escapeHtml(ta.bufferThresholdGo)} Go`);
+            if (ta.sessionEnabled) active.push(`Session &gt; ${escapeHtml(ta.sessionDays)} j`);
+            if (active.length === 0) return `<p class="beta-note">Ce tracker suit les notifications globales.</p>${editBtn}`;
+            return `<table class="beta-mini-table"><thead><tr><th>Notifications spécifiques actives</th></tr></thead><tbody>${active.map(a => `<tr><td>${a}</td></tr>`).join('')}</tbody></table>${editBtn}`;
+          })()}
         </div>
       </div>
       <div style="margin-top:12px">
@@ -3612,15 +3632,15 @@
       <div style="display:grid;gap:8px">
         <label style="display:flex;align-items:center;gap:8px">
           <input id="beta-global-ratio-enabled" type="checkbox" ${g.ratioEnabled ? 'checked' : ''}> Ratio inférieur à
-          <input id="beta-global-ratio-threshold" type="number" step="0.01" value="${escapeHtml(g.ratioThreshold ?? 1)}" style="width:80px;height:30px">
+          <input id="beta-global-ratio-threshold" type="number" step="0.01" value="${escapeHtml(g.ratioThreshold ?? 1)}" class="beta-num">
         </label>
         <label style="display:flex;align-items:center;gap:8px">
           <input id="beta-global-buffer-enabled" type="checkbox" ${g.bufferEnabled ? 'checked' : ''}> Buffer inférieur à
-          <input id="beta-global-buffer-threshold" type="number" step="1" value="${escapeHtml(g.bufferThresholdGo ?? 100)}" style="width:80px;height:30px"> Go
+          <input id="beta-global-buffer-threshold" type="number" step="1" value="${escapeHtml(g.bufferThresholdGo ?? 100)}" class="beta-num"> Go
         </label>
         <label style="display:flex;align-items:center;gap:8px">
           <input id="beta-global-session-enabled" type="checkbox" ${g.sessionEnabled ? 'checked' : ''}> Session ancienne supérieure à
-          <input id="beta-global-session-days" type="number" step="1" value="${escapeHtml(g.sessionDays ?? 30)}" style="width:80px;height:30px"> jours
+          <input id="beta-global-session-days" type="number" step="1" value="${escapeHtml(g.sessionDays ?? 30)}" class="beta-num"> jours
         </label>
       </div>
     `;
@@ -3630,63 +3650,150 @@
     const container = document.getElementById('beta-notification-targets');
     if (!container) return;
     const targets = betaSettings.notificationTargets || [];
-    container.innerHTML = targets.map((target, idx) => `
-      <div class="beta-form-row" data-beta-target="${idx}">
-        <div class="beta-field"><label>Nom</label><input data-field="label" value="${escapeHtml(target.label || '')}"></div>
-        <div class="beta-field"><label>Type</label><select data-field="type" onchange="changeBetaNotificationType(${idx}, this.value)"><option value="discord" ${target.type !== 'apprise' ? 'selected' : ''}>Discord</option><option value="apprise" ${target.type === 'apprise' ? 'selected' : ''}>Apprise</option></select></div>
-        <div class="beta-field" style="grid-column:1 / -1"><label>${target.type === 'apprise' ? 'URL du serveur Apprise' : 'Webhook Discord'}</label><input data-field="url" value="${escapeHtml(target.url || '')}" placeholder="https://..."></div>
-        ${target.type === 'apprise' ? `<div class="beta-field" style="grid-column:1 / -1"><label>URLs Apprise (une par ligne)</label><textarea data-field="urls" rows="3" placeholder="pover://...&#10;discord://...">${escapeHtml((target.urls || []).join('\n'))}</textarea></div>` : ''}
-        <div class="beta-field"><label>Actif</label><select data-field="enabled"><option value="true" ${target.enabled !== false ? 'selected' : ''}>Oui</option><option value="false" ${target.enabled === false ? 'selected' : ''}>Non</option></select></div>
-        <div style="display:flex; gap:6px"><button class="beta-icon-btn" onclick="testBetaNotification('${escapeHtml(target.id)}')" type="button">Tester</button><button class="beta-icon-btn" onclick="removeBetaNotificationTarget(${idx})" type="button">X</button></div>
-      </div>
-    `).join('') || '<p class="beta-note">Ajouter Discord et/ou Apprise. Les URL sont masquées au rechargement.</p>';
-  }
-
-  function renderBetaAlertRules() {
-    const container = document.getElementById('beta-alert-rules');
-    if (!container) return;
-    const rules = betaSettings.alertRules || [];
-    const trackerOptions = trackerConfig.map(t => `<option value="${escapeHtml(t.id)}">${escapeHtml(t.name)}</option>`).join('');
-    const kindOptions = (selected) => `
-      <option value="ratio" ${selected === 'ratio' ? 'selected' : ''}>Ratio</option>
-      <option value="buffer" ${selected === 'buffer' ? 'selected' : ''}>Buffer</option>
-      <option value="fail" ${selected === 'fail' ? 'selected' : ''}>Échec</option>
-      <option value="mp" ${selected === 'mp' ? 'selected' : ''}>MP reçu</option>
-      <option value="cookie" ${selected === 'cookie' ? 'selected' : ''}>Session ancienne</option>
-      <option value="stats" ${selected === 'stats' ? 'selected' : ''}>Statistiques</option>`;
-    const opOptions = (selected) => `
-      <option value="<" ${selected === '<' ? 'selected' : ''}>&lt;</option>
-      <option value="<=" ${selected === '<=' ? 'selected' : ''}>&lt;=</option>
-      <option value=">=" ${selected === '>=' ? 'selected' : ''}>&gt;=</option>
-      <option value=">" ${selected === '>' ? 'selected' : ''}>&gt;</option>`;
-    const usesThreshold = (kind) => ['ratio', 'buffer', 'cookie'].includes(kind);
-    container.innerHTML = rules.map((rule, idx) => {
-      const needsThreshold = usesThreshold(rule.kind || 'ratio');
+    const hasApprise = targets.some(t => t.type === 'apprise' && t.enabled !== false);
+    container.innerHTML = targets.map((target, idx) => {
+      const isMail = target.type === 'mail';
+      const isApprise = target.type === 'apprise';
+      const typeSelect = `<select data-field="type" onchange="changeBetaNotificationType(${idx}, this.value)">
+        <option value="discord" ${target.type === 'discord' ? 'selected' : ''}>Discord</option>
+        <option value="apprise" ${isApprise ? 'selected' : ''}>Apprise</option>
+        <option value="mail" ${isMail ? 'selected' : ''}>Mail</option>
+      </select>`;
+      const mailWarning = isMail && !hasApprise
+        ? `<div class="beta-note" style="grid-column:1/-1;color:var(--yellow)">⚠ Un canal Apprise actif est requis pour le transport Mail. Ajoutez-en un.</div>` : '';
+      const urlField = !isMail
+        ? `<div class="beta-field" style="grid-column:1 / -1"><label>${isApprise ? 'URL du serveur Apprise' : 'Webhook Discord'}</label><input data-field="url" value="${escapeHtml(target.url || '')}" placeholder="https://..."></div>` : '';
+      const appriseUrls = isApprise
+        ? `<div class="beta-field" style="grid-column:1 / -1"><label>URLs Apprise (une par ligne)</label><textarea data-field="urls" rows="3" placeholder="pover://...&#10;discord://...">${escapeHtml((target.urls || []).join('\n'))}</textarea></div>` : '';
+      const mailFields = isMail ? `
+        ${mailWarning}
+        <div class="beta-field" style="grid-column:1/-1"><label>Adresse email (expéditeur / login SMTP)</label><input data-field="mailFrom" type="email" value="${escapeHtml(target.mailFrom || '')}" placeholder="user@gmail.com"></div>
+        <div class="beta-field"><label>Mot de passe / App password</label><input data-field="mailPass" type="password" value="${target.mailPass ? '••••••••' : ''}"></div>
+        <div class="beta-field"><label>Destinataire (optionnel, défaut = expéditeur)</label><input data-field="mailTo" type="email" value="${escapeHtml(target.mailTo || '')}" placeholder="moi@exemple.com"></div>
+        <div class="beta-field"><label>Serveur SMTP (optionnel)</label><input data-field="mailSmtp" value="${escapeHtml(target.mailSmtp || '')}" placeholder="mail.exemple.com"></div>
+        <div class="beta-field"><label>Port (optionnel, défaut 587)</label><input data-field="mailPort" type="number" value="${escapeHtml(target.mailPort || '')}" placeholder="587" class="beta-port"></div>` : '';
       return `
-      <div class="beta-form-row" data-beta-rule="${idx}">
-        <div class="beta-field"><label>Tracker</label><select data-field="trackerId">${trackerOptions}</select></div>
-        <div class="beta-field"><label>Type</label><select data-field="kind" onchange="refreshBetaAlertRow(${idx}, this.value)">${kindOptions(rule.kind || 'ratio')}</select></div>
-        <div class="beta-field" style="${needsThreshold ? '' : 'visibility:hidden'}"><label>Condition</label><select data-field="operator">${opOptions(rule.operator || '<')}</select></div>
-        <div class="beta-field" style="${needsThreshold ? '' : 'visibility:hidden'}"><label>${rule.kind === 'cookie' ? 'Jours' : 'Seuil'}</label><input data-field="threshold" type="number" step="0.01" value="${escapeHtml(rule.threshold ?? 1)}"></div>
-        <div class="beta-field"><label>Actif</label><select data-field="enabled"><option value="true" ${rule.enabled !== false ? 'selected' : ''}>Oui</option><option value="false" ${rule.enabled === false ? 'selected' : ''}>Non</option></select></div>
-        <button class="beta-icon-btn" onclick="removeBetaAlertRule(${idx})" type="button">X</button>
+      <div class="beta-form-row" data-beta-target="${idx}" style="border:1px solid var(--border);border-radius:8px;padding:12px;margin-bottom:10px;background:color-mix(in srgb,var(--bg2) 60%,transparent)">
+        <div style="grid-column:1/-1;font-size:11px;font-weight:700;color:var(--text2);text-transform:uppercase;letter-spacing:.06em;margin-bottom:4px">${{discord:'Discord',apprise:'Apprise',mail:'Mail'}[target.type]||target.type}</div>
+        <div class="beta-field"><label>Nom</label><input data-field="label" value="${escapeHtml(target.label || '')}"></div>
+        <div class="beta-field"><label>Type</label>${typeSelect}</div>
+        ${urlField}${appriseUrls}${mailFields}
+        <div class="beta-field"><label>Actif</label><select data-field="enabled"><option value="true" ${target.enabled !== false ? 'selected' : ''}>Oui</option><option value="false" ${target.enabled === false ? 'selected' : ''}>Non</option></select></div>
+        <div style="display:flex; gap:6px"><button class="beta-icon-btn" onclick="testBetaNotification('${escapeHtml(target.id)}')" type="button">Tester</button><button class="beta-icon-btn" onclick="removeBetaNotificationTarget(${idx})" type="button">Supprimer</button></div>
       </div>`;
-    }).join('') || '<p class="beta-note">Aucun override. Ajouter ici des règles spécifiques par tracker.</p>';
-    rules.forEach((rule, idx) => {
-      const row = container.querySelector(`[data-beta-rule="${idx}"]`);
-      if (!row) return;
-      ['trackerId', 'kind', 'operator', 'enabled'].forEach(field => {
-        const el = row.querySelector(`[data-field="${field}"]`);
-        if (el) el.value = String(rule[field] ?? '');
-      });
-    });
+    }).join('') || '<p class="beta-note">Ajouter Discord, Apprise et/ou Mail. Les mots de passe sont masqués au rechargement.</p>';
   }
 
-  function refreshBetaAlertRow(idx, kind) {
-    betaSettings = collectBetaSettingsFromDom();
-    if (betaSettings.alertRules[idx]) betaSettings.alertRules[idx].kind = kind;
-    renderBetaAlertRules();
+  // Page « Notifications par tracker » : sélecteur de tracker en haut, puis mêmes
+  // options que les notifications globales (toggle auto/manuel + cases + seuils).
+  function defaultTrackerAlertFront() {
+    const p = betaSettings.notificationPreferences || {};
+    const g = betaSettings.globalAlerts || {};
+    // Valeurs de depart proposees = copie des reglages globaux courants.
+    return {
+      notifyError: p.notifyError === true, notifyManualError: p.notifyManualError === true,
+      notifySuccess: p.notifySuccess === true, notifyManualSuccess: p.notifyManualSuccess === true,
+      notifyStats: p.notifyStats === true, notifyManualStats: p.notifyManualStats === true,
+      notifyMp: p.notifyMp === true, notifyManualMp: p.notifyManualMp === true,
+      ratioEnabled: false, ratioThreshold: g.ratioThreshold ?? 1,
+      bufferEnabled: false, bufferThresholdGo: g.bufferThresholdGo ?? 100,
+      sessionEnabled: false, sessionDays: g.sessionDays ?? 30,
+    };
   }
+
+  function renderBetaTrackerAlerts() {
+    const container = document.getElementById('beta-tracker-alerts');
+    if (!container) return;
+    // N'afficher que les trackers configurés (credentials présents = dans betaStats).
+    const configuredIds = new Set(betaStats().map(s => s.id));
+    const trackers = (trackerConfig || []).filter(t => configuredIds.has(t.id));
+    if (trackers.length === 0) { container.innerHTML = '<p class="beta-note">Aucun tracker configuré.</p>'; return; }
+    if (!betaSettings.trackerAlerts) betaSettings.trackerAlerts = {};
+    if (!betaTrackerAlertId || !trackers.some(t => t.id === betaTrackerAlertId)) betaTrackerAlertId = trackers[0].id;
+    const saved = betaSettings.trackerAlerts[betaTrackerAlertId];
+    const a = saved ? { ...defaultTrackerAlertFront(), ...saved } : defaultTrackerAlertFront();
+    const auto = betaTrackerNotifMode === 'auto';
+    const err = auto ? a.notifyError : a.notifyManualError;
+    const suc = auto ? a.notifySuccess : a.notifyManualSuccess;
+    const sta = auto ? a.notifyStats : a.notifyManualStats;
+    const mp  = auto ? a.notifyMp : a.notifyManualMp;
+    const trackerTabs = trackers.map(t => {
+      const s = betaSettings.trackerAlerts[t.id];
+      const has = s && ['notifyError','notifyManualError','notifySuccess','notifyManualSuccess','notifyStats','notifyManualStats','notifyMp','notifyManualMp','ratioEnabled','bufferEnabled','sessionEnabled'].some(k => s[k]);
+      const on = t.id === betaTrackerAlertId;
+      return `<button type="button" class="beta-icon-btn ${on ? 'primary' : ''}" onclick="setBetaTrackerAlert('${escapeHtml(t.id)}')">${escapeHtml(t.name)}${has ? ' ●' : ''}</button>`;
+    }).join('');
+    const modeTab = (label, mode) => `<button type="button" class="beta-icon-btn ${betaTrackerNotifMode === mode ? 'primary' : ''}" onclick="setBetaTrackerNotifMode('${mode}')">${label}</button>`;
+    container.innerHTML = `
+      <div class="beta-note" style="margin-bottom:6px;font-weight:500">Tracker</div>
+      <div style="display:flex;gap:6px;flex-wrap:wrap;margin-bottom:14px">${trackerTabs}</div>
+      <div style="display:flex;gap:6px;margin-bottom:12px">${modeTab('Si automatique', 'auto')}${modeTab('Si manuel', 'manual')}</div>
+      <div class="beta-form-row" style="grid-template-columns:repeat(2,minmax(0,1fr));margin-bottom:14px">
+        <label><input id="beta-ta-error" type="checkbox" ${err ? 'checked' : ''}> Échecs</label>
+        <label><input id="beta-ta-success" type="checkbox" ${suc ? 'checked' : ''}> Succès</label>
+        <label><input id="beta-ta-stats" type="checkbox" ${sta ? 'checked' : ''}> Inclure les statistiques</label>
+        <label><input id="beta-ta-mp" type="checkbox" ${mp ? 'checked' : ''}> MP non lus</label>
+      </div>
+      <div class="beta-note" style="margin-bottom:6px;font-weight:500">Seuils (communs auto et manuel)</div>
+      <div style="display:grid;gap:8px">
+        <label style="display:flex;align-items:center;gap:8px">
+          <input id="beta-ta-ratio-enabled" type="checkbox" ${a.ratioEnabled ? 'checked' : ''}> Ratio inférieur à
+          <input id="beta-ta-ratio-threshold" type="number" step="0.01" value="${escapeHtml(a.ratioThreshold ?? 1)}" class="beta-num">
+        </label>
+        <label style="display:flex;align-items:center;gap:8px">
+          <input id="beta-ta-buffer-enabled" type="checkbox" ${a.bufferEnabled ? 'checked' : ''}> Buffer inférieur à
+          <input id="beta-ta-buffer-threshold" type="number" step="1" value="${escapeHtml(a.bufferThresholdGo ?? 100)}" class="beta-num"> Go
+        </label>
+        <label style="display:flex;align-items:center;gap:8px">
+          <input id="beta-ta-session-enabled" type="checkbox" ${a.sessionEnabled ? 'checked' : ''}> Session ancienne supérieure à
+          <input id="beta-ta-session-days" type="number" step="1" value="${escapeHtml(a.sessionDays ?? 30)}" class="beta-num"> jours
+        </label>
+      </div>
+    `;
+  }
+
+  // Lit le DOM de la page par tracker et ecrit dans betaSettings.trackerAlerts pour le
+  // tracker selectionne, en preservant les valeurs de l'autre mode (auto/manuel).
+  function collectBetaTrackerAlertFromDom() {
+    if (!betaTrackerAlertId) return;
+    const errEl = document.getElementById('beta-ta-error');
+    if (!errEl) return; // page non affichee
+    if (!betaSettings.trackerAlerts) betaSettings.trackerAlerts = {};
+    const prev = betaSettings.trackerAlerts[betaTrackerAlertId] || defaultTrackerAlertFront();
+    const entry = { ...defaultTrackerAlertFront(), ...prev };
+    const auto = betaTrackerNotifMode === 'auto';
+    entry[auto ? 'notifyError' : 'notifyManualError'] = errEl.checked;
+    entry[auto ? 'notifySuccess' : 'notifyManualSuccess'] = document.getElementById('beta-ta-success')?.checked === true;
+    entry[auto ? 'notifyStats' : 'notifyManualStats'] = document.getElementById('beta-ta-stats')?.checked === true;
+    entry[auto ? 'notifyMp' : 'notifyManualMp'] = document.getElementById('beta-ta-mp')?.checked === true;
+    entry.ratioEnabled = document.getElementById('beta-ta-ratio-enabled')?.checked === true;
+    entry.ratioThreshold = Number(document.getElementById('beta-ta-ratio-threshold')?.value || 1);
+    entry.bufferEnabled = document.getElementById('beta-ta-buffer-enabled')?.checked === true;
+    entry.bufferThresholdGo = Number(document.getElementById('beta-ta-buffer-threshold')?.value || 100);
+    entry.sessionEnabled = document.getElementById('beta-ta-session-enabled')?.checked === true;
+    entry.sessionDays = Number(document.getElementById('beta-ta-session-days')?.value || 30);
+    betaSettings.trackerAlerts[betaTrackerAlertId] = entry;
+  }
+
+  function setBetaTrackerAlert(trackerId) {
+    collectBetaTrackerAlertFromDom();
+    betaTrackerAlertId = trackerId;
+    renderBetaTrackerAlerts();
+  }
+
+  function setBetaTrackerNotifMode(mode) {
+    collectBetaTrackerAlertFromDom();
+    betaTrackerNotifMode = mode === 'manual' ? 'manual' : 'auto';
+    renderBetaTrackerAlerts();
+  }
+
+  // Ouvre la page « Notifications par tracker » en sélectionnant directement ce tracker.
+  function openTrackerNotif(trackerId) {
+    betaTrackerAlertId = trackerId;
+    showView('notif-tracker');
+    renderBetaTrackerAlerts();
+  }
+
 
   function renderBetaLab() {
     renderBetaTrackerList();
@@ -3708,7 +3815,7 @@
     renderBetaScheduleSettings();
     renderBetaNotificationPreferences();
     renderBetaNotificationTargets();
-    renderBetaAlertRules();
+    renderBetaTrackerAlerts();
   }
 
   function collectBetaSettingsFromDom() {
@@ -3728,23 +3835,33 @@
       announceHost: row.querySelector('[data-field="announceHost"]').value.trim(),
       trackerId: row.querySelector('[data-field="trackerId"]').value,
     })).filter(mapping => mapping.announceHost && mapping.trackerId);
-    const notificationTargets = Array.from(document.querySelectorAll('[data-beta-target]')).map((row, idx) => ({
-      id: betaSettings.notificationTargets?.[idx]?.id || genId(),
-      label: row.querySelector('[data-field="label"]').value.trim(),
-      type: row.querySelector('[data-field="type"]').value,
-      url: row.querySelector('[data-field="url"]').value.trim(),
-      urls: row.querySelector('[data-field="urls"]')?.value.split('\n').map(value => value.trim()).filter(Boolean) || [],
-      enabled: row.querySelector('[data-field="enabled"]').value === 'true',
-    })).filter(target => target.url);
-    const alertRules = Array.from(document.querySelectorAll('[data-beta-rule]')).map((row, idx) => ({
-      id: betaSettings.alertRules?.[idx]?.id || genId(),
-      trackerId: row.querySelector('[data-field="trackerId"]').value,
-      kind: row.querySelector('[data-field="kind"]').value,
-      operator: row.querySelector('[data-field="operator"]').value,
-      threshold: Number(row.querySelector('[data-field="threshold"]').value),
-      enabled: row.querySelector('[data-field="enabled"]').value === 'true',
-      targetIds: notificationTargets.filter(target => target.enabled).map(target => target.id),
-    })).filter(rule => rule.trackerId);
+    const notificationTargets = Array.from(document.querySelectorAll('[data-beta-target]')).map((row, idx) => {
+      const prev = betaSettings.notificationTargets?.[idx];
+      const type = row.querySelector('[data-field="type"]').value;
+      const base = {
+        id: prev?.id || genId(),
+        label: row.querySelector('[data-field="label"]').value.trim(),
+        type,
+        url: row.querySelector('[data-field="url"]')?.value.trim() || '',
+        urls: row.querySelector('[data-field="urls"]')?.value.split('\n').map(v => v.trim()).filter(Boolean) || [],
+        enabled: row.querySelector('[data-field="enabled"]').value === 'true',
+      };
+      if (type === 'mail') {
+        const passVal = row.querySelector('[data-field="mailPass"]')?.value;
+        return {
+          ...base,
+          mailFrom: row.querySelector('[data-field="mailFrom"]')?.value.trim() || '',
+          mailPass: passVal === '••••••••' ? (prev?.mailPass || '') : (passVal || ''),
+          mailTo: row.querySelector('[data-field="mailTo"]')?.value.trim() || undefined,
+          mailSmtp: row.querySelector('[data-field="mailSmtp"]')?.value.trim() || undefined,
+          mailPort: Number(row.querySelector('[data-field="mailPort"]')?.value) || undefined,
+        };
+      }
+      return base;
+    }).filter(target => target.type === 'mail' ? Boolean(target.mailFrom) : Boolean(target.url));
+    // Capturer les modifs en cours de la page « par tracker » avant relecture.
+    collectBetaTrackerAlertFromDom();
+    const trackerAlerts = { ...(betaSettings.trackerAlerts || {}) };
     const [hour, minute] = (document.getElementById('beta-schedule-time')?.value || '03:00').split(':').map(Number);
     const schedule = {
       ...(betaSettings.schedule || {}),
@@ -3797,7 +3914,7 @@
       schedule,
       scheduleOverrides,
       notificationPreferences,
-      alertRules,
+      trackerAlerts,
       globalAlerts,
     };
   }
@@ -3853,7 +3970,8 @@
 
   function addBetaNotificationTarget(type) {
     betaSettings = collectBetaSettingsFromDom();
-    betaSettings.notificationTargets.push({ id: genId(), type, label: type === 'apprise' ? 'Apprise' : 'Discord', url: '', urls: [], enabled: true });
+    const labelMap = { discord: 'Discord', apprise: 'Apprise', mail: 'Mail' };
+    betaSettings.notificationTargets.push({ id: genId(), type, label: labelMap[type] || type, url: '', urls: [], enabled: true });
     renderBetaNotificationTargets();
   }
 
@@ -3861,6 +3979,7 @@
     betaSettings = collectBetaSettingsFromDom();
     if (!betaSettings.notificationTargets[index]) return;
     betaSettings.notificationTargets[index].type = type;
+    betaSettings.notificationTargets[index].label = { discord: 'Discord', apprise: 'Apprise', mail: 'Mail' }[type] || type;
     renderBetaNotificationTargets();
   }
 
@@ -3868,43 +3987,6 @@
     betaSettings = collectBetaSettingsFromDom();
     betaSettings.notificationTargets.splice(index, 1);
     renderBetaNotificationTargets();
-  }
-
-  function addBetaAlertRule() {
-    betaSettings = collectBetaSettingsFromDom();
-    betaSettings.alertRules.push({
-      id: genId(),
-      trackerId: selectedBetaTracker()?.id || trackerConfig[0]?.id || '',
-      enabled: true,
-      kind: 'ratio',
-      operator: '<',
-      threshold: 1,
-      targetIds: [],
-    });
-    renderBetaAlertRules();
-  }
-
-  async function addBetaAlertRuleForTracker(trackerId) {
-    betaSettings = collectBetaSettingsFromDom();
-    const activeTargets = (betaSettings.notificationTargets || []).filter(target => target.enabled).map(target => target.id);
-    betaSettings.alertRules.push({
-      id: genId(),
-      trackerId,
-      enabled: true,
-      kind: document.getElementById(`tracker-alert-kind-${trackerId}`)?.value || 'ratio',
-      operator: document.getElementById(`tracker-alert-op-${trackerId}`)?.value || '<',
-      threshold: Number(document.getElementById(`tracker-alert-threshold-${trackerId}`)?.value || 1),
-      targetIds: activeTargets,
-    });
-    renderBetaTrackerPage();
-    renderBetaAlertRules();
-    await saveBetaSettings();
-  }
-
-  function removeBetaAlertRule(index) {
-    betaSettings = collectBetaSettingsFromDom();
-    betaSettings.alertRules.splice(index, 1);
-    renderBetaAlertRules();
   }
 
   async function saveBetaSettings() {
@@ -4028,6 +4110,8 @@
 
 
   let betaNotifMode = 'auto'; // 'auto' | 'manual'
+  let betaTrackerAlertId = null; // tracker sélectionné dans « par tracker »
+  let betaTrackerNotifMode = 'auto'; // mode auto/manuel de la page par tracker
 
   function setBetaNotifMode(mode) {
     betaSettings = collectBetaSettingsFromDom();

--- a/src/server.ts
+++ b/src/server.ts
@@ -126,11 +126,17 @@ interface BetaQbitClient {
 
 interface BetaNotificationTarget {
   id: string;
-  type: 'discord' | 'apprise';
+  type: 'discord' | 'apprise' | 'mail';
   label: string;
-  url: string;
-  urls?: string[];
+  url: string;       // webhook Discord ou URL serveur Apprise ; vide pour mail (resolu auto)
+  urls?: string[];   // URLs Apprise (type apprise)
   enabled: boolean;
+  // Champs specifiques au type mail (construits en mailtos:// au moment de l'envoi)
+  mailFrom?: string;    // ex. user@gmail.com ou user1@example.com
+  mailPass?: string;    // mot de passe / app password
+  mailTo?: string;      // destinataire (defaut = mailFrom)
+  mailSmtp?: string;    // serveur SMTP custom (optionnel, ex. mail.example.com)
+  mailPort?: number;    // port custom (optionnel, defaut 587)
 }
 
 interface BetaScheduleSettings {
@@ -166,17 +172,26 @@ interface BetaTrackerScheduleOverride {
   lastRunAt: string | null;
 }
 
-// Alerte par tracker (override). 'kind' = metrique surveillee.
-// ratio/buffer/cookie : comparaison numerique via operator + threshold.
-// fail : tracker en echec. mp : MP non lus > 0. stats : envoie la ligne stats.
-interface BetaAlertRule {
-  id: string;
-  trackerId: string;
-  enabled: boolean;
-  kind: 'ratio' | 'buffer' | 'fail' | 'mp' | 'cookie' | 'stats';
-  operator: '<=' | '<' | '>=' | '>';
-  threshold: number;
-  targetIds: string[];
+// Alertes par tracker : memes options que les reglages globaux (Echec/Succes/Stats/MP
+// en mode auto+manuel, + seuils ratio/buffer/session). Systeme ADDITIF et INDEPENDANT
+// du global : un tracker present ici declenche sa propre notification, en plus de la
+// notif globale. Pas d'override. Stockage : Record<trackerId, BetaTrackerAlert>.
+// Un tracker est "specifique" des qu'au moins une option est active.
+interface BetaTrackerAlert {
+  notifyError: boolean;
+  notifyManualError: boolean;
+  notifySuccess: boolean;
+  notifyManualSuccess: boolean;
+  notifyStats: boolean;
+  notifyManualStats: boolean;
+  notifyMp: boolean;
+  notifyManualMp: boolean;
+  ratioEnabled: boolean;
+  ratioThreshold: number;
+  bufferEnabled: boolean;
+  bufferThresholdGo: number;
+  sessionEnabled: boolean;
+  sessionDays: number;
 }
 
 // Alertes globales numeriques communes aux deux modes (auto et manuel).
@@ -202,7 +217,7 @@ interface BetaSettings {
   schedule: BetaScheduleSettings;
   scheduleOverrides: BetaTrackerScheduleOverride[];
   notificationPreferences: BetaNotificationPreferences;
-  alertRules: BetaAlertRule[];
+  trackerAlerts: Record<string, BetaTrackerAlert>;
   globalAlerts: BetaGlobalAlerts;
   defaults: {
     ratioEnabled: boolean;
@@ -1566,76 +1581,112 @@ function computeRatio(stat: TrackerStats): number | null {
   return up / down;
 }
 
-function compareNumber(value: number, operator: '<=' | '<' | '>=' | '>', threshold: number): boolean {
-  switch (operator) {
-    case '<=': return value <= threshold;
-    case '<': return value < threshold;
-    case '>=': return value >= threshold;
-    case '>': return value > threshold;
-    default: return false;
-  }
+// Construit les lignes d'une notification (echecs + succes/stats/mp + alertes
+// ratio/buffer/session) pour un sous-ensemble de trackers, selon un jeu de reglages
+// donne (global OU specifique a un tracker). Reutilise pour les deux notifications.
+interface AlertConfig {
+  notifyError: boolean; notifyManualError: boolean;
+  notifySuccess: boolean; notifyManualSuccess: boolean;
+  notifyStats: boolean; notifyManualStats: boolean;
+  notifyMp: boolean; notifyManualMp: boolean;
+  ratioEnabled: boolean; ratioThreshold: number;
+  bufferEnabled: boolean; bufferThresholdGo: number;
+  sessionEnabled: boolean; sessionDays: number;
 }
 
-function evaluateTrackerAlerts(settings: BetaSettings, results: TrackerStats[]): string[] {
-  const global = settings.globalAlerts;
-  const overrides = settings.alertRules.filter(rule => rule.enabled);
-  const messages: string[] = [];
-  for (const stat of results) {
-    const trackerOverrides = overrides.filter(rule => rule.trackerId === stat.id);
-    const overriddenKinds = new Set(trackerOverrides.map(rule => rule.kind));
-    const ratioOverride = trackerOverrides.find(rule => rule.kind === 'ratio');
-    if (ratioOverride) {
-      const ratio = computeRatio(stat);
-      if (ratio !== null && Number.isFinite(ratio) && compareNumber(ratio, ratioOverride.operator, ratioOverride.threshold)) {
-        messages.push(`${stat.name} : ratio ${ratio.toFixed(2)} ${ratioOverride.operator} ${ratioOverride.threshold}`);
-      }
-    } else if (global.ratioEnabled && stat.status === 'ok') {
-      const ratio = computeRatio(stat);
-      if (ratio !== null && Number.isFinite(ratio) && ratio < global.ratioThreshold) {
-        messages.push(`${stat.name} : ratio ${ratio.toFixed(2)} < ${global.ratioThreshold}`);
-      }
-    }
-    const bufferOverride = trackerOverrides.find(rule => rule.kind === 'buffer');
-    const up = Number((stat.fields ?? {}).uploadedBytes);
-    const down = Number((stat.fields ?? {}).downloadedBytes);
-    const bufferKnown = !Number.isNaN(up) && !Number.isNaN(down);
-    if (bufferOverride) {
-      if (bufferKnown) {
-        const buffer = up - down;
-        if (compareNumber(buffer, bufferOverride.operator, bufferOverride.threshold)) {
-          messages.push(`${stat.name} : buffer ${formatBytesForNotif(buffer, stat.byteUnit)} ${bufferOverride.operator} ${formatBytesForNotif(bufferOverride.threshold, stat.byteUnit)}`);
-        }
-      }
-    } else if (global.bufferEnabled && stat.status === 'ok' && bufferKnown) {
-      const buffer = up - down;
-      const thresholdBytes = global.bufferThresholdGo * 1e9;
-      if (buffer < thresholdBytes) {
-        messages.push(`${stat.name} : buffer ${formatBytesForNotif(buffer, stat.byteUnit)} < ${global.bufferThresholdGo} Go`);
-      }
-    }
-    if (overriddenKinds.has('fail') && stat.status === 'error') {
-      const reason = stat.error || stat.siteReachability?.reason || 'erreur inconnue';
-      messages.push(`${stat.name} : échec — ${reason}`);
-    }
-    if (overriddenKinds.has('mp') && stat.status === 'ok') {
-      const mp = unreadMessagesCount(stat);
-      if (mp > 0) messages.push(`${stat.name} : ${mp} MP non lu${mp > 1 ? 's' : ''}`);
-    }
-    const cookieOverride = trackerOverrides.find(rule => rule.kind === 'cookie');
-    const sessionDays = cookieOverride ? cookieOverride.threshold : global.sessionDays;
-    const sessionApplies = cookieOverride ? true : (global.sessionEnabled && !overriddenKinds.has('cookie'));
-    if (sessionApplies && stat.lastLoginAt) {
-      const ageDays = (Date.now() - Date.parse(stat.lastLoginAt)) / 86_400_000;
-      if (Number.isFinite(ageDays) && ageDays > sessionDays) {
-        messages.push(`${stat.name} : session ancienne (${Math.floor(ageDays)} j, seuil ${sessionDays} j)`);
-      }
-    }
-    if (overriddenKinds.has('stats') && stat.status === 'ok') {
-      const statLine = formatStatLine(stat);
-      messages.push(`${stat.name} : ${statLine || 'OK'}`);
+// Evalue les seuils ratio/buffer/session d'un tracker selon une config donnee.
+function evaluateThresholds(stat: TrackerStats, cfg: AlertConfig): string[] {
+  const out: string[] = [];
+  if (cfg.ratioEnabled && stat.status === 'ok') {
+    const ratio = computeRatio(stat);
+    if (ratio !== null && Number.isFinite(ratio) && ratio < cfg.ratioThreshold) {
+      out.push(`${stat.name} : ratio ${ratio.toFixed(2)} < ${cfg.ratioThreshold}`);
     }
   }
-  return messages;
+  if (cfg.bufferEnabled && stat.status === 'ok') {
+    const up = Number((stat.fields ?? {}).uploadedBytes);
+    const down = Number((stat.fields ?? {}).downloadedBytes);
+    if (!Number.isNaN(up) && !Number.isNaN(down) && (up - down) < cfg.bufferThresholdGo * 1e9) {
+      out.push(`${stat.name} : buffer ${formatBytesForNotif(up - down, stat.byteUnit)} < ${cfg.bufferThresholdGo} Go`);
+    }
+  }
+  if (cfg.sessionEnabled && stat.lastLoginAt) {
+    const ageDays = (Date.now() - Date.parse(stat.lastLoginAt)) / 86_400_000;
+    if (Number.isFinite(ageDays) && ageDays > cfg.sessionDays) {
+      out.push(`${stat.name} : session ancienne (${Math.floor(ageDays)} j, seuil ${cfg.sessionDays} j)`);
+    }
+  }
+  return out;
+}
+
+const plural = (n: number, word: string) => `${n} ${word}${n > 1 ? 's' : ''}`;
+
+// Construit jusqu'a 3 notifications (echecs / succes / alertes) a partir d'une liste
+// de trackers et d'une config. Le titre est partage : "TD : X succes - Y echecs - Z MP".
+function buildNotifications(
+  relevant: TrackerStats[],
+  cfg: AlertConfig,
+  previousFailures: Set<string>,
+  manual: boolean,
+): Array<{ title: string; lines: string[] }> {
+  const wantError = manual ? cfg.notifyManualError : cfg.notifyError;
+  const wantSuccess = manual ? cfg.notifyManualSuccess : cfg.notifySuccess;
+  const wantStats = manual ? cfg.notifyManualStats : cfg.notifyStats;
+  const wantMp = manual ? cfg.notifyManualMp : cfg.notifyMp;
+
+  const errors = wantError ? relevant.filter(r => r.status === 'error') : [];
+  const ok = wantSuccess ? relevant.filter(r => r.status === 'ok') : [];
+  const recovered = ok.filter(r => previousFailures.has(r.id));
+  const totalMp = wantMp ? relevant.filter(r => r.status === 'ok').reduce((s, r) => s + unreadMessagesCount(r), 0) : 0;
+
+  const titleParts: string[] = [];
+  if (ok.length > 0) titleParts.push(`${ok.length} succès`);
+  if (errors.length > 0) titleParts.push(plural(errors.length, 'échec'));
+  if (totalMp > 0) titleParts.push(plural(totalMp, 'MP'));
+  const sharedTitle = titleParts.length ? `TD : ${titleParts.join(' - ')}` : 'TD';
+
+  const notifications: Array<{ title: string; lines: string[] }> = [];
+
+  if (errors.length > 0) {
+    notifications.push({
+      title: sharedTitle,
+      lines: errors.map(r => `- ${r.name} : ${r.error || 'erreur inconnue'}`),
+    });
+  }
+
+  if (ok.length > 0) {
+    const lines: string[] = [];
+    if (recovered.length > 0) {
+      lines.push(`Sites rétablis : ${recovered.map(r => r.name).join(', ')}`, '');
+    }
+    if (wantStats) {
+      ok.forEach((r, index) => {
+        const mp = wantMp ? unreadMessagesCount(r) : 0;
+        const mpSuffix = mp > 0 ? ` - ${mp} MP non lu${mp > 1 ? 's' : ''}` : '';
+        lines.push(`- ${r.name}${mpSuffix}`);
+        lines.push(formatStatLine(r) || 'OK');
+        if (index < ok.length - 1) lines.push('');
+      });
+    } else {
+      ok.forEach(r => {
+        const mp = wantMp ? unreadMessagesCount(r) : 0;
+        const mpSuffix = mp > 0 ? ` - ${mp} MP non lu${mp > 1 ? 's' : ''}` : '';
+        lines.push(`- ${r.name}${mpSuffix}`);
+      });
+    }
+    notifications.push({ title: sharedTitle, lines });
+  }
+
+  // Alertes seuils ratio/buffer/session
+  const alertMessages = relevant.flatMap(stat => evaluateThresholds(stat, cfg));
+  if (alertMessages.length > 0) {
+    notifications.push({
+      title: `TD : ${plural(alertMessages.length, 'alerte')}`,
+      lines: alertMessages.map(m => `- ${m}`),
+    });
+  }
+
+  return notifications;
 }
 
 async function notifyScheduledResult(
@@ -1652,62 +1703,70 @@ async function notifyScheduledResult(
   const relevant = results.filter(result => !isUnconfigured(result));
   if (relevant.length === 0) return;
 
-  const errors = relevant.filter(result => result.status === 'error');
-  const ok = relevant.filter(result => result.status === 'ok');
-  const recovered = ok.filter(result => previousFailures.has(result.id));
-  const prefs = settings.notificationPreferences;
-  const notifications: Array<{ title: string; lines: string[] }> = [];
+  const p = settings.notificationPreferences;
+  const g = settings.globalAlerts;
+  const trackerAlerts = settings.trackerAlerts || {};
 
-  const wantError = manual ? prefs.notifyManualError : prefs.notifyError;
-  const wantSuccess = manual ? prefs.notifyManualSuccess : prefs.notifySuccess;
-  const wantStats = manual ? prefs.notifyManualStats : prefs.notifyStats;
-  const wantMp = manual ? prefs.notifyManualMp : prefs.notifyMp;
-  const plural = (n: number, word: string) => `${n} ${word}${n > 1 ? 's' : ''}`;
+  // 1) NOTIF GLOBALE : tous les trackers, selon les reglages globaux.
+  const globalCfg: AlertConfig = {
+    notifyError: p.notifyError, notifyManualError: p.notifyManualError,
+    notifySuccess: p.notifySuccess, notifyManualSuccess: p.notifyManualSuccess,
+    notifyStats: p.notifyStats, notifyManualStats: p.notifyManualStats,
+    notifyMp: p.notifyMp, notifyManualMp: p.notifyManualMp,
+    ratioEnabled: g.ratioEnabled, ratioThreshold: g.ratioThreshold,
+    bufferEnabled: g.bufferEnabled, bufferThresholdGo: g.bufferThresholdGo,
+    sessionEnabled: g.sessionEnabled, sessionDays: g.sessionDays,
+  };
+  const notifications = buildNotifications(relevant, globalCfg, previousFailures, manual);
 
-  const totalMp = wantMp ? ok.reduce((sum, result) => sum + unreadMessagesCount(result), 0) : 0;
-  const titleParts: string[] = [];
-  if (ok.length > 0) titleParts.push(`${ok.length} succès`);
-  if (errors.length > 0) titleParts.push(plural(errors.length, 'échec'));
-  if (totalMp > 0) titleParts.push(plural(totalMp, 'MP'));
-  const sharedTitle = `TD : ${titleParts.join(' - ')}`;
-
-  if (errors.length > 0 && wantError) {
-    notifications.push({
-      title: sharedTitle,
-      lines: errors.map(result => `- ${result.name} : ${result.error || 'erreur inconnue'}`),
-    });
-  }
-
-  if (ok.length > 0 && wantSuccess) {
-    const lines: string[] = [];
-    if (recovered.length > 0) {
-      lines.push(`Sites rétablis : ${recovered.map(result => result.name).join(', ')}`, '');
-    }
-    if (wantStats) {
-      ok.forEach((result, index) => {
-        const statLine = formatStatLine(result);
-        const mp = wantMp ? unreadMessagesCount(result) : 0;
+  // 2) NOTIF PAR TRACKER : independante, groupee, uniquement les trackers ayant des
+  // reglages specifiques, chacun selon SES reglages. Une notif distincte du global.
+  const specificStats = relevant.filter(stat => trackerAlerts[stat.id]);
+  if (specificStats.length > 0) {
+    // Chaque tracker specifique evalue avec sa propre config ; on agrege les lignes.
+    const perTrackerNotifs = specificStats.flatMap(stat =>
+      buildNotifications([stat], trackerAlerts[stat.id] as AlertConfig, previousFailures, manual),
+    );
+    // Regrouper par titre identique serait complexe ; on prefixe d'un marqueur clair.
+    // On fusionne toutes les lignes en une seule notif "par tracker".
+    const errLines: string[] = [];
+    const okLines: string[] = [];
+    const alertLines: string[] = [];
+    let okCount = 0, errCount = 0, mpCount = 0, alertCount = 0;
+    for (const stat of specificStats) {
+      const cfg = trackerAlerts[stat.id] as AlertConfig;
+      const wantError = manual ? cfg.notifyManualError : cfg.notifyError;
+      const wantSuccess = manual ? cfg.notifyManualSuccess : cfg.notifySuccess;
+      const wantStats = manual ? cfg.notifyManualStats : cfg.notifyStats;
+      const wantMp = manual ? cfg.notifyManualMp : cfg.notifyMp;
+      if (wantError && stat.status === 'error') {
+        errLines.push(`- ${stat.name} : ${stat.error || 'erreur inconnue'}`);
+        errCount += 1;
+      }
+      if (wantSuccess && stat.status === 'ok') {
+        const mp = wantMp ? unreadMessagesCount(stat) : 0;
         const mpSuffix = mp > 0 ? ` - ${mp} MP non lu${mp > 1 ? 's' : ''}` : '';
-        lines.push(`- ${result.name}${mpSuffix}`);
-        lines.push(statLine || 'OK');
-        if (index < ok.length - 1) lines.push('');
-      });
-    } else {
-      lines.push(ok.map(result => `- ${result.name}`).join('\n'));
+        okLines.push(`- ${stat.name}${mpSuffix}`);
+        if (wantStats) okLines.push(formatStatLine(stat) || 'OK');
+        okCount += 1;
+        mpCount += mp;
+      }
+      const thr = evaluateThresholds(stat, cfg);
+      alertLines.push(...thr.map(m => `- ${m}`));
+      alertCount += thr.length;
     }
-    notifications.push({ title: sharedTitle, lines });
-  }
-
-  const alertMessages = evaluateTrackerAlerts(settings, relevant);
-  if (alertMessages.length > 0) {
-    notifications.push({
-      title: `TD : ${plural(alertMessages.length, 'alerte')}`,
-      lines: alertMessages.map(message => `- ${message}`),
-    });
+    const titleParts: string[] = [];
+    if (okCount > 0) titleParts.push(`${okCount} succès`);
+    if (errCount > 0) titleParts.push(plural(errCount, 'échec'));
+    if (mpCount > 0) titleParts.push(plural(mpCount, 'MP'));
+    const trackerTitle = titleParts.length ? `TD : ${titleParts.join(' - ')}` : 'TD';
+    if (errLines.length > 0) notifications.push({ title: trackerTitle, lines: errLines });
+    if (okLines.length > 0) notifications.push({ title: trackerTitle, lines: okLines });
+    if (alertLines.length > 0) notifications.push({ title: `TD : ${plural(alertCount, 'alerte')}`, lines: alertLines });
   }
 
   for (const { title, lines } of notifications) {
-    const deliveries = await Promise.allSettled(targets.map(target => sendBetaNotification(target, lines.join('\n'), title)));
+    const deliveries = await Promise.allSettled(targets.map(target => sendBetaNotification(target, lines.join('\n'), title, targets)));
     deliveries.forEach((delivery, index) => {
       if (delivery.status === 'rejected') {
         console.error(`[Beta Notifications] ${targets[index].label}:`, delivery.reason);
@@ -1952,7 +2011,7 @@ function defaultBetaSettings(): BetaSettings {
       notifyManualStats: false,
       notifyManualMp: true,
     },
-    alertRules: [],
+    trackerAlerts: {},
     globalAlerts: {
       ratioEnabled: false,
       ratioThreshold: 1,
@@ -1985,7 +2044,7 @@ function loadBetaSettings(): BetaSettings {
       ...defaultBetaSettings().notificationPreferences,
       ...(settings.notificationPreferences ?? {}),
     },
-    alertRules: Array.isArray(settings.alertRules) ? settings.alertRules : [],
+    trackerAlerts: (settings.trackerAlerts && typeof settings.trackerAlerts === "object") ? settings.trackerAlerts : {},
     globalAlerts: { ...defaultBetaSettings().globalAlerts, ...(settings.globalAlerts ?? {}) },
   };
 }
@@ -2035,11 +2094,11 @@ function saveBetaSettingsPayload(raw: unknown): BetaSettings {
     const id = typeof target.id === 'string' && target.id ? target.id : crypto.randomUUID();
     const previous = previousTargets.get(id);
     const url = target.url === '••••••••' ? (previous?.url ?? '') : (target.url ?? '');
-    const type: BetaNotificationTarget['type'] = target.type === 'apprise' ? 'apprise' : 'discord';
-    return {
+    const type: BetaNotificationTarget['type'] = target.type === 'apprise' ? 'apprise' : target.type === 'mail' ? 'mail' : 'discord';
+    const base = {
       id,
       type,
-      label: String(target.label || (type === 'discord' ? 'Discord' : 'Apprise')).trim().slice(0, 80),
+      label: String(target.label || (type === 'discord' ? 'Discord' : type === 'mail' ? 'Mail' : 'Apprise')).trim().slice(0, 80),
       url: String(url || '').trim(),
       urls: Array.isArray(target.urls)
         ? (target.urls.every(value => value === '********')
@@ -2048,7 +2107,20 @@ function saveBetaSettingsPayload(raw: unknown): BetaSettings {
         : (previous?.urls ?? []),
       enabled: target.enabled !== false,
     };
-  }).filter(target => target.url) : current.notificationTargets;
+    if (type === 'mail') {
+      const resolveSecret = (val: string | undefined, prev: string | undefined) =>
+        val === '••••••••' ? (prev ?? '') : (val ?? '');
+      return {
+        ...base,
+        mailFrom: String(target.mailFrom || '').trim().toLowerCase(),
+        mailPass: resolveSecret(target.mailPass, previous?.mailPass),
+        mailTo: String(target.mailTo || '').trim().toLowerCase() || undefined,
+        mailSmtp: String(target.mailSmtp || '').trim() || undefined,
+        mailPort: target.mailPort ? Number(target.mailPort) : undefined,
+      };
+    }
+    return base;
+  }).filter(target => target.type === 'mail' ? Boolean((target as BetaNotificationTarget).mailFrom) : target.url) : current.notificationTargets;
 
   const announceMappings: BetaAnnounceMapping[] = Array.isArray(body.announceMappings) ? body.announceMappings.map(rawMapping => {
     const mapping = rawMapping as Partial<BetaAnnounceMapping>;
@@ -2058,18 +2130,33 @@ function saveBetaSettingsPayload(raw: unknown): BetaSettings {
     };
   }).filter(mapping => mapping.announceHost && mapping.announceHost !== 'unknown' && mapping.trackerId) : current.announceMappings;
 
-  const alertRules = Array.isArray(body.alertRules) ? body.alertRules.map(rawRule => {
-    const rule = rawRule as Partial<BetaAlertRule>;
-    return {
-      id: typeof rule.id === 'string' && rule.id ? rule.id : crypto.randomUUID(),
-      trackerId: String(rule.trackerId || '').trim(),
-      enabled: rule.enabled !== false,
-      kind: ['ratio', 'buffer', 'fail', 'mp', 'cookie', 'stats'].includes(String(rule.kind)) ? rule.kind as BetaAlertRule['kind'] : 'ratio',
-      operator: ['<=', '<', '>=', '>'].includes(String(rule.operator)) ? rule.operator as BetaAlertRule['operator'] : '<',
-      threshold: Number.isFinite(Number(rule.threshold)) ? Number(rule.threshold) : 1,
-      targetIds: Array.isArray(rule.targetIds) ? rule.targetIds.filter((id): id is string => typeof id === 'string') : [],
+  const rawTrackerAlerts = (body.trackerAlerts && typeof body.trackerAlerts === 'object') ? body.trackerAlerts as Record<string, Partial<BetaTrackerAlert>> : current.trackerAlerts;
+  const trackerAlerts: Record<string, BetaTrackerAlert> = {};
+  for (const [trackerId, raw] of Object.entries(rawTrackerAlerts || {})) {
+    if (!trackerId || !raw || typeof raw !== 'object') continue;
+    const a = raw as Partial<BetaTrackerAlert>;
+    const entry: BetaTrackerAlert = {
+      notifyError: a.notifyError === true,
+      notifyManualError: a.notifyManualError === true,
+      notifySuccess: a.notifySuccess === true,
+      notifyManualSuccess: a.notifyManualSuccess === true,
+      notifyStats: a.notifyStats === true,
+      notifyManualStats: a.notifyManualStats === true,
+      notifyMp: a.notifyMp === true,
+      notifyManualMp: a.notifyManualMp === true,
+      ratioEnabled: a.ratioEnabled === true,
+      ratioThreshold: Number.isFinite(Number(a.ratioThreshold)) ? Number(a.ratioThreshold) : 1,
+      bufferEnabled: a.bufferEnabled === true,
+      bufferThresholdGo: Number.isFinite(Number(a.bufferThresholdGo)) ? Number(a.bufferThresholdGo) : 100,
+      sessionEnabled: a.sessionEnabled === true,
+      sessionDays: Number.isFinite(Number(a.sessionDays)) ? Number(a.sessionDays) : 30,
     };
-  }).filter(rule => rule.trackerId) : current.alertRules;
+    // Ne conserver que les trackers ayant au moins une option active.
+    const hasAny = entry.notifyError || entry.notifyManualError || entry.notifySuccess || entry.notifyManualSuccess
+      || entry.notifyStats || entry.notifyManualStats || entry.notifyMp || entry.notifyManualMp
+      || entry.ratioEnabled || entry.bufferEnabled || entry.sessionEnabled;
+    if (hasAny) trackerAlerts[trackerId] = entry;
+  }
 
   const defaults = {
     ...current.defaults,
@@ -2160,7 +2247,7 @@ function saveBetaSettingsPayload(raw: unknown): BetaSettings {
     sessionDays: Number.isFinite(Number(rawGlobal.sessionDays)) ? Number(rawGlobal.sessionDays) : 30,
   };
 
-  const next = { qbitClients, announceMappings, notificationTargets, schedule, scheduleOverrides, notificationPreferences, alertRules, globalAlerts, defaults };
+  const next = { qbitClients, announceMappings, notificationTargets, schedule, scheduleOverrides, notificationPreferences, trackerAlerts, globalAlerts, defaults };
   setJsonSetting(BETA_SETTINGS_KEY, next);
   return next;
 }
@@ -2662,13 +2749,32 @@ async function sendBetaNotification(
   target: BetaNotificationTarget,
   message: string,
   title = 'Tracker Dashboard Beta',
+  allTargets: BetaNotificationTarget[] = [],
 ): Promise<void> {
   if (target.type === 'discord') {
     const content = `**${title}**\n${message}`.slice(0, 2000);
     await axios.post(target.url, { content }, { timeout: 8000 });
     return;
   }
-  if (!target.urls?.length) throw new Error('Aucune URL de destination Apprise configuree');
+  if (target.type === 'mail') {
+    // Construire l'URL mailtos:// et l'envoyer via le premier canal Apprise actif.
+    const appriseTarget = allTargets.find(t => t.type === 'apprise' && t.enabled && t.url);
+    if (!appriseTarget) throw new Error('Type mail : aucun canal Apprise configuré pour le transport');
+    const from = target.mailFrom ?? '';
+    const pass = encodeURIComponent(target.mailPass ?? '');
+    const domain = from.includes('@') ? from.split('@')[1] : from;
+    const user = from.includes('@') ? encodeURIComponent(from) : encodeURIComponent(from);
+    let mailUrl = `mailtos://${user}:${pass}@${domain}`;
+    const params: string[] = [];
+    if (target.mailSmtp) params.push(`smtp=${encodeURIComponent(target.mailSmtp)}`);
+    if (target.mailPort) params.push(`port=${target.mailPort}`);
+    if (target.mailTo && target.mailTo !== from) params.push(`to=${encodeURIComponent(target.mailTo)}`);
+    if (params.length) mailUrl += `?${params.join('&')}`;
+    const endpoint = `${appriseTarget.url.replace(/\/$/, '')}/notify/`;
+    await axios.post(endpoint, { title, body: message, urls: mailUrl }, { timeout: 10_000 });
+    return;
+  }
+  if (!target.urls?.length) throw new Error('Aucune URL de destination Apprise configurée');
   const endpoint = `${target.url.replace(/\/$/, '')}/notify/`;
   await axios.post(endpoint, {
     title,
@@ -2947,7 +3053,7 @@ export async function start(): Promise<void> {
     const target = settings.notificationTargets.find(item => item.id === id);
     if (!target) return res.status(404).json({ ok: false, error: 'Destination introuvable' });
     try {
-      await sendBetaNotification(target, 'Test Tracker Dashboard Beta : notification recue.');
+      await sendBetaNotification(target, 'Test Tracker Dashboard Beta : notification recue.', 'Tracker Dashboard Beta', settings.notificationTargets);
       res.json({ ok: true });
     } catch (err: unknown) {
       res.json({ ok: false, error: err instanceof Error ? err.message : String(err) });


### PR DESCRIPTION
## Refonte des notifications par tracker + type Mail

### Notifications par tracker
Remplacement complet de l'ancien système (liste de règles ajoutées une à une) par une interface calquée sur les notifications globales :
- Sélecteur de tracker en haut (seuls les trackers configurés apparaissent)
- Toggle Auto/Manuel
- Parité complète avec les globales : Échecs, Succès, Statistiques, MP non lus + seuils Ratio / Buffer / Session
- Pastille ● sur les trackers ayant des réglages spécifiques

### Modèle : deux systèmes additifs et indépendants
Les notifications globales (tous les trackers) et par tracker (trackers spécifiques) sont **distinctes** et ne s'overrident pas. Un tracker couvert par les deux apparaît dans les deux notifications, chacune avec son propre titre « TD : … ». La notification par tracker regroupe tous les trackers spécifiques.

### Type Mail
Nouveau type de canal « Mail » dans les destinations, à côté de Discord et Apprise. Le transport se fait via le serveur Apprise déjà configuré (construction d'une URL `mailtos://`). Champs conviviaux : email, mot de passe, destinataire, serveur SMTP et port optionnels. Providers connus (Gmail, etc.) auto-détectés.

### Corrections UI
- Canaux : séparation visuelle claire par type (en-tête + bordure par bloc)
- Inputs numériques (seuils, port) sans flèches, largeur ajustée
- Lien depuis la fiche d'un tracker vers sa page de notifications par tracker

### Notes
- `server.ts` : nouveau modèle `trackerAlerts` (remplace `alertRules`), logique de notification par tracker dans `notifyScheduledResult`
- Rebasé proprement sur `main` (commits #52→#57)
- TypeScript compile, JS et structure HTML vérifiés