### PR TITLE
fix(trackers): ne plus traiter les trackers non configurés comme des erreurs

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3477,7 +3477,9 @@
   function renderBetaCalendar() {
     const container = document.getElementById('beta-calendar');
     if (!container) return;
-    const rows = betaHistory;
+    // Les trackers non configures (credentials manquants) ne sont pas un suivi :
+    // on ne veut ni les compter en KO ni les afficher dans le calendrier.
+    const rows = betaHistory.filter(row => !isUnconfigured(row));
     const title = document.getElementById('beta-calendar-title');
     const month = new Date(betaCalendarMonth.getFullYear(), betaCalendarMonth.getMonth(), 1);
     if (title) title.textContent = month.toLocaleDateString('fr-FR', { month: 'long', year: 'numeric' });
@@ -3529,7 +3531,7 @@
   function latestBetaRowsForDay(day) {
     const byTracker = new Map();
     betaHistory
-      .filter(row => String(row.capturedAt || '').slice(0, 10) === day)
+      .filter(row => !isUnconfigured(row) && String(row.capturedAt || '').slice(0, 10) === day)
       .forEach(row => {
         const previous = byTracker.get(row.trackerId);
         if (!previous || String(row.capturedAt || '') > String(previous.capturedAt || '')) byTracker.set(row.trackerId, row);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1176,6 +1176,14 @@ function visibleStats(trackers: TrackerConfig[]): TrackerStats[] {
       - (order.get(b.id) ?? Number.MAX_SAFE_INTEGER));
 }
 
+// Un tracker "non configure" = aucun credential en base : ce n'est pas un suivi
+// actif, juste un tracker du catalogue auquel on n'a pas (encore) de compte. On ne
+// le persiste pas en historique, on ne le compte pas en erreur et on ne notifie pas.
+function isUnconfiguredStat(stat: TrackerStats): boolean {
+  return stat.status === 'error' && typeof stat.error === 'string'
+    && stat.error.startsWith('Credentials manquants');
+}
+
 function logStatResult(stat: TrackerStats): void {
   if (stat.stale) {
     console.log(`  [${stat.name}] Stats anciennes conservees - ${stat.stale.error}`);
@@ -1189,7 +1197,7 @@ function logStatResult(stat: TrackerStats): void {
     return;
   }
 
-  if (stat.error?.startsWith('Credentials manquants')) return;
+  if (isUnconfiguredStat(stat)) return;
   console.log(`  [${stat.name}] Stats ERREUR - ${stat.error ?? 'Erreur inconnue'}`);
 }
 
@@ -1395,11 +1403,13 @@ async function refresh(trackers: TrackerConfig[]): Promise<TrackerStats[]> {
       ...results.map(attachIncident),
     ];
     lastRefresh = new Date().toISOString();
-    saveStatSnapshots(results.filter(stat => !stat.stale));
-    const ok  = results.filter(s => s.status === 'ok').length;
-    const err = results.filter(s => s.status === 'error').length;
-    console.log(`  ✅ ${ok} ok  ❌ ${err} erreur(s)`);
-    results.filter(s => s.status === 'error' && !s.error?.startsWith('Credentials manquants'))
+    saveStatSnapshots(results.filter(stat => !stat.stale && !isUnconfiguredStat(stat)));
+    const ok           = results.filter(s => s.status === 'ok').length;
+    const unconfigured = results.filter(isUnconfiguredStat).length;
+    const err          = results.filter(s => s.status === 'error').length - unconfigured;
+    const unconfiguredSuffix = unconfigured ? `  ⚙️  ${unconfigured} non configure(s)` : '';
+    console.log(`  ✅ ${ok} ok  ❌ ${err} erreur(s)${unconfiguredSuffix}`);
+    results.filter(s => s.status === 'error' && !isUnconfiguredStat(s))
       .forEach(s => console.log(`  ⚠️  ${s.name}: ${s.error}`));
     return results;
   } finally {
@@ -1698,9 +1708,7 @@ async function notifyScheduledResult(
   const targets = settings.notificationTargets.filter(target => target.enabled && target.url);
   if (targets.length === 0 || results.length === 0) return;
 
-  const isUnconfigured = (result: TrackerStats) =>
-    result.status === 'error' && result.error?.startsWith('Credentials manquants');
-  const relevant = results.filter(result => !isUnconfigured(result));
+  const relevant = results.filter(result => !isUnconfiguredStat(result));
   if (relevant.length === 0) return;
 
   const p = settings.notificationPreferences;


### PR DESCRIPTION
## Problème

Les trackers présents dans le catalogue mais sans credentials en base
(erreur « Credentials manquants ») étaient comptés et affichés comme des
KO dans le calendrier. Or un tracker non configuré n'est pas un suivi en
panne : soit on n'y a pas de compte, soit il ne nous intéresse pas. Il ne
devrait donc pas apparaître en erreur.

## Changements

**Calendrier (`public/index.html`)**
- `renderBetaCalendar()` et `latestBetaRowsForDay()` excluent désormais les
  trackers non configurés, via le helper existant `isUnconfigured()`.
- Effet immédiat sur les pastilles OK/KO du mois et sur les colonnes du jour,
  y compris pour les jours passés déjà en base.

**Serveur (`src/server.ts`)**
- Nouveau helper module-level `isUnconfiguredStat()` (centralise un test qui
  était dupliqué).
- `refresh()` ne persiste plus les stats non configurées dans `stat_snapshots`
  → la table arrête de se remplir de lignes inutiles à chaque cycle.
- Le log de résumé du refresh ne compte plus les non configurés dans le total
  d'erreurs ; ils sont indiqués séparément :
  `✅ X ok  ❌ Y erreur(s)  ⚙️ Z non configure(s)`.
- `logStatResult()` et le filtre des notifications routés sur le nouveau helper.

## Ce qui ne change pas (volontairement)

- Un tracker **configuré mais injoignable** (échec login, timeout, Cloudflare…)
  produit un message d'erreur différent, donc reste bien en KO dans le calendrier.
  La distinction « non configuré » ≠ « configuré mais en panne » est préservée.
- Les snapshots déjà présents en base ne sont pas purgés : ils sont masqués par
  le filtre du calendrier et vieilliront naturellement.

## Test

Sur l'instance dev (3003) après `down && up -d --build` :
- Calendrier : les trackers sans creds n'apparaissent plus ni dans les compteurs
  du mois ni dans le détail du jour.