### PR TITLE
feat(bittorrent): choisir le tracker à lier pour une source détectée

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -591,6 +591,8 @@
       width: 132px;
     }
     .beta-mini-table th { color: var(--muted); font-size: 11px; font-weight: 600; }
+    .beta-link-picker { display: inline-flex; gap: 6px; align-items: center; }
+    .beta-link-picker select { max-width: 200px; }
     .beta-chart {
       width: 100%;
       min-height: 240px;
@@ -3647,6 +3649,9 @@
     const mappings = betaSettings.announceMappings || [];
     const detectedHosts = Array.from(new Set((betaOverview?.qbitStats || []).map(item => item.trackerHost).filter(Boolean))).sort();
     const trackerOptions = trackerConfig.map(t => `<option value="${escapeHtml(t.id)}">${escapeHtml(t.name)}</option>`).join('');
+    const optionsWith = (selectedId) => trackerConfig
+      .map(t => `<option value="${escapeHtml(t.id)}"${t.id === selectedId ? ' selected' : ''}>${escapeHtml(t.name)}</option>`)
+      .join('');
     const detectedRows = detectedHosts.map(host => {
       const mapped = mappings.find(mapping => trackerHostFromUrl(mapping.announceHost) === trackerHostFromUrl(host));
       const match = betaTrackerMatchForHost(host);
@@ -3657,7 +3662,10 @@
           <td>${escapeHtml(host)}</td>
           <td>${torrentCount} torrent(s)</td>
           <td>${mapped ? escapeHtml(trackerConfig.find(t => t.id === mapped.trackerId)?.name || mapped.trackerId) : (match ? `${escapeHtml(match.tracker.name)} <span class="cell-muted">(${match.score})</span>` : '<span class="cell-muted">Non lié</span>')}</td>
-          <td>${mapped ? '' : `<button class="beta-icon-btn" onclick="addBetaAnnounceMapping('${escapeHtml(host)}', '${escapeHtml(match?.tracker.id || '')}')" type="button">${match ? 'Lier la suggestion' : 'Lier'}</button>`}</td>
+          <td>${mapped ? '' : (match
+            ? `<div class="beta-link-picker"><select data-link-host data-suggested="${escapeHtml(match.tracker.id)}" aria-label="Tracker à lier" onchange="updateLinkButtonLabel(this)">${optionsWith(match.tracker.id)}</select><button class="beta-icon-btn" onclick="linkDetectedHostFromSelect(this, '${escapeHtml(host)}')" type="button">Lier la suggestion</button></div>`
+            : `<div class="beta-link-picker"><select data-link-host aria-label="Tracker à lier" onchange="updateLinkButtonLabel(this)"><option value="" selected disabled>— choisir un tracker —</option>${optionsWith('')}</select><button class="beta-icon-btn" onclick="linkDetectedHostFromSelect(this, '${escapeHtml(host)}')" type="button">Lier</button></div>`
+          )}</td>
         </tr>`;
     }).join('');
     const editRows = mappings.map((mapping, idx) => `
@@ -4088,6 +4096,25 @@
     } catch (e) {
       alert('Erreur de sauvegarde : ' + e.message);
     }
+  }
+
+  // Bascule le libellé du bouton de liaison : "Lier la suggestion" tant que le
+  // menu reste sur le tracker deviné, "Lier" dès qu'on choisit autre chose.
+  function updateLinkButtonLabel(select) {
+    const button = select.parentElement.querySelector('button');
+    if (!button) return;
+    const suggested = select.getAttribute('data-suggested') || '';
+    button.textContent = (suggested && select.value === suggested) ? 'Lier la suggestion' : 'Lier';
+  }
+
+  // Lier un hôte détecté au tracker choisi dans la liste déroulante de sa ligne
+  // (suggestion présélectionnée ou choix manuel). On lit la valeur du <select>
+  // voisin du bouton plutôt que de laisser addBetaAnnounceMapping choisir.
+  function linkDetectedHostFromSelect(button, host) {
+    const select = button.parentElement.querySelector('select[data-link-host]');
+    const trackerId = select ? select.value : '';
+    if (!trackerId) { alert('Choisir un tracker à lier dans la liste.'); return; }
+    addBetaAnnounceMapping(host, trackerId);
   }
 
   function removeBetaAnnounceMapping(index) {


### PR DESCRIPTION
## Problème

Dans Configuration › Clients BitTorrent, l'association d'une source détectée
à un tracker actif ne laissait pas le choix de la cible :

- Source non reconnue (URL différente) : le bouton « Lier » choisissait un
  tracker par défaut à notre place. Il fallait lier, puis corriger.
- Source reconnue : « Lier la suggestion » liait au site deviné, sans
  possibilité de corriger si la suggestion était fausse.

## Changements

Les deux cas passent par une liste déroulante des trackers configurés, dans
la cellule d'action :

- **Source reconnue** : le menu est présélectionné sur le tracker deviné,
  mais modifiable. Le bouton affiche « Lier la suggestion » tant que le menu
  reste sur la suggestion, et bascule sur « Lier » dès qu'on choisit autre
  chose (et inversement).
- **Source non reconnue** : menu avec un placeholder « — choisir un tracker — »
  et bouton « Lier ». Cliquer sans avoir choisi affiche un rappel au lieu de
  lier au hasard.

Le clic lit la valeur courante du menu, donc on lie directement au bon tracker
sans l'étape lier-puis-corriger.

## Détails techniques

100 % front (`public/index.html`) :
- `optionsWith(selectedId)` : génère les options avec une présélection.
- Cellule d'action unifiée dans `renderBetaAnnounceMappings()` (un seul chemin
  pour les deux cas).
- `linkDetectedHostFromSelect(button, host)` : lit le `<select>` voisin et
  appelle `addBetaAnnounceMapping(host, trackerId)` avec l'id choisi.
- `updateLinkButtonLabel(select)` : bascule le libellé du bouton.

`addBetaAnnounceMapping` n'a pas changé : il acceptait déjà un trackerId
explicite.

## Test

Sur le dev (3003), dans Clients BitTorrent :
- Source reconnue : menu présélectionné, libellé qui bascule
  « Lier la suggestion » ↔ « Lier » selon la sélection, liaison vers le tracker
  choisi.
- Source non reconnue : placeholder + « Lier », rappel si rien n'est choisi.