### PR TITLE
Ajout de trackers persos (assistant guidé + mode expert) et unités d'octets fidèles au site

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1692,6 +1692,60 @@
       background: var(--blue);
       color: #fff;
     }
+    /* ── Formulaire « nouveau tracker » ──────────────────────────────────── */
+    .newtracker-h {
+      margin: 20px 0 10px; font-size: 13px; font-weight: 700;
+      padding-bottom: 6px; border-bottom: 1px solid var(--border);
+    }
+    .nt-subh { margin: 14px 0 6px; font-size: 12px; font-weight: 700; color: var(--muted); }
+    .newtracker-grid {
+      display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 10px 14px; align-items: end;
+    }
+    .nt-hint { color: var(--muted); font-weight: 400; font-size: 10px; }
+    .nt-toggle { align-self: center; }
+    .nt-add { padding: 5px 10px; margin-top: 8px; }
+    .nt-kv-list, .nt-field-list { display: flex; flex-direction: column; gap: 8px; }
+    .nt-kv-row, .nt-field-row {
+      display: flex; gap: 8px; align-items: center; flex-wrap: wrap;
+    }
+    .nt-kv-row input { flex: 1 1 140px; }
+    .nt-field-row .nt-fname { flex: 1 1 150px; }
+    .nt-field-row .nt-fextract { flex: 2 1 240px; font-family: monospace; font-size: 11px; }
+    .nt-field-row .nt-ftransform { flex: 0 1 130px; }
+    .nt-row-del {
+      background: transparent; border: 1px solid var(--border); color: var(--muted);
+      border-radius: 6px; cursor: pointer; padding: 6px 9px; line-height: 1; font-size: 13px;
+    }
+    .nt-row-del:hover { color: var(--red); border-color: var(--red); }
+
+    /* ── Assistant guidé ─────────────────────────────────────────────────── */
+    .guided-steps { display: flex; gap: 8px; flex-wrap: wrap; margin: 6px 0 18px; }
+    .guided-step {
+      font-size: 11px; font-weight: 600; padding: 5px 10px; border-radius: 999px;
+      background: var(--surface-2, rgba(127,127,127,.08)); color: var(--muted);
+      border: 1px solid var(--border);
+    }
+    .guided-step.active { background: var(--green, #2ecc71); color: #fff; border-color: transparent; }
+    .guided-step.done { color: var(--green); border-color: var(--green); }
+    .guided-engine-list { display: flex; flex-direction: column; gap: 8px; }
+    .guided-engine-card {
+      display: block; width: 100%; text-align: left; cursor: pointer;
+      border: 1px solid var(--border); border-radius: 10px; padding: 12px 14px;
+      background: var(--surface-2, rgba(127,127,127,.05)); transition: border-color .12s, background .12s;
+    }
+    .guided-engine-card:hover { border-color: var(--green); }
+    .guided-engine-card.selected { border-color: var(--green); background: rgba(46,204,113,.10); }
+    .guided-engine-card .ge-title { font-weight: 700; font-size: 14px; }
+    .guided-engine-card .ge-suggested { font-size: 10px; font-weight: 700; color: var(--green); margin-left: 8px; }
+    .guided-engine-card .ge-desc { font-size: 12px; color: var(--muted); margin-top: 3px; }
+    .guided-engine-card .ge-examples { font-size: 11px; color: var(--muted); margin-top: 4px; font-style: italic; }
+    .guided-engine-card .ge-hint { font-size: 11px; margin-top: 6px; padding-top: 6px; border-top: 1px dashed var(--border); }
+    .guided-summary {
+      font-size: 13px; border: 1px solid var(--border); border-radius: 10px; padding: 12px 14px;
+      background: var(--surface-2, rgba(127,127,127,.05));
+    }
+    .guided-summary b { font-weight: 700; }
   </style>
   <link rel="stylesheet" href="/responsive.css">
 </head>
@@ -1731,6 +1785,8 @@
       <span class="nav-caret">▸</span>
     </button>
     <div class="nav-sub" id="nav-sub-config">
+      <button class="nav-item" data-nav="tracker-guided" onclick="openGuidedTrackerForm()" type="button"><span class="nav-icon">✦</span> Ajouter un tracker (guidé)</button>
+      <button class="nav-item" data-nav="tracker-new" onclick="openNewTrackerForm()" type="button"><span class="nav-icon">＋</span> Ajouter un tracker (expert)</button>
       <div class="nav-group" data-nav-group="add">
         <button class="nav-item nav-group-toggle" onclick="toggleNavGroup(event, 'add')" type="button">
           <span class="nav-icon">＋</span> Ajouter un tracker
@@ -1920,6 +1976,293 @@
     </div>
   </section>
 
+  <section class="tab-view" data-view="tracker-new">
+    <div class="beta-stack" style="width:100%; max-width:920px">
+      <section class="beta-panel">
+        <h3 id="newtracker-title">Configurer un nouveau tracker</h3>
+        <p class="beta-note" style="margin-top:4px">
+          Ajoute un tracker absent de la liste intégrée. Renseigne sa page de login, sa page de stats et les champs à extraire.
+          Les définitions techniques d'un tracker perso sont conservées telles quelles (jamais écrasées par une mise à jour d'image).
+          Astuce : inspire-toi d'un tracker existant du même type (UNIT3D, Gazelle…).
+        </p>
+
+        <!-- Général -->
+        <h4 class="newtracker-h">1 · Général</h4>
+        <div class="newtracker-grid">
+          <div class="beta-field">
+            <label for="nt-id">Identifiant <span class="nt-hint">unique, minuscules (ex: montracker)</span></label>
+            <input class="tracker-input" id="nt-id" autocomplete="off" placeholder="montracker">
+          </div>
+          <div class="beta-field">
+            <label for="nt-name">Nom affiché</label>
+            <input class="tracker-input" id="nt-name" autocomplete="off" placeholder="Mon Tracker">
+          </div>
+          <div class="beta-field">
+            <label for="nt-baseurl">URL de base</label>
+            <input class="tracker-input" id="nt-baseurl" autocomplete="off" placeholder="https://montracker.org">
+          </div>
+          <div class="beta-field">
+            <label for="nt-curlbinary">Profil curl-impersonate <span class="nt-hint">(anti-Cloudflare, optionnel)</span></label>
+            <select class="tracker-input" id="nt-curlbinary">
+              <option value="">Aucun</option>
+              <option value="curl_firefox135">curl_firefox135</option>
+              <option value="curl_firefox133">curl_firefox133</option>
+            </select>
+          </div>
+          <div class="beta-field">
+            <label for="nt-byteunit">Unité d'octets</label>
+            <select class="tracker-input" id="nt-byteunit">
+              <option value="binary">Binaire (Kio/Mio/Gio)</option>
+              <option value="decimal">Décimale (KB/MB/GB)</option>
+            </select>
+          </div>
+          <label class="toggle-switch nt-toggle" title="Tracker sans système de ratio">
+            <input type="checkbox" id="nt-ratioless">
+            <div class="toggle-track"><div class="toggle-knob"></div></div>
+            <span>Sans ratio (ratioless)</span>
+          </label>
+        </div>
+
+        <!-- Login -->
+        <h4 class="newtracker-h">2 · Connexion (login)</h4>
+        <div class="newtracker-grid">
+          <div class="beta-field">
+            <label for="nt-login-url">Page / endpoint de login <span class="nt-hint">relatif à l'URL de base (ex: login.php)</span></label>
+            <input class="tracker-input" id="nt-login-url" autocomplete="off" placeholder="login.php">
+          </div>
+          <div class="beta-field">
+            <label for="nt-login-method">Méthode</label>
+            <select class="tracker-input" id="nt-login-method">
+              <option value="POST">POST</option>
+              <option value="GET">GET</option>
+            </select>
+          </div>
+          <div class="beta-field">
+            <label for="nt-login-contenttype">Type de corps</label>
+            <select class="tracker-input" id="nt-login-contenttype">
+              <option value="form">Formulaire (x-www-form-urlencoded)</option>
+              <option value="json">JSON</option>
+            </select>
+          </div>
+          <label class="toggle-switch nt-toggle" title="Login automatique désactivé : seul un cookie de session est utilisé">
+            <input type="checkbox" id="nt-login-cookieonly">
+            <div class="toggle-track"><div class="toggle-knob"></div></div>
+            <span>Cookie uniquement (pas de login auto)</span>
+          </label>
+        </div>
+
+        <div class="beta-field" style="margin-top:6px">
+          <label>Corps du login <span class="nt-hint">placeholders : {{username}} {{password}} {{otp}} {{_csrf}}</span></label>
+          <div id="nt-login-body" class="nt-kv-list"></div>
+          <button class="btn-test nt-add" type="button" onclick="ntAddBodyRow()">+ Ajouter un champ</button>
+        </div>
+
+        <div class="beta-field">
+          <label>Motifs d'échec (failurePatterns) <span class="nt-hint">une chaîne HTML par ligne — présence = login échoué</span></label>
+          <textarea class="tracker-input" id="nt-login-failures" rows="3" spellcheck="false" style="font-family:monospace; font-size:11px; white-space:pre" placeholder='type="password"&#10;name="password"&#10;Identifiants incorrects'></textarea>
+        </div>
+
+        <details class="definition-advanced">
+          <summary>Options de login avancées (CSRF, 2FA, API JSON…)</summary>
+          <div class="definition-advanced-body">
+            <div class="newtracker-grid">
+              <div class="beta-field">
+                <label for="nt-login-posturl">postUrl <span class="nt-hint">cible du POST si ≠ page de login</span></label>
+                <input class="tracker-input" id="nt-login-posturl" autocomplete="off" placeholder="(optionnel)">
+              </div>
+              <div class="beta-field">
+                <label for="nt-login-otpfield">Champ code 2FA (otpField)</label>
+                <input class="tracker-input" id="nt-login-otpfield" autocomplete="off" placeholder="ex: two_step_code">
+              </div>
+              <div class="beta-field">
+                <label for="nt-login-successfield">successField <span class="nt-hint">(login API JSON)</span></label>
+                <input class="tracker-input" id="nt-login-successfield" autocomplete="off" placeholder="(optionnel)">
+              </div>
+              <div class="beta-field">
+                <label for="nt-login-csrfheader">csrfHeader</label>
+                <input class="tracker-input" id="nt-login-csrfheader" autocomplete="off" placeholder="ex: csrf-token">
+              </div>
+              <div class="beta-field">
+                <label for="nt-login-tokenfield">tokenField <span class="nt-hint">jeton Bearer pour le fetch</span></label>
+                <input class="tracker-input" id="nt-login-tokenfield" autocomplete="off" placeholder="(optionnel)">
+              </div>
+            </div>
+            <div class="beta-field">
+              <label>preVisitUrls <span class="nt-hint">GET préalables pour initialiser des cookies — une URL par ligne</span></label>
+              <textarea class="tracker-input" id="nt-login-previsit" rows="2" spellcheck="false" style="font-family:monospace; font-size:11px" placeholder="login.php"></textarea>
+            </div>
+            <h5 class="nt-subh">preStep — récupération CSRF</h5>
+            <div class="newtracker-grid">
+              <div class="beta-field">
+                <label for="nt-prestep-url">URL de la preStep</label>
+                <input class="tracker-input" id="nt-prestep-url" autocomplete="off" placeholder="login.php">
+              </div>
+              <label class="toggle-switch nt-toggle" title="Inclure tous les champs cachés du formulaire">
+                <input type="checkbox" id="nt-prestep-hidden">
+                <div class="toggle-track"><div class="toggle-knob"></div></div>
+                <span>includeHiddenInputs</span>
+              </label>
+            </div>
+            <div class="beta-field">
+              <label for="nt-prestep-csrf">Regex extraction _csrf <span class="nt-hint">groupe (?&lt;value&gt;…)</span></label>
+              <input class="tracker-input" id="nt-prestep-csrf" autocomplete="off" spellcheck="false" style="font-family:monospace; font-size:11px" placeholder='name=&quot;_token&quot;\s+value=&quot;(?<value>[^&quot;]+)&quot;'>
+            </div>
+            <h5 class="nt-subh">otpStep — page 2FA dédiée (ex: Nexum)</h5>
+            <div class="newtracker-grid">
+              <div class="beta-field">
+                <label for="nt-otpstep-url">urlContains</label>
+                <input class="tracker-input" id="nt-otpstep-url" autocomplete="off" placeholder="/login/2fa">
+              </div>
+              <div class="beta-field">
+                <label for="nt-otpstep-field">Champ du code</label>
+                <input class="tracker-input" id="nt-otpstep-field" autocomplete="off" placeholder="code">
+              </div>
+            </div>
+          </div>
+        </details>
+
+        <!-- Fetch -->
+        <h4 class="newtracker-h">3 · Lecture des stats (fetch)</h4>
+        <div class="newtracker-grid">
+          <div class="beta-field">
+            <label for="nt-fetch-url">Page / endpoint de stats <span class="nt-hint">relatif à l'URL de base</span></label>
+            <input class="tracker-input" id="nt-fetch-url" autocomplete="off" placeholder="index.php">
+          </div>
+          <div class="beta-field">
+            <label for="nt-fetch-mode">Mode</label>
+            <select class="tracker-input" id="nt-fetch-mode" onchange="ntSyncResponseHint()">
+              <option value="browser">Navigateur (rendu JS)</option>
+              <option value="http">HTTP (rapide)</option>
+            </select>
+          </div>
+          <div class="beta-field">
+            <label for="nt-fetch-responsetype">Type de réponse</label>
+            <select class="tracker-input" id="nt-fetch-responsetype" onchange="ntSyncResponseHint(); ntRenderFields()">
+              <option value="html">HTML (regex)</option>
+              <option value="json">JSON (chemin)</option>
+            </select>
+          </div>
+        </div>
+
+        <div class="beta-field" style="margin-top:6px">
+          <label>Champs à extraire <span class="nt-hint" id="nt-fields-hint">HTML : regex avec (?&lt;value&gt;…) · transform = bytes / number / integer / string</span></label>
+          <div id="nt-fetch-fields" class="nt-field-list"></div>
+          <div style="display:flex; gap:8px; flex-wrap:wrap; margin-top:8px">
+            <button class="btn-test nt-add" type="button" onclick="ntAddFieldRow()">+ Ajouter un champ</button>
+            <button class="btn-test nt-add" type="button" onclick="ntAddCommonFields()" title="Pré-remplit uploadedBytes, downloadedBytes, ratio, seeding…">+ Champs courants</button>
+          </div>
+        </div>
+
+        <!-- Actions -->
+        <div class="proxy-actions" style="margin-top:18px; align-items:center; flex-wrap:wrap">
+          <button class="btn-test" type="button" onclick="ntTestTracker(this)">Tester la connexion</button>
+          <button class="btn-save" type="button" onclick="ntSaveTracker(this)">Enregistrer</button>
+          <button class="btn-test" type="button" id="nt-delete-btn" onclick="ntDeleteTracker(this)" style="display:none; color:var(--red); border-color:var(--red)">Supprimer ce tracker</button>
+          <button class="btn-test" type="button" onclick="openNewTrackerForm()">Réinitialiser le formulaire</button>
+          <span id="nt-result" style="font-size:12px"></span>
+        </div>
+
+        <div id="nt-test-credentials" class="beta-panel" style="margin-top:14px; padding:12px; background:var(--surface-2, rgba(127,127,127,.06))">
+          <p class="beta-note" style="margin:0 0 8px">Identifiants utilisés <b>uniquement pour le test</b> (enregistrés séparément après création via « Configurer les actifs ») :</p>
+          <div class="newtracker-grid">
+            <div class="beta-field"><label for="nt-test-user">Utilisateur</label><input class="tracker-input" id="nt-test-user" autocomplete="off"></div>
+            <div class="beta-field"><label for="nt-test-pass">Mot de passe</label><input class="tracker-input" id="nt-test-pass" type="password" autocomplete="new-password"></div>
+            <div class="beta-field"><label for="nt-test-totp">Secret 2FA (TOTP) <span class="nt-hint">optionnel</span></label><input class="tracker-input" id="nt-test-totp" type="password" autocomplete="off"></div>
+          </div>
+          <div class="beta-field" style="margin-top:8px">
+            <label for="nt-test-cookie">Cookie de session <span class="nt-hint">requis si « cookie uniquement »</span></label>
+            <textarea class="tracker-input" id="nt-test-cookie" rows="2" spellcheck="false" style="font-family:monospace; font-size:11px; white-space:pre" placeholder="nom=valeur; nom2=valeur2  (ou export cookies.txt / Cookie-Editor)"></textarea>
+          </div>
+        </div>
+      </section>
+    </div>
+  </section>
+
+  <section class="tab-view" data-view="tracker-guided">
+    <div class="beta-stack" style="width:100%; max-width:820px">
+      <section class="beta-panel">
+        <h3>Ajouter un tracker — assistant guidé</h3>
+        <div class="guided-steps" id="guided-stepbar">
+          <span class="guided-step active" data-step="1">1 · Adresse</span>
+          <span class="guided-step" data-step="2">2 · Type de tracker</span>
+          <span class="guided-step" data-step="3">3 · Identifiants</span>
+          <span class="guided-step" data-step="4">4 · Vérification</span>
+        </div>
+
+        <!-- Étape 1 : URL -->
+        <div class="guided-pane" data-pane="1">
+          <p class="beta-note">Colle l'adresse de ton tracker. On va essayer de reconnaître automatiquement quel logiciel il utilise pour pré-remplir la configuration.</p>
+          <div class="beta-field">
+            <label for="gd-baseurl">Adresse du site</label>
+            <input class="tracker-input" id="gd-baseurl" autocomplete="off" placeholder="https://montracker.org" onkeydown="if(event.key==='Enter')gdDetect(this)">
+          </div>
+          <div class="proxy-actions" style="margin-top:12px">
+            <button class="btn-save" type="button" onclick="gdDetect(this)">Continuer</button>
+            <span id="gd-detect-result" style="font-size:12px"></span>
+          </div>
+        </div>
+
+        <!-- Étape 2 : moteur -->
+        <div class="guided-pane" data-pane="2" style="display:none">
+          <p class="beta-note" id="gd-engine-intro">Choisis le logiciel qui correspond à ton tracker. En cas de doute, lis les indices et choisis « Autre ».</p>
+          <div id="gd-engine-list" class="guided-engine-list"></div>
+          <div class="proxy-actions" style="margin-top:12px">
+            <button class="btn-test" type="button" onclick="gdGoStep(1)">← Retour</button>
+            <button class="btn-save" type="button" onclick="gdPickEngineContinue()">Continuer</button>
+            <span id="gd-engine-result" style="font-size:12px"></span>
+          </div>
+        </div>
+
+        <!-- Étape 3 : identifiants -->
+        <div class="guided-pane" data-pane="3" style="display:none">
+          <p class="beta-note" id="gd-creds-hint"></p>
+          <div class="newtracker-grid">
+            <div class="beta-field">
+              <label for="gd-name">Nom affiché</label>
+              <input class="tracker-input" id="gd-name" autocomplete="off" placeholder="Mon Tracker">
+            </div>
+            <div class="beta-field">
+              <label for="gd-user" id="gd-user-label">Nom d'utilisateur</label>
+              <input class="tracker-input" id="gd-user" autocomplete="off">
+            </div>
+            <div class="beta-field">
+              <label for="gd-pass">Mot de passe</label>
+              <input class="tracker-input" id="gd-pass" type="password" autocomplete="new-password">
+            </div>
+            <div class="beta-field">
+              <label for="gd-totp">Secret 2FA (TOTP) <span class="nt-hint">si activé, sinon laisse vide</span></label>
+              <input class="tracker-input" id="gd-totp" type="password" autocomplete="off">
+            </div>
+          </div>
+          <details class="definition-advanced" id="gd-cookie-wrap">
+            <summary>J'ai un cookie de session (sites à CAPTCHA / Cloudflare)</summary>
+            <div class="definition-advanced-body">
+              <p class="beta-note">Si le login automatique échoue (Cloudflare, captcha), connecte-toi dans ton navigateur, exporte tes cookies et colle-les ici.</p>
+              <textarea class="tracker-input" id="gd-cookie" rows="3" spellcheck="false" style="font-family:monospace; font-size:11px; white-space:pre" placeholder="nom=valeur; nom2=valeur2  (ou export cookies.txt / Cookie-Editor)"></textarea>
+            </div>
+          </details>
+          <div class="proxy-actions" style="margin-top:12px">
+            <button class="btn-test" type="button" onclick="gdGoStep(2)">← Retour</button>
+            <button class="btn-save" type="button" onclick="gdGoStep(4)">Continuer</button>
+          </div>
+        </div>
+
+        <!-- Étape 4 : test + enregistrement -->
+        <div class="guided-pane" data-pane="4" style="display:none">
+          <p class="beta-note">On teste la connexion réelle avec tes identifiants. Si ça marche, tu pourras enregistrer. Sinon, tu peux revenir en arrière ou affiner en mode expert.</p>
+          <div id="gd-summary" class="guided-summary"></div>
+          <div class="proxy-actions" style="margin-top:12px; flex-wrap:wrap; align-items:center">
+            <button class="btn-test" type="button" onclick="gdGoStep(3)">← Retour</button>
+            <button class="btn-test" type="button" onclick="gdTest(this)">Tester la connexion</button>
+            <button class="btn-save" type="button" onclick="gdSave(this)">Enregistrer le tracker</button>
+            <button class="btn-test" type="button" onclick="gdOpenInExpert()" title="Ouvre la config complète pour ajustement manuel">Affiner en mode expert</button>
+            <span id="gd-final-result" style="font-size:12px"></span>
+          </div>
+        </div>
+      </section>
+    </div>
+  </section>
+
   <section class="tab-view" data-view="fiche">
     <div class="beta-stack" style="width:100%">
       <section class="beta-panel">
@@ -1954,6 +2297,12 @@
 
   <section class="tab-view" data-view="graphs">
         <div class="beta-stack" style="width:100%">
+        <section class="beta-panel" style="padding:10px 14px">
+          <div class="beta-chart-controls" style="margin:0">
+            <div class="beta-field"><label for="beta-chart-unit">Unité des graphiques</label><select id="beta-chart-unit" onchange="drawBetaCharts()"><option value="auto">Auto (décimal en comparaison, unité du site sinon)</option><option value="decimal">Décimale (GB / TB)</option><option value="binary">Binaire (GiB / TiB)</option></select></div>
+            <div class="beta-note">En mode comparaison multi-trackers, une unité commune est nécessaire pour superposer les courbes : par défaut décimale (GB). « Auto » suit l'unité du site sur les graphes d'un seul tracker.</div>
+          </div>
+        </section>
         <section class="beta-panel">
           <h3>Global</h3>
           <div class="beta-chart-controls">
@@ -2521,12 +2870,39 @@
   // État déplié/replié de la section « Fréquences individuelles » (AutoVisit).
   // Conservé en mémoire pour survivre aux re-renders périodiques de la vue.
   let betaOverridesExpanded = false;
-  const betaMetricDefs = {
-    uploadedBytes: { label: 'UP', color: '#22c55e', format: value => bytesText(value).replace(/<[^>]+>/g, ''), axis: value => formatBytes(value, 'binary').join(' ') },
-    downloadedBytes: { label: 'DL', color: '#3b82f6', format: value => bytesText(value).replace(/<[^>]+>/g, ''), axis: value => formatBytes(value, 'binary').join(' ') },
-    ratio: { label: 'Ratio', color: '#eab308', format: value => Number.isFinite(value) ? value.toFixed(2) : '-', axis: value => Number.isFinite(value) ? value.toFixed(2) : '-' },
-    seedTimeDays: { label: 'Seedtime', color: '#eab308', format: value => `${Number(value || 0).toFixed(1)} j`, axis: value => `${Number(value || 0).toFixed(1)} j` },
-  };
+  // Fabrique les définitions de métriques pour une unité d'octets donnée
+  // (decimal/binary). Les graphes superposant plusieurs trackers imposent une
+  // unité commune (sinon l'axe Y serait ambigu) ; les graphes mono-tracker
+  // suivent l'unité du tracker. Le sélecteur de la page graphiques peut forcer.
+  function betaMetricDefsFor(byteUnit) {
+    const u = byteUnit === 'decimal' ? 'decimal' : 'binary';
+    return {
+      uploadedBytes:   { label: 'UP', color: '#22c55e', format: value => bytesText(value, u).replace(/<[^>]+>/g, ''), axis: value => formatBytes(value, u).join(' ') },
+      downloadedBytes: { label: 'DL', color: '#3b82f6', format: value => bytesText(value, u).replace(/<[^>]+>/g, ''), axis: value => formatBytes(value, u).join(' ') },
+      ratio:           { label: 'Ratio', color: '#eab308', format: value => Number.isFinite(value) ? value.toFixed(2) : '-', axis: value => Number.isFinite(value) ? value.toFixed(2) : '-' },
+      seedTimeDays:    { label: 'Seedtime', color: '#eab308', format: value => `${Number(value || 0).toFixed(1)} j`, axis: value => `${Number(value || 0).toFixed(1)} j` },
+    };
+  }
+  // Alias par défaut (unité binaire) — conservé pour compat avec d'anciens appels.
+  const betaMetricDefs = betaMetricDefsFor('binary');
+
+  // Unité forcée par le sélecteur de la page graphiques : 'auto' | 'decimal' | 'binary'.
+  function betaChartUnitOverride() {
+    return document.getElementById('beta-chart-unit')?.value || 'auto';
+  }
+  // Unité d'un graphe mono-tracker : override du sélecteur sinon unité du tracker.
+  function resolveMonoTrackerUnit(trackerId) {
+    const ov = betaChartUnitOverride();
+    if (ov !== 'auto') return ov;
+    const stat = latestSortedStats.find(s => s.id === trackerId);
+    return statByteUnit(stat);
+  }
+  // Unité d'un graphe agrégé/multi-trackers : override sinon décimal (commun, GO).
+  function resolveAggregateUnit() {
+    const ov = betaChartUnitOverride();
+    return ov !== 'auto' ? ov : 'decimal';
+  }
+
 
   function getActiveGrid() {
     return document.getElementById('grid');
@@ -2681,6 +3057,526 @@
     renderSelectedTrackerCard();
     renderTrackerConfigNav();
   }
+
+  // ── Formulaire « Configurer un nouveau tracker » ───────────────────────────
+  // editingTrackerId : non-null si on edite un tracker custom existant.
+  let ntEditingTrackerId = null;
+
+  function ntSetVal(id, value) { const el = document.getElementById(id); if (el) el.value = value ?? ''; }
+  function ntGetVal(id) { const el = document.getElementById(id); return el ? el.value.trim() : ''; }
+  function ntSetChecked(id, v) { const el = document.getElementById(id); if (el) el.checked = Boolean(v); }
+  function ntGetChecked(id) { const el = document.getElementById(id); return el ? el.checked : false; }
+
+  function ntBodyRowHtml(key = '', value = '') {
+    return `<div class="nt-kv-row">
+      <input class="tracker-input nt-bk" autocomplete="off" placeholder="champ (ex: username)" value="${escapeHtml(key)}">
+      <input class="tracker-input nt-bv" autocomplete="off" placeholder="valeur (ex: {{username}})" value="${escapeHtml(value)}">
+      <button type="button" class="nt-row-del" onclick="this.parentElement.remove()" title="Supprimer">✕</button>
+    </div>`;
+  }
+  function ntAddBodyRow(key, value) {
+    const list = document.getElementById('nt-login-body');
+    if (list) list.insertAdjacentHTML('beforeend', ntBodyRowHtml(key, value));
+  }
+
+  function ntFieldRowHtml(name = '', extract = '', transform = '') {
+    const opts = ['', 'bytes', 'number', 'integer', 'string']
+      .map(t => `<option value="${t}" ${t === transform ? 'selected' : ''}>${t || '— transform —'}</option>`).join('');
+    return `<div class="nt-field-row">
+      <input class="tracker-input nt-fname" autocomplete="off" placeholder="nom (ex: uploadedBytes)" value="${escapeHtml(name)}">
+      <input class="tracker-input nt-fextract" autocomplete="off" spellcheck="false" placeholder="regex (?<value>…) ou chemin JSON" value="${escapeHtml(extract)}">
+      <select class="tracker-input nt-ftransform">${opts}</select>
+      <button type="button" class="nt-row-del" onclick="this.parentElement.remove()" title="Supprimer">✕</button>
+    </div>`;
+  }
+  function ntAddFieldRow(name, extract, transform) {
+    const list = document.getElementById('nt-fetch-fields');
+    if (list) list.insertAdjacentHTML('beforeend', ntFieldRowHtml(name, extract, transform));
+  }
+  function ntAddCommonFields() {
+    const isJson = ntGetVal('nt-fetch-responsetype') === 'json';
+    const common = isJson
+      ? [['uploadedBytes', 'uploaded', 'bytes'], ['downloadedBytes', 'downloaded', 'bytes'], ['ratio', 'ratio', 'number'], ['seeding', 'seeding', 'integer'], ['leeching', 'leeching', 'integer']]
+      : [['uploadedBytes', '(?<value>[\\d.,]+\\s*[KMGTP]?i?B)', 'bytes'], ['downloadedBytes', '(?<value>[\\d.,]+\\s*[KMGTP]?i?B)', 'bytes'], ['ratio', '(?<value>[\\d.,]+)', 'number'], ['seeding', '(?<value>\\d+)', 'integer'], ['leeching', '(?<value>\\d+)', 'integer']];
+    common.forEach(([n, e, t]) => ntAddFieldRow(n, e, t));
+  }
+
+  function ntSyncResponseHint() {
+    const isJson = ntGetVal('nt-fetch-responsetype') === 'json';
+    const hint = document.getElementById('nt-fields-hint');
+    if (hint) hint.innerHTML = isJson
+      ? 'JSON : chemin dot-notation (ex: response.stats.uploaded) · transform = bytes / number / integer / string'
+      : 'HTML : regex avec (?&lt;value&gt;…) · transform = bytes / number / integer / string';
+    // Met a jour les placeholders des lignes existantes.
+    document.querySelectorAll('#nt-fetch-fields .nt-fextract').forEach(input => {
+      input.placeholder = isJson ? 'chemin JSON (ex: response.uploaded)' : 'regex (?<value>…)';
+    });
+  }
+  function ntRenderFields() { ntSyncResponseHint(); }
+
+  // Ouvre le formulaire vierge (creation).
+  function openNewTrackerForm() {
+    ntEditingTrackerId = null;
+    setNavGroupOpen('config', true);
+    showView('tracker-new');
+    document.getElementById('newtracker-title').textContent = 'Configurer un nouveau tracker';
+    ['nt-id','nt-name','nt-baseurl','nt-login-url','nt-login-posturl','nt-login-otpfield','nt-login-successfield','nt-login-csrfheader','nt-login-tokenfield','nt-login-previsit','nt-prestep-url','nt-prestep-csrf','nt-otpstep-url','nt-otpstep-field','nt-fetch-url','nt-login-failures','nt-test-user','nt-test-pass','nt-test-totp','nt-test-cookie']
+      .forEach(id => ntSetVal(id, ''));
+    ntSetVal('nt-curlbinary', ''); ntSetVal('nt-byteunit', 'binary');
+    ntSetVal('nt-login-method', 'POST'); ntSetVal('nt-login-contenttype', 'form');
+    ntSetVal('nt-fetch-mode', 'browser'); ntSetVal('nt-fetch-responsetype', 'html');
+    ntSetChecked('nt-ratioless', false); ntSetChecked('nt-login-cookieonly', false); ntSetChecked('nt-prestep-hidden', false);
+    document.getElementById('nt-id').disabled = false;
+    document.getElementById('nt-login-body').innerHTML = '';
+    ntAddBodyRow('username', '{{username}}');
+    ntAddBodyRow('password', '{{password}}');
+    document.getElementById('nt-fetch-fields').innerHTML = '';
+    ntAddCommonFields();
+    document.getElementById('nt-delete-btn').style.display = 'none';
+    const r = document.getElementById('nt-result'); if (r) r.textContent = '';
+    ntSyncResponseHint();
+  }
+
+  // Construit l'objet TrackerConfig depuis le formulaire.
+  function ntBuildConfig() {
+    const body = {};
+    document.querySelectorAll('#nt-login-body .nt-kv-row').forEach(row => {
+      const k = row.querySelector('.nt-bk').value.trim();
+      const v = row.querySelector('.nt-bv').value;
+      if (k) body[k] = v;
+    });
+    const fields = {};
+    document.querySelectorAll('#nt-fetch-fields .nt-field-row').forEach(row => {
+      const name = row.querySelector('.nt-fname').value.trim();
+      if (!name) return;
+      const extract = row.querySelector('.nt-fextract').value.trim();
+      const transform = row.querySelector('.nt-ftransform').value;
+      const isJson = ntGetVal('nt-fetch-responsetype') === 'json';
+      fields[name] = isJson ? { path: extract } : { regex: extract };
+      if (transform) fields[name].transform = transform;
+    });
+    const failurePatterns = ntGetVal('nt-login-failures').split('\n').map(s => s.trim()).filter(Boolean);
+    const preVisit = ntGetVal('nt-login-previsit').split('\n').map(s => s.trim()).filter(Boolean);
+
+    const login = {
+      url: ntGetVal('nt-login-url'),
+      method: ntGetVal('nt-login-method'),
+      contentType: ntGetVal('nt-login-contenttype'),
+      body,
+      failurePatterns,
+    };
+    if (ntGetChecked('nt-login-cookieonly')) login.cookieOnly = true;
+    if (ntGetVal('nt-login-posturl')) login.postUrl = ntGetVal('nt-login-posturl');
+    if (ntGetVal('nt-login-otpfield')) login.otpField = ntGetVal('nt-login-otpfield');
+    if (ntGetVal('nt-login-successfield')) login.successField = ntGetVal('nt-login-successfield');
+    if (ntGetVal('nt-login-csrfheader')) login.csrfHeader = ntGetVal('nt-login-csrfheader');
+    if (ntGetVal('nt-login-tokenfield')) login.tokenField = ntGetVal('nt-login-tokenfield');
+    if (preVisit.length) login.preVisitUrls = preVisit;
+    if (ntGetVal('nt-prestep-url')) {
+      const extract = {};
+      const csrf = ntGetVal('nt-prestep-csrf');
+      if (csrf) extract._csrf = { regex: csrf };
+      login.preStep = { url: ntGetVal('nt-prestep-url'), extract };
+      if (ntGetChecked('nt-prestep-hidden')) login.preStep.includeHiddenInputs = true;
+    }
+    if (ntGetVal('nt-otpstep-url') && ntGetVal('nt-otpstep-field')) {
+      login.otpStep = { urlContains: ntGetVal('nt-otpstep-url'), field: ntGetVal('nt-otpstep-field') };
+    }
+
+    const config = {
+      id: ntGetVal('nt-id').toLowerCase(),
+      name: ntGetVal('nt-name'),
+      baseUrl: ntGetVal('nt-baseurl'),
+      enabled: true,
+      login,
+      fetch: {
+        url: ntGetVal('nt-fetch-url'),
+        mode: ntGetVal('nt-fetch-mode'),
+        responseType: ntGetVal('nt-fetch-responsetype'),
+        fields,
+      },
+    };
+    if (ntGetChecked('nt-ratioless')) config.ratioless = true;
+    if (ntGetVal('nt-curlbinary')) config.curlBinary = ntGetVal('nt-curlbinary');
+    if (ntGetVal('nt-byteunit')) config.dashboard = { byteUnit: ntGetVal('nt-byteunit') };
+    return config;
+  }
+
+  function ntFlash(msg, color) {
+    const r = document.getElementById('nt-result');
+    if (r) { r.textContent = msg; r.style.color = color || 'var(--muted)'; }
+  }
+
+  async function ntTestTracker(btn) {
+    const config = ntBuildConfig();
+    const prev = btn.textContent; btn.disabled = true; btn.textContent = 'Test en cours…';
+    ntFlash('Connexion et lecture en cours (cela peut prendre 10-40 s)…');
+    try {
+      const r = await fetch('/api/trackers/test', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          config,
+          username: ntGetVal('nt-test-user'),
+          password: document.getElementById('nt-test-pass').value,
+          totp: document.getElementById('nt-test-totp').value,
+          cookie: document.getElementById('nt-test-cookie').value,
+        }),
+      });
+      const d = await r.json();
+      if (d.ok) {
+        const pairs = Object.entries(d.stat.fields || {}).map(([k, v]) => `${k} = ${v}`).join(' · ');
+        ntFlash('✓ Test réussi — ' + (pairs || 'aucun champ extrait'), 'var(--green)');
+      } else {
+        ntFlash('✗ ' + (d.error || 'Échec du test'), 'var(--red)');
+      }
+    } catch (e) {
+      ntFlash('✗ Erreur réseau : ' + e.message, 'var(--red)');
+    } finally {
+      btn.disabled = false; btn.textContent = prev;
+    }
+  }
+
+  async function ntSaveTracker(btn) {
+    const config = ntBuildConfig();
+    const prev = btn.textContent; btn.disabled = true; btn.textContent = 'Enregistrement…';
+    try {
+      const r = await fetch('/api/trackers', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(config),
+      });
+      const d = await r.json();
+      if (!d.ok) throw new Error(d.error || 'Erreur');
+      ntFlash('✓ Tracker enregistré. Renseigne ses identifiants dans « Configurer les actifs ».', 'var(--green)');
+      ntEditingTrackerId = config.id;
+      document.getElementById('nt-id').disabled = true;
+      document.getElementById('newtracker-title').textContent = 'Éditer : ' + config.name;
+      document.getElementById('nt-delete-btn').style.display = '';
+      await loadTrackerDefinitionsPanel();
+      await loadConfig();
+      await loadStats();
+    } catch (e) {
+      ntFlash('✗ ' + e.message, 'var(--red)');
+    } finally {
+      btn.disabled = false; btn.textContent = prev;
+    }
+  }
+
+  async function ntDeleteTracker(btn) {
+    const id = ntEditingTrackerId || ntGetVal('nt-id').toLowerCase();
+    if (!id) return;
+    if (!confirm(`Supprimer définitivement le tracker « ${id} » et toutes ses données (identifiants, historique) ?`)) return;
+    const prev = btn.textContent; btn.disabled = true; btn.textContent = 'Suppression…';
+    try {
+      const r = await fetch(`/api/trackers/${encodeURIComponent(id)}`, { method: 'DELETE' });
+      const d = await r.json();
+      if (!d.ok) throw new Error(d.error || 'Erreur');
+      await loadTrackerDefinitionsPanel();
+      await loadConfig();
+      await loadStats();
+      openNewTrackerForm();
+      ntFlash('✓ Tracker supprimé.', 'var(--green)');
+    } catch (e) {
+      ntFlash('✗ ' + e.message, 'var(--red)');
+      btn.disabled = false; btn.textContent = prev;
+    }
+  }
+
+  // Édite un tracker custom existant en pré-remplissant le formulaire.
+  function ntEditCustomTracker(trackerId) {
+    const def = cachedTrackerDefinitions.find(d => d.id === trackerId);
+    fetch(`/api/trackers`).then(r => r.json()).then(data => {
+      const cfg = (data.trackers || []).find(t => t.id === trackerId);
+      if (!cfg) { openNewTrackerForm(); return; }
+      openNewTrackerForm();
+      ntEditingTrackerId = trackerId;
+      document.getElementById('newtracker-title').textContent = 'Éditer : ' + cfg.name;
+      ntSetVal('nt-id', cfg.id); document.getElementById('nt-id').disabled = true;
+      ntSetVal('nt-name', cfg.name); ntSetVal('nt-baseurl', cfg.baseUrl);
+      ntSetVal('nt-curlbinary', cfg.curlBinary || ''); ntSetVal('nt-byteunit', cfg.dashboard?.byteUnit || 'binary');
+      ntSetChecked('nt-ratioless', cfg.ratioless);
+      const lg = cfg.login || {};
+      ntSetVal('nt-login-url', lg.url || ''); ntSetVal('nt-login-method', lg.method || 'POST');
+      ntSetVal('nt-login-contenttype', lg.contentType || 'form'); ntSetChecked('nt-login-cookieonly', lg.cookieOnly);
+      ntSetVal('nt-login-posturl', lg.postUrl || ''); ntSetVal('nt-login-otpfield', lg.otpField || '');
+      ntSetVal('nt-login-successfield', lg.successField || ''); ntSetVal('nt-login-csrfheader', lg.csrfHeader || '');
+      ntSetVal('nt-login-tokenfield', lg.tokenField || '');
+      ntSetVal('nt-login-previsit', (lg.preVisitUrls || []).join('\n'));
+      ntSetVal('nt-login-failures', (lg.failurePatterns || []).join('\n'));
+      if (lg.preStep) { ntSetVal('nt-prestep-url', lg.preStep.url || ''); ntSetVal('nt-prestep-csrf', lg.preStep.extract?._csrf?.regex || ''); ntSetChecked('nt-prestep-hidden', lg.preStep.includeHiddenInputs); }
+      if (lg.otpStep) { ntSetVal('nt-otpstep-url', lg.otpStep.urlContains || ''); ntSetVal('nt-otpstep-field', lg.otpStep.field || ''); }
+      document.getElementById('nt-login-body').innerHTML = '';
+      Object.entries(lg.body || {}).forEach(([k, v]) => ntAddBodyRow(k, v));
+      ntSetVal('nt-fetch-url', cfg.fetch?.url || ''); ntSetVal('nt-fetch-mode', cfg.fetch?.mode || 'browser');
+      ntSetVal('nt-fetch-responsetype', cfg.fetch?.responseType || 'html');
+      document.getElementById('nt-fetch-fields').innerHTML = '';
+      Object.entries(cfg.fetch?.fields || {}).forEach(([n, f]) => ntAddFieldRow(n, f.path || f.regex || '', f.transform || ''));
+      document.getElementById('nt-delete-btn').style.display = '';
+      ntSyncResponseHint();
+    });
+  }
+
+  // ── Assistant guidé ────────────────────────────────────────────────────────
+  let gdEngines = [];            // liste des moteurs (métadonnées)
+  let gdSelectedEngine = null;   // id du moteur choisi
+  let gdSuggestedEngine = null;  // id détecté auto (mis en avant)
+  let gdPreset = null;           // preset {login,fetch,dashboard,...} du moteur choisi
+
+  function openGuidedTrackerForm() {
+    setNavGroupOpen('config', true);
+    showView('tracker-guided');
+    gdSelectedEngine = null; gdSuggestedEngine = null; gdPreset = null;
+    ['gd-baseurl','gd-name','gd-user','gd-pass','gd-totp','gd-cookie'].forEach(id => { const e = document.getElementById(id); if (e) e.value = ''; });
+    document.getElementById('gd-detect-result').textContent = '';
+    document.getElementById('gd-engine-result').textContent = '';
+    document.getElementById('gd-final-result').textContent = '';
+    gdGoStep(1);
+    gdLoadEngines();
+  }
+
+  async function gdLoadEngines() {
+    if (gdEngines.length) return;
+    try {
+      const r = await fetch('/api/tracker-engines');
+      const d = await r.json();
+      gdEngines = d.engines || [];
+    } catch (e) { console.warn('engines', e); }
+  }
+
+  function gdGoStep(n) {
+    document.querySelectorAll('[data-view="tracker-guided"] .guided-pane').forEach(p => {
+      p.style.display = Number(p.dataset.pane) === n ? '' : 'none';
+    });
+    document.querySelectorAll('#guided-stepbar .guided-step').forEach(s => {
+      const sn = Number(s.dataset.step);
+      s.classList.toggle('active', sn === n);
+      s.classList.toggle('done', sn < n);
+    });
+    if (n === 4) gdRenderSummary();
+  }
+
+  function gdFlash(id, msg, color) {
+    const el = document.getElementById(id);
+    if (el) { el.textContent = msg; el.style.color = color || 'var(--muted)'; }
+  }
+
+  async function gdDetect(btn) {
+    const baseUrl = document.getElementById('gd-baseurl').value.trim();
+    if (!/^https?:\/\//i.test(baseUrl)) {
+      gdFlash('gd-detect-result', 'Entre une adresse commençant par http:// ou https://', 'var(--red)');
+      return;
+    }
+    await gdLoadEngines();
+    const prev = btn.textContent; btn.disabled = true; btn.textContent = 'Analyse…';
+    gdFlash('gd-detect-result', 'Lecture du site en cours (cela peut prendre quelques secondes)…');
+    try {
+      const r = await fetch('/api/tracker-engines/detect', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ baseUrl }),
+      });
+      const d = await r.json();
+      gdSuggestedEngine = d.engine || null;
+      // pré-remplit le nom à partir du domaine
+      try { const host = new URL(baseUrl).hostname.replace(/^www\./, ''); const base = host.split('.')[0]; document.getElementById('gd-name').value = base.charAt(0).toUpperCase() + base.slice(1); } catch {}
+      if (d.engine) {
+        const lbl = (gdEngines.find(e => e.id === d.engine) || {}).label || d.engine;
+        gdFlash('gd-detect-result', `Détecté : ${lbl}`, 'var(--green)');
+        document.getElementById('gd-engine-intro').textContent = `On a reconnu « ${lbl} » (mis en avant ci-dessous). Confirme, ou choisis-en un autre si ce n'est pas ça.`;
+      } else if (d.reachable) {
+        gdFlash('gd-detect-result', 'Site lu, mais moteur non reconnu — choisis-le manuellement.', 'var(--muted)');
+        document.getElementById('gd-engine-intro').textContent = "On n'a pas pu reconnaître le moteur automatiquement. Choisis-le dans la liste (les indices t'aident).";
+      } else {
+        gdFlash('gd-detect-result', 'Site injoignable (Cloudflare/proxy ?) — choix manuel.', 'var(--muted)');
+        document.getElementById('gd-engine-intro').textContent = "Le site n'a pas pu être lu (protection anti-bot ou proxy requis). Choisis ton moteur manuellement.";
+      }
+      gdRenderEngineList();
+      gdGoStep(2);
+    } catch (e) {
+      gdFlash('gd-detect-result', 'Erreur réseau : ' + e.message, 'var(--red)');
+    } finally {
+      btn.disabled = false; btn.textContent = prev;
+    }
+  }
+
+  function gdRenderEngineList() {
+    const list = document.getElementById('gd-engine-list');
+    if (!list) return;
+    // suggéré en premier
+    const ordered = [...gdEngines].sort((a, b) => (b.id === gdSuggestedEngine ? 1 : 0) - (a.id === gdSuggestedEngine ? 1 : 0));
+    list.innerHTML = ordered.map(e => {
+      const suggested = e.id === gdSuggestedEngine;
+      const sel = e.id === gdSelectedEngine || (!gdSelectedEngine && suggested);
+      const ex = (e.examples && e.examples.length) ? `<div class="ge-examples">Ex : ${e.examples.map(escapeHtml).join(', ')}</div>` : '';
+      return `<button type="button" class="guided-engine-card ${sel ? 'selected' : ''}" data-engine="${escapeHtml(e.id)}" onclick="gdSelectEngine('${escapeHtml(e.id)}')">
+        <div class="ge-title">${escapeHtml(e.label)}${suggested ? '<span class="ge-suggested">✓ détecté</span>' : ''}</div>
+        <div class="ge-desc">${escapeHtml(e.description)}</div>
+        ${ex}
+        <div class="ge-hint">${escapeHtml(e.hint)}</div>
+      </button>`;
+    }).join('');
+    if (!gdSelectedEngine && gdSuggestedEngine) gdSelectedEngine = gdSuggestedEngine;
+  }
+
+  function gdSelectEngine(id) {
+    gdSelectedEngine = id;
+    document.querySelectorAll('#gd-engine-list .guided-engine-card').forEach(c => {
+      c.classList.toggle('selected', c.dataset.engine === id);
+    });
+  }
+
+  async function gdPickEngineContinue() {
+    if (!gdSelectedEngine) { gdFlash('gd-engine-result', 'Choisis un type de tracker.', 'var(--red)'); return; }
+    try {
+      const r = await fetch(`/api/tracker-engines/${encodeURIComponent(gdSelectedEngine)}/preset`);
+      const d = await r.json();
+      if (!d.ok) throw new Error(d.error || 'Preset indisponible');
+      gdPreset = d.preset;
+      const meta = gdEngines.find(e => e.id === gdSelectedEngine) || {};
+      // adapte le libellé du champ identifiant (MAM = email)
+      const userLabel = gdSelectedEngine === 'mam' ? "Adresse email (identifiant MAM)" : "Nom d'utilisateur";
+      document.getElementById('gd-user-label').textContent = userLabel;
+      document.getElementById('gd-creds-hint').textContent = meta.hint || '';
+      // cookie-only -> rendre la section cookie ouverte par défaut
+      const cookieWrap = document.getElementById('gd-cookie-wrap');
+      if (cookieWrap) cookieWrap.open = Boolean(gdPreset?.login?.cookieOnly);
+      gdGoStep(3);
+    } catch (e) {
+      gdFlash('gd-engine-result', e.message, 'var(--red)');
+    }
+  }
+
+  // Construit le TrackerConfig final à partir du preset + saisies utilisateur.
+  function gdBuildConfig() {
+    const baseUrl = document.getElementById('gd-baseurl').value.trim().replace(/\/+$/, '');
+    const name = document.getElementById('gd-name').value.trim() || (gdSelectedEngine || 'tracker');
+    // id : slug du nom, fallback domaine
+    let id = name.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '').replace(/[^a-z0-9]+/g, '').slice(0, 40);
+    if (id.length < 2) { try { id = new URL(baseUrl).hostname.replace(/^www\./, '').split('.')[0].replace(/[^a-z0-9]/g, ''); } catch {} }
+    const cfg = JSON.parse(JSON.stringify(gdPreset || {}));
+    // byteUnit n'est qu'une amorce : l'unité réelle est auto-détectée au scraping
+    // (suit ce que le site affiche). On garde le défaut du preset en attendant le 1er refresh.
+    const byteUnit = cfg.dashboard?.byteUnit || 'decimal';
+    return {
+      id,
+      name,
+      baseUrl,
+      enabled: true,
+      ...(cfg.curlBinary ? { curlBinary: cfg.curlBinary } : {}),
+      ...(cfg.ratioless ? { ratioless: true } : {}),
+      dashboard: { byteUnit },
+      login: cfg.login,
+      fetch: cfg.fetch,
+    };
+  }
+
+  function gdRenderSummary() {
+    const cfg = gdBuildConfig();
+    const meta = gdEngines.find(e => e.id === gdSelectedEngine) || {};
+    const fields = Object.keys(cfg.fetch?.fields || {}).join(', ') || '—';
+    document.getElementById('gd-summary').innerHTML = `
+      <div><b>Nom :</b> ${escapeHtml(cfg.name)} <span style="color:var(--muted)">(id: ${escapeHtml(cfg.id)})</span></div>
+      <div><b>Adresse :</b> ${escapeHtml(cfg.baseUrl)}</div>
+      <div><b>Type :</b> ${escapeHtml(meta.label || gdSelectedEngine || '—')}</div>
+      <div><b>Login :</b> ${escapeHtml(cfg.login?.url || '—')} (${escapeHtml(cfg.login?.method || 'POST')}/${escapeHtml(cfg.login?.contentType || 'form')})</div>
+      <div><b>Stats lues sur :</b> ${escapeHtml(cfg.fetch?.url || '—')} — champs : ${escapeHtml(fields)}</div>`;
+  }
+
+  function gdCredsPayload() {
+    return {
+      username: document.getElementById('gd-user').value.trim(),
+      password: document.getElementById('gd-pass').value,
+      totp: document.getElementById('gd-totp').value,
+      cookie: document.getElementById('gd-cookie').value,
+    };
+  }
+
+  async function gdTest(btn) {
+    const config = gdBuildConfig();
+    const creds = gdCredsPayload();
+    const prev = btn.textContent; btn.disabled = true; btn.textContent = 'Test…';
+    gdFlash('gd-final-result', 'Connexion et lecture en cours (10-40 s)…');
+    try {
+      const r = await fetch('/api/trackers/test', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ config, ...creds }),
+      });
+      const d = await r.json();
+      if (d.ok) {
+        const pairs = Object.entries(d.stat.fields || {}).map(([k, v]) => `${k} = ${v}`).join(' · ');
+        gdFlash('gd-final-result', '✓ Test réussi — ' + (pairs || 'aucun champ'), 'var(--green)');
+      } else {
+        gdFlash('gd-final-result', '✗ ' + (d.error || 'Échec'), 'var(--red)');
+      }
+    } catch (e) {
+      gdFlash('gd-final-result', '✗ Erreur réseau : ' + e.message, 'var(--red)');
+    } finally {
+      btn.disabled = false; btn.textContent = prev;
+    }
+  }
+
+  async function gdSave(btn) {
+    const config = gdBuildConfig();
+    const creds = gdCredsPayload();
+    const prev = btn.textContent; btn.disabled = true; btn.textContent = 'Enregistrement…';
+    try {
+      const r = await fetch('/api/trackers', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(config),
+      });
+      const d = await r.json();
+      if (!d.ok) throw new Error(d.error || 'Erreur');
+      // enregistre identifiants / cookie / 2FA
+      if (creds.username && creds.password) {
+        await fetch(`/api/credentials/${encodeURIComponent(config.id)}`, {
+          method: 'POST', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ username: creds.username, password: creds.password }),
+        });
+      }
+      if (creds.cookie) await fetch(`/api/trackers/${encodeURIComponent(config.id)}/cookie`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ cookie: creds.cookie }) });
+      if (creds.totp) await fetch(`/api/trackers/${encodeURIComponent(config.id)}/totp`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ secret: creds.totp }) });
+      gdFlash('gd-final-result', '✓ Tracker ajouté et configuré !', 'var(--green)');
+      await loadTrackerDefinitionsPanel();
+      await loadConfig();
+      await loadStats();
+    } catch (e) {
+      gdFlash('gd-final-result', '✗ ' + e.message, 'var(--red)');
+    } finally {
+      btn.disabled = false; btn.textContent = prev;
+    }
+  }
+
+  // Bascule vers le formulaire expert en pré-remplissant tout depuis le mode guidé.
+  function gdOpenInExpert() {
+    const config = gdBuildConfig();
+    const creds = gdCredsPayload();
+    openNewTrackerForm();
+    ntSetVal('nt-id', config.id);
+    ntSetVal('nt-name', config.name);
+    ntSetVal('nt-baseurl', config.baseUrl);
+    ntSetVal('nt-byteunit', config.dashboard?.byteUnit || 'binary');
+    ntSetVal('nt-curlbinary', config.curlBinary || '');
+    ntSetChecked('nt-ratioless', config.ratioless);
+    const lg = config.login || {};
+    ntSetVal('nt-login-url', lg.url || ''); ntSetVal('nt-login-method', lg.method || 'POST');
+    ntSetVal('nt-login-contenttype', lg.contentType || 'form'); ntSetChecked('nt-login-cookieonly', lg.cookieOnly);
+    ntSetVal('nt-login-posturl', lg.postUrl || ''); ntSetVal('nt-login-otpfield', lg.otpField || '');
+    ntSetVal('nt-login-successfield', lg.successField || ''); ntSetVal('nt-login-csrfheader', lg.csrfHeader || '');
+    ntSetVal('nt-login-tokenfield', lg.tokenField || '');
+    ntSetVal('nt-login-previsit', (lg.preVisitUrls || []).join('\n'));
+    ntSetVal('nt-login-failures', (lg.failurePatterns || []).join('\n'));
+    if (lg.preStep) { ntSetVal('nt-prestep-url', lg.preStep.url || ''); ntSetVal('nt-prestep-csrf', lg.preStep.extract?._csrf?.regex || ''); ntSetChecked('nt-prestep-hidden', lg.preStep.includeHiddenInputs); }
+    if (lg.otpStep) { ntSetVal('nt-otpstep-url', lg.otpStep.urlContains || ''); ntSetVal('nt-otpstep-field', lg.otpStep.field || ''); }
+    document.getElementById('nt-login-body').innerHTML = '';
+    Object.entries(lg.body || {}).forEach(([k, v]) => ntAddBodyRow(k, v));
+    ntSetVal('nt-fetch-url', config.fetch?.url || ''); ntSetVal('nt-fetch-mode', config.fetch?.mode || 'browser');
+    ntSetVal('nt-fetch-responsetype', config.fetch?.responseType || 'html');
+    document.getElementById('nt-fetch-fields').innerHTML = '';
+    Object.entries(config.fetch?.fields || {}).forEach(([n, f]) => ntAddFieldRow(n, f.path || f.regex || '', f.transform || ''));
+    ntSetVal('nt-test-user', creds.username); document.getElementById('nt-test-pass').value = creds.password;
+    document.getElementById('nt-test-totp').value = creds.totp; document.getElementById('nt-test-cookie').value = creds.cookie;
+    ntSyncResponseHint();
+  }
+
+
 
   function betaTrackerUrl(stat) {
     return stat.trackerUrl || trackerConfig.find(t => t.id === stat.id)?.baseUrl || '';
@@ -2908,17 +3804,18 @@
     const stat = selectedBetaTracker();
     if (!stat) return;
     const rows = chartRowsForTracker(stat.id, 'day', 'total', ficheChartSource());
+    const md = betaMetricDefsFor(statByteUnit(stat));
     const volDefs = [
-      { ...betaMetricDefs.uploadedBytes, value: row => row.uploadedBytes, area: true },
-      { ...betaMetricDefs.downloadedBytes, value: row => row.downloadedBytes, area: true },
+      { ...md.uploadedBytes, value: row => row.uploadedBytes, area: true },
+      { ...md.downloadedBytes, value: row => row.downloadedBytes, area: true },
     ];
     if (ficheBufferOn) {
-      volDefs.push({ label: 'Buffer', color: '#a855f7', value: row => row.uploadedBytes - row.downloadedBytes, format: betaMetricDefs.uploadedBytes.format, axis: betaMetricDefs.uploadedBytes.axis });
+      volDefs.push({ label: 'Buffer', color: '#a855f7', value: row => row.uploadedBytes - row.downloadedBytes, format: md.uploadedBytes.format, axis: md.uploadedBytes.axis });
     }
-    drawSeriesChart('beta-fiche-vol-chart', rows, volDefs, `Volumes (UP / DL${ficheBufferOn ? ' / buffer' : ''})`, { axisFormat: betaMetricDefs.uploadedBytes.axis });
+    drawSeriesChart('beta-fiche-vol-chart', rows, volDefs, `Volumes (UP / DL${ficheBufferOn ? ' / buffer' : ''})`, { axisFormat: md.uploadedBytes.axis });
     drawSeriesChart('beta-fiche-ratio-chart', rows, [
-      { ...betaMetricDefs.ratio, value: row => row.ratio },
-    ], 'Ratio', { axisFormat: betaMetricDefs.ratio.axis });
+      { ...md.ratio, value: row => row.ratio },
+    ], 'Ratio', { axisFormat: md.ratio.axis });
   }
 
   function renderBetaTrackerPage() {
@@ -3293,11 +4190,12 @@
     const period = document.getElementById('beta-global-period')?.value || 'day';
     const mode = document.getElementById('beta-global-mode')?.value || 'delta';
     const rows = latestSnapshotsByTrackerAndPeriod(period, mode, filterHistoryByRange('beta-global-from', 'beta-global-to'));
+    const defs = betaMetricDefsFor(resolveAggregateUnit());
     drawSeriesChart('beta-global-chart', rows, [
-      { ...betaMetricDefs.uploadedBytes, label: mode === 'delta' ? 'UP période' : 'UP total', value: row => row.uploadedBytes, area: true },
-      { ...betaMetricDefs.downloadedBytes, label: mode === 'delta' ? 'DL période' : 'DL total', value: row => row.downloadedBytes, area: true },
-      { ...betaMetricDefs.seedTimeDays, value: row => row.seedTimeDays },
-    ], mode === 'delta' ? 'Global: activité par période' : 'Global: cumuls', { axisFormat: betaMetricDefs.uploadedBytes.axis });
+      { ...defs.uploadedBytes, label: mode === 'delta' ? 'UP période' : 'UP total', value: row => row.uploadedBytes, area: true },
+      { ...defs.downloadedBytes, label: mode === 'delta' ? 'DL période' : 'DL total', value: row => row.downloadedBytes, area: true },
+      { ...defs.seedTimeDays, value: row => row.seedTimeDays },
+    ], mode === 'delta' ? 'Global: activité par période' : 'Global: cumuls', { axisFormat: defs.uploadedBytes.axis });
   }
 
   // Remplit la liste de trackers de l'« Évolution » (Tout + trackers activés),
@@ -3327,13 +4225,15 @@
       rows = chartRowsForTracker(trackerId, 'day', mode, source);
       title = latestSortedStats.find(stat => stat.id === trackerId)?.name || 'Tracker';
     }
+    const unit = trackerId === 'all' ? resolveAggregateUnit() : resolveMonoTrackerUnit(trackerId);
+    const md = betaMetricDefsFor(unit);
     const defs = [
-      { ...betaMetricDefs.uploadedBytes, value: row => row.uploadedBytes, area: true },
-      { ...betaMetricDefs.downloadedBytes, value: row => row.downloadedBytes, area: true },
-      { ...betaMetricDefs.ratio, value: row => row.ratio },
-    ].filter(def => metric === 'all' || def.label === betaMetricDefs[metric]?.label);
-    const axisDef = metric === 'ratio' ? betaMetricDefs.ratio : betaMetricDefs.uploadedBytes;
-    drawSeriesChart('beta-history-chart', rows, defs, `${title}: ${metric === 'all' ? 'UP / DL / ratio' : betaMetricDefs[metric].label}`, { axisFormat: axisDef.axis });
+      { ...md.uploadedBytes, value: row => row.uploadedBytes, area: true },
+      { ...md.downloadedBytes, value: row => row.downloadedBytes, area: true },
+      { ...md.ratio, value: row => row.ratio },
+    ].filter(def => metric === 'all' || def.label === md[metric]?.label);
+    const axisDef = metric === 'ratio' ? md.ratio : md.uploadedBytes;
+    drawSeriesChart('beta-history-chart', rows, defs, `${title}: ${metric === 'all' ? 'UP / DL / ratio' : md[metric].label}`, { axisFormat: axisDef.axis });
   }
 
   // Sélection des trackers affichés dans la comparaison multi-trackers.
@@ -3390,7 +4290,7 @@
       });
       return out;
     });
-    const metricDef = betaMetricDefs[metric];
+    const metricDef = betaMetricDefsFor(resolveAggregateUnit())[metric];
     const defs = rowsByTracker.map(item => ({
       label: trackerDisplayName(item.stat.id),
       color: trackerColor(item.stat.id, item.idx),
@@ -4218,7 +5118,7 @@
     alert(data.ok ? 'Notification envoyée' : `Notification KO: ${data.error}`);
   }
 
-  const ALL_VIEWS = ['dashboard', 'trackers', 'proxies', 'calendar', 'graphs', 'qbit', 'scraping', 'notif-canaux', 'notif-globales', 'notif-tracker', 'fiche'];
+  const ALL_VIEWS = ['dashboard', 'trackers', 'tracker-new', 'tracker-guided', 'proxies', 'calendar', 'graphs', 'qbit', 'scraping', 'notif-canaux', 'notif-globales', 'notif-tracker', 'fiche'];
 
   // Affiche la vue demandée : bascule les sections de <main>, le panneau proxy
   // (sibling de <main>) et l'état actif de la barre latérale.
@@ -4845,6 +5745,9 @@
                 <div class="definition-actions">
                   <button class="btn-test" style="padding:6px 10px" onclick="setTrackerEnabled('${safeId}', ${isEnabled ? 'false' : 'true'})">${isEnabled ? 'Retirer' : 'Ajouter'}</button>
                 </div>
+                ${definition.isCustom ? `<div class="definition-actions">
+                  <button class="btn-test" style="padding:6px 10px" title="Modifier la définition technique de ce tracker perso" onclick="ntEditCustomTracker('${safeId}')">Éditer la définition</button>
+                </div>` : ''}
                 <details class="definition-advanced" style="grid-column:1/-1">
                   <summary>Options avancées${credential.hasCookie ? ' · <b style="color:var(--green)">cookie défini</b>' : ''}${credential.hasTotp ? ' · <b style="color:var(--green)">2FA défini</b>' : ''}</summary>
                   <div class="definition-advanced-body">

--- a/src/browserFetcher.ts
+++ b/src/browserFetcher.ts
@@ -814,6 +814,35 @@ export async function fetchWithBrowser(
   }
 }
 
+/**
+ * Recupere le HTML brut d'une URL via un navigateur EPHEMERE (contexte non
+ * persistant, sans profil ni cookies), pour la detection de moteur quand le GET
+ * HTTP echoue (Cloudflare/JS). Aucun login, aucune session : usage strictement
+ * lecture-seule d'une page publique (ex: page de login). Best-effort : renvoie '' en cas d'echec.
+ */
+export async function fetchRawHtmlWithBrowser(url: string, trackerId = '__detect__'): Promise<string> {
+  const contextOptions = {
+    userAgent: selectUserAgent(),
+    viewport: { width: 1365, height: 900 },
+    locale: 'fr-FR',
+  };
+  let browser: Awaited<ReturnType<typeof chromium.launch>> | null = null;
+  try {
+    browser = await chromium.launch({ headless: true, proxy: playwrightProxy(trackerId) });
+    const context = await browser.newContext(contextOptions);
+    const page = await context.newPage();
+    await page.goto(url, { waitUntil: 'commit', timeout: 45_000 });
+    await page.waitForLoadState('domcontentloaded', { timeout: 30_000 }).catch(() => {});
+    await waitForAnubis(page).catch(() => {});
+    await page.waitForLoadState('networkidle', { timeout: 8_000 }).catch(() => {});
+    return await safeContent(page);
+  } catch {
+    return '';
+  } finally {
+    await browser?.close().catch(() => {});
+  }
+}
+
 export async function closeBrowserSessions(): Promise<void> {
   await Promise.all([...contexts.values()].map(context => context.close().catch(() => {})));
   contexts.clear();

--- a/src/db.ts
+++ b/src/db.ts
@@ -419,6 +419,34 @@ export function deleteTrackerCredentials(trackerId: string): void {
     .run(trackerId);
 }
 
+/**
+ * Supprime entierement un tracker custom : config, identifiants, planning et
+ * historique de snapshots. Cookie/TOTP (stockes dans la table settings sous forme
+ * de map JSON) sont nettoyes par l'appelant via setTrackerCookie/setTrackerTotpSecret.
+ * A reserver aux trackers ajoutes par l'utilisateur (absents de default-trackers/),
+ * car syncDefaultTrackerDefinitions() reseederait un tracker embarque au prochain boot.
+ */
+export function deleteTrackerConfig(trackerId: string): void {
+  const db = getDb();
+  db.exec('BEGIN');
+  try {
+    db.prepare('DELETE FROM tracker_configs WHERE tracker_id = ?').run(trackerId);
+    db.prepare('DELETE FROM tracker_credentials WHERE tracker_id = ?').run(trackerId);
+    db.prepare('DELETE FROM tracker_schedule WHERE tracker_id = ?').run(trackerId);
+    db.prepare('DELETE FROM stat_snapshots WHERE tracker_id = ?').run(trackerId);
+    db.exec('COMMIT');
+  } catch (err) {
+    db.exec('ROLLBACK');
+    throw err;
+  }
+}
+
+/** True si une definition embarquee (default-trackers/) existe pour cet id. */
+export function isDefaultTracker(trackerId: string): boolean {
+  if (!fs.existsSync(DEFAULT_TRACKERS_DIR)) return false;
+  return fs.existsSync(path.join(DEFAULT_TRACKERS_DIR, `${trackerId}.json`));
+}
+
 export function ensureTrackerSchedules(trackers: TrackerConfig[]): void {
   const stmt = getDb().prepare(`
     INSERT INTO tracker_schedule (tracker_id, enabled, interval_hours, next_run_at)

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -17,7 +17,7 @@ import { getProxyConfig, ensureProxyReady } from './proxy.js';
 import { closeAllSshTunnels } from './sshTunnel.js';
 import { curlImpersonateGet, CurlSession, fastFetchEnabled } from './curlImpersonate.js';
 import { buildCookieHeader } from './browserFetcher.js';
-import { getTrackerTotpSecret } from './db.js';
+import { getTrackerTotpSecret, loadTrackerConfigsFromDb, saveTrackerConfig } from './db.js';
 import { generateTotp } from './totp.js';
 import { selectUserAgent } from './userAgent.js';
 import { closeBrowserSession, closeBrowserSessions, fetchWithBrowser } from './browserFetcher.js';
@@ -48,6 +48,50 @@ function parseBytes(raw: unknown): number {
   return Math.round(n * (map[u] ?? 1));
 }
 
+/**
+ * Déduit l'unité d'affichage (decimal/binary) d'une chaîne d'octets scrapée.
+ * « 10 GB » -> 'decimal' (puissances de 1000), « 10 GiB »/« 10 Gio » -> 'binary'
+ * (puissances de 1024). Renvoie null si pas d'unité reconnaissable (nombre nu,
+ * « B »/« o » seuls qui sont ambigus). Suit ainsi la convention réelle du site.
+ */
+function detectByteUnitFromString(raw: unknown): 'decimal' | 'binary' | null {
+  if (typeof raw !== 'string') return null;
+  const s = raw.replace(/&nbsp;|&#160;|&#xa0;/gi, ' ').replace(/ /g, ' ');
+  const m = s.match(/[\d][\s.,\u202f]*\s*([KMGTPE])(i)?(?:B|o)/i);
+  if (!m) return null;
+  return m[2] ? 'binary' : 'decimal'; // présence du "i" (KiB/Gio) = binaire
+}
+
+/**
+ * Persiste l'unité détectée dans la config du tracker, UNIQUEMENT si elle a changé.
+ * Indispensable pour que les stats servies depuis un snapshot (démarrage à froid,
+ * entre deux refresh) affichent la bonne unité — la fonction de snapshot lit
+ * tracker.dashboard.byteUnit, pas la valeur live. Écriture rare (seulement au
+ * changement), donc pas d'amplification d'écriture. Ne touche jamais aux autres
+ * champs : on relit la config courante en base et on ne modifie que byteUnit.
+ */
+function maybePersistByteUnit(tracker: TrackerConfig, unit: 'decimal' | 'binary'): void {
+  if (tracker.dashboard?.byteUnit === unit) return; // déjà à jour en mémoire
+  try {
+    const current = loadTrackerConfigsFromDb().find(t => t.id === tracker.id);
+    if (!current) return; // tracker pas (encore) en base : rien à persister
+    if (current.dashboard?.byteUnit === unit) {
+      tracker.dashboard = { ...(tracker.dashboard ?? {}), byteUnit: unit };
+      return;
+    }
+    const updated: TrackerConfig = {
+      ...current,
+      dashboard: { ...(current.dashboard ?? {}), byteUnit: unit },
+    };
+    saveTrackerConfig(updated);
+    // Refléter aussi en mémoire pour les lectures suivantes du même cycle.
+    tracker.dashboard = { ...(tracker.dashboard ?? {}), byteUnit: unit };
+    console.log(`  [${tracker.name}] Unité d'affichage alignée sur le site : ${unit === 'decimal' ? 'GB (décimal)' : 'GiB (binaire)'}`);
+  } catch {
+    // best-effort : un échec de persistance ne doit jamais casser le refresh
+  }
+}
+
 function applyTransform(raw: unknown, tf?: string): string | number {
   if (raw === undefined || raw === null || raw === '') return '';
   switch (tf) {
@@ -74,27 +118,32 @@ function getPath(obj: unknown, path: string): unknown {
 function extractJson(
   json: unknown,
   fields: Record<string, FieldExtractor>,
-): Record<string, string | number> {
+): { values: Record<string, string | number>; byteUnit: 'decimal' | 'binary' | null } {
   const out: Record<string, string | number> = {};
+  let byteUnit: 'decimal' | 'binary' | null = null;
   for (const [name, ext] of Object.entries(fields)) {
     if (!ext.path) continue;
-    out[name] = applyTransform(getPath(json, ext.path), ext.transform);
+    const raw = getPath(json, ext.path);
+    out[name] = applyTransform(raw, ext.transform);
+    if (!byteUnit && ext.transform === 'bytes') byteUnit = detectByteUnitFromString(raw);
   }
-  return out;
+  return { values: out, byteUnit };
 }
 
 function extractHtml(
   html: string,
   fields: Record<string, FieldExtractor>,
-): Record<string, string | number> {
+): { values: Record<string, string | number>; byteUnit: 'decimal' | 'binary' | null } {
   const out: Record<string, string | number> = {};
+  let byteUnit: 'decimal' | 'binary' | null = null;
   for (const [name, ext] of Object.entries(fields)) {
     if (!ext.regex) continue;
     const match = new RegExp(ext.regex, 's').exec(html);
     const val   = match?.groups?.['value'] ?? match?.[1];
     out[name]   = applyTransform(val, ext.transform);
+    if (!byteUnit && ext.transform === 'bytes') byteUnit = detectByteUnitFromString(val);
   }
-  return out;
+  return { values: out, byteUnit };
 }
 
 function hasExtractedValues(fields: Record<string, string | number>): boolean {
@@ -163,7 +212,7 @@ export async function fetchUnreadMessages(
       unreadMessages: { path: uf.path, regex: uf.regex, transform: uf.transform },
     };
     const rt = uf.responseType ?? (uf.path ? 'json' : 'html');
-    let out: Record<string, string | number>;
+    let out: { values: Record<string, string | number>; byteUnit: 'decimal' | 'binary' | null };
     if (rt === 'json') {
       let json: unknown;
       try { json = JSON.parse(res.body); } catch { return ''; }
@@ -171,7 +220,7 @@ export async function fetchUnreadMessages(
     } else {
       out = extractHtml(res.body, single);
     }
-    return out.unreadMessages ?? '';
+    return out.values.unreadMessages ?? '';
   } catch {
     return '';
   }
@@ -804,6 +853,7 @@ export async function fetchTracker(
     }
 
     let fields: Record<string, string | number>;
+    let detectedByteUnit: 'decimal' | 'binary' | null = null;
     if (tracker.fetch.responseType === 'json') {
       let json: unknown;
       try {
@@ -811,9 +861,9 @@ export async function fetchTracker(
       } catch {
         throw new Error('Reponse attendue en JSON, recu du HTML (mauvais endpoint ?)');
       }
-      fields = extractJson(json, tracker.fetch.fields);
+      ({ values: fields, byteUnit: detectedByteUnit } = extractJson(json, tracker.fetch.fields));
     } else {
-      fields = extractHtml(html, tracker.fetch.fields);
+      ({ values: fields, byteUnit: detectedByteUnit } = extractHtml(html, tracker.fetch.fields));
     }
 
     if (!hasExtractedValues(fields)) {
@@ -828,6 +878,12 @@ export async function fetchTracker(
       console.log(`  [${tracker.name}] Champs manquants: ${missingFields.join(', ')}${dumpPath ? ` - dump: ${dumpPath}` : ''}`);
     }
 
+    // L'unité d'affichage suit ce que le site écrit réellement (« GB » -> décimal,
+    // « GiB » -> binaire), détectée au scraping. Repli sur le réglage du tracker
+    // puis 'binary' si la chaîne ne portait pas d'unité reconnaissable.
+    const resolvedByteUnit = detectedByteUnit ?? tracker.dashboard?.byteUnit ?? 'binary';
+    maybePersistByteUnit(tracker, resolvedByteUnit);
+
     return {
       id:          tracker.id,
       name:        tracker.name,
@@ -835,7 +891,7 @@ export async function fetchTracker(
       status:      'ok',
       lastUpdated: new Date().toISOString(),
       lastLoginAt: session.loggedInAt ? new Date(session.loggedInAt).toISOString() : undefined,
-      byteUnit:    tracker.dashboard?.byteUnit ?? 'binary',
+      byteUnit:    resolvedByteUnit,
       fields,
     };
   };
@@ -1163,6 +1219,7 @@ export async function fetchTracker(
 
     // Extraction des champs
     let fields: Record<string, string | number>;
+    let detectedByteUnit: 'decimal' | 'binary' | null = null;
     if (tracker.fetch.responseType === 'json') {
       let json: unknown;
       try {
@@ -1170,9 +1227,9 @@ export async function fetchTracker(
       } catch {
         throw new Error('Réponse attendue en JSON, reçu du HTML (mauvais endpoint ?)');
       }
-      fields = extractJson(json, tracker.fetch.fields);
+      ({ values: fields, byteUnit: detectedByteUnit } = extractJson(json, tracker.fetch.fields));
     } else {
-      fields = extractHtml(res.data, tracker.fetch.fields);
+      ({ values: fields, byteUnit: detectedByteUnit } = extractHtml(res.data, tracker.fetch.fields));
     }
 
     if (!hasExtractedValues(fields)) {
@@ -1192,6 +1249,9 @@ export async function fetchTracker(
       fields.unreadMessages = await fetchUnreadMessagesViaAxios(session.client, tracker, fetchHeaders);
     }
 
+    const resolvedByteUnit = detectedByteUnit ?? tracker.dashboard?.byteUnit ?? 'binary';
+    maybePersistByteUnit(tracker, resolvedByteUnit);
+
     return {
       id:          tracker.id,
       name:        tracker.name,
@@ -1199,7 +1259,7 @@ export async function fetchTracker(
       status:      'ok',
       lastUpdated: new Date().toISOString(),
       lastLoginAt: session.loggedInAt ? new Date(session.loggedInAt).toISOString() : undefined,
-      byteUnit:    tracker.dashboard?.byteUnit ?? 'binary',
+      byteUnit:    resolvedByteUnit,
       fields,
     };
   };

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,8 +4,13 @@ import fs from 'fs';
 import { fileURLToPath } from 'url';
 import axios from 'axios';
 import { fetchTracker, invalidateAllSessions, invalidateSession } from './fetcher.js';
-import { resetBrowserProfile, closeBrowserSession } from './browserFetcher.js';
+import { resetBrowserProfile, closeBrowserSession, fetchRawHtmlWithBrowser } from './browserFetcher.js';
 import { type FieldExtractor, type TrackerConfig, type TrackerStats } from './types.js';
+import {
+  listEngines,
+  getEngineTemplate,
+  detectEngineFromHtml,
+} from './trackerTemplates.js';
 import {
   loadProxySettings, saveProxySettings, buildProxyConfig, logProxyStatus, resolveProxyForTracker, ensureProxyReady,
   loadProxyOverrides, saveProxyOverrides, toSshConfig,
@@ -21,6 +26,8 @@ import {
 } from './logos.js';
 import {
   deleteTrackerCredentials,
+  deleteTrackerConfig,
+  isDefaultTracker,
   getTrackerCredentials,
   importLegacyCredentialsIfNeeded,
   importLegacySettingsIfNeeded,
@@ -40,8 +47,10 @@ import {
   saveTrackerConfig,
   setJsonSetting,
   hasTrackerCookie,
+  getTrackerCookie,
   setTrackerCookie,
   hasTrackerTotpSecret,
+  getTrackerTotpSecret,
   setTrackerTotpSecret,
 } from './db.js';
 import {
@@ -985,6 +994,204 @@ function normalizeTrackerConfigs(): TrackerConfig[] {
   }
   return loadTrackerConfigsFromDb();
 }
+
+/**
+ * Valide et normalise une definition de tracker recue depuis le formulaire UI
+ * (ou /api/trackers). Renvoie une config typee propre, ou un message d'erreur FR.
+ * Tolere les champs optionnels absents ; rejette les formes manifestement cassees
+ * (id invalide, body de login vide, aucun champ a extraire, regex/path manquant).
+ */
+function sanitizeTrackerConfigInput(
+  raw: unknown,
+  opts: { isNew?: boolean } = {},
+): { config: TrackerConfig | null; error?: string } {
+  const fail = (error: string) => ({ config: null, error });
+  if (!raw || typeof raw !== 'object') return fail('Config tracker absente ou invalide.');
+  const input = raw as Record<string, any>;
+
+  const id = String(input.id ?? '').trim().toLowerCase();
+  if (!/^[a-z0-9][a-z0-9_-]{1,39}$/.test(id)) {
+    return fail('Identifiant invalide : 2 a 40 caracteres, minuscules/chiffres/tiret/underscore, commencant par une lettre ou un chiffre.');
+  }
+  const name = String(input.name ?? '').trim();
+  if (!name) return fail('Nom du tracker requis.');
+
+  let baseUrl = String(input.baseUrl ?? '').trim();
+  if (!/^https?:\/\//i.test(baseUrl)) return fail('URL de base invalide : doit commencer par http:// ou https://');
+  baseUrl = baseUrl.replace(/\/+$/, '');
+
+  const login = input.login;
+  if (!login || typeof login !== 'object') return fail('Bloc « login » manquant.');
+  const loginUrl = String(login.url ?? '').trim();
+  if (!loginUrl) return fail('URL de login requise.');
+
+  const cookieOnly = Boolean(login.cookieOnly);
+  const body = login.body && typeof login.body === 'object' ? login.body as Record<string, string> : {};
+  const bodyEntries = Object.entries(body).filter(([k]) => k.trim());
+  if (!cookieOnly && bodyEntries.length === 0) {
+    return fail('Corps du login vide : ajoute au moins un champ (ex: username = {{username}}).');
+  }
+
+  const failurePatterns = Array.isArray(login.failurePatterns)
+    ? login.failurePatterns.map((p: unknown) => String(p)).filter((p: string) => p.length > 0)
+    : [];
+
+  const loginOut: TrackerConfig['login'] = {
+    url: loginUrl,
+    method: login.method === 'GET' ? 'GET' : 'POST',
+    contentType: login.contentType === 'json' ? 'json' : 'form',
+    body: Object.fromEntries(bodyEntries.map(([k, v]) => [k.trim(), String(v)])),
+    failurePatterns,
+  };
+  if (cookieOnly) loginOut.cookieOnly = true;
+  if (String(login.postUrl ?? '').trim()) loginOut.postUrl = String(login.postUrl).trim();
+  if (String(login.otpField ?? '').trim()) loginOut.otpField = String(login.otpField).trim();
+  if (String(login.csrfHeader ?? '').trim()) loginOut.csrfHeader = String(login.csrfHeader).trim();
+  if (String(login.tokenField ?? '').trim()) loginOut.tokenField = String(login.tokenField).trim();
+  if (String(login.successField ?? '').trim()) loginOut.successField = String(login.successField).trim();
+  if (Array.isArray(login.preVisitUrls)) {
+    const urls = login.preVisitUrls.map((u: unknown) => String(u).trim()).filter(Boolean);
+    if (urls.length) loginOut.preVisitUrls = urls;
+  }
+  // preStep (CSRF) : optionnel.
+  if (login.preStep && typeof login.preStep === 'object' && String(login.preStep.url ?? '').trim()) {
+    const extractRaw = login.preStep.extract && typeof login.preStep.extract === 'object' ? login.preStep.extract : {};
+    const extract: Record<string, { regex: string }> = {};
+    for (const [k, v] of Object.entries(extractRaw)) {
+      const regex = String((v as any)?.regex ?? '').trim();
+      if (k.trim() && regex) extract[k.trim()] = { regex };
+    }
+    loginOut.preStep = {
+      url: String(login.preStep.url).trim(),
+      extract,
+      ...(login.preStep.includeHiddenInputs ? { includeHiddenInputs: true } : {}),
+    };
+  }
+  // otpStep (2FA page dediee, ex: Nexum).
+  if (login.otpStep && typeof login.otpStep === 'object'
+      && String(login.otpStep.urlContains ?? '').trim() && String(login.otpStep.field ?? '').trim()) {
+    loginOut.otpStep = {
+      urlContains: String(login.otpStep.urlContains).trim(),
+      field: String(login.otpStep.field).trim(),
+    };
+  }
+  // mfaStep (login API JSON en 2 etapes, ex: C411).
+  if (login.mfaStep && typeof login.mfaStep === 'object'
+      && String(login.mfaStep.url ?? '').trim()
+      && String(login.mfaStep.triggerField ?? '').trim()
+      && String(login.mfaStep.codeField ?? '').trim()) {
+    loginOut.mfaStep = {
+      url: String(login.mfaStep.url).trim(),
+      triggerField: String(login.mfaStep.triggerField).trim(),
+      codeField: String(login.mfaStep.codeField).trim(),
+      ...(String(login.mfaStep.successField ?? '').trim() ? { successField: String(login.mfaStep.successField).trim() } : {}),
+    };
+  }
+
+  // ── fetch ──────────────────────────────────────────────────────────────────
+  const fetchIn = input.fetch;
+  if (!fetchIn || typeof fetchIn !== 'object') return fail('Bloc « fetch » manquant.');
+  const fetchUrl = String(fetchIn.url ?? '').trim();
+  if (!fetchUrl) return fail('URL de lecture (fetch) requise.');
+  const responseType = fetchIn.responseType === 'json' ? 'json' : 'html';
+  const mode = fetchIn.mode === 'http' ? 'http' : 'browser';
+
+  const fieldsIn = fetchIn.fields && typeof fetchIn.fields === 'object' ? fetchIn.fields : {};
+  const fields: Record<string, FieldExtractor> = {};
+  const allowedTransforms = new Set(['bytes', 'number', 'integer', 'string']);
+  for (const [key, val] of Object.entries(fieldsIn)) {
+    const name = key.trim();
+    if (!name) continue;
+    const v = (val ?? {}) as Record<string, any>;
+    const path = String(v.path ?? '').trim();
+    const regex = String(v.regex ?? '').trim();
+    if (responseType === 'json' && !path) {
+      return fail(`Champ « ${name} » : un chemin JSON (path) est requis en mode JSON.`);
+    }
+    if (responseType === 'html' && !regex) {
+      return fail(`Champ « ${name} » : une regex est requise en mode HTML.`);
+    }
+    if (regex) {
+      try { new RegExp(regex); } catch { return fail(`Champ « ${name} » : regex invalide.`); }
+      if (!/\(\?<value>/.test(regex)) {
+        return fail(`Champ « ${name} » : la regex doit capturer un groupe nomme (?<value>...).`);
+      }
+    }
+    const extractor: FieldExtractor = {};
+    if (path) extractor.path = path;
+    if (regex) extractor.regex = regex;
+    if (typeof v.transform === 'string' && allowedTransforms.has(v.transform)) extractor.transform = v.transform as FieldExtractor['transform'];
+    fields[name] = extractor;
+  }
+  if (Object.keys(fields).length === 0) {
+    return fail('Ajoute au moins un champ a extraire (ex: uploadedBytes, ratio...).');
+  }
+
+  const fetchOut: TrackerConfig['fetch'] = {
+    url: fetchUrl,
+    mode,
+    responseType,
+    fields,
+  };
+  // unreadFetch (compteur de MP secondaire).
+  if (fetchIn.unreadFetch && typeof fetchIn.unreadFetch === 'object' && String(fetchIn.unreadFetch.url ?? '').trim()) {
+    const uf = fetchIn.unreadFetch as Record<string, any>;
+    const ufPath = String(uf.path ?? '').trim();
+    const ufRegex = String(uf.regex ?? '').trim();
+    if (ufRegex) { try { new RegExp(ufRegex); } catch { return fail('unreadFetch : regex invalide.'); } }
+    const ufTransform = allowedTransforms.has(uf.transform) ? (uf.transform as FieldExtractor['transform']) : undefined;
+    fetchOut.unreadFetch = {
+      url: String(uf.url).trim(),
+      ...(uf.responseType === 'html' || uf.responseType === 'json' ? { responseType: uf.responseType } : {}),
+      ...(ufPath ? { path: ufPath } : {}),
+      ...(ufRegex ? { regex: ufRegex } : {}),
+      ...(ufTransform ? { transform: ufTransform } : {}),
+    };
+  }
+
+  const config: TrackerConfig = {
+    id,
+    name,
+    baseUrl,
+    enabled: input.enabled === false ? false : true,
+    login: loginOut,
+    fetch: fetchOut,
+  };
+  if (input.ratioless) config.ratioless = true;
+  if (input.curlBinary === 'curl_firefox133' || input.curlBinary === 'curl_firefox135') {
+    config.curlBinary = input.curlBinary;
+  }
+  const byteUnit = input.dashboard?.byteUnit;
+  if (byteUnit === 'binary' || byteUnit === 'decimal') {
+    config.dashboard = { byteUnit };
+  }
+
+  void opts; // isNew reserve pour de futures regles differenciees creation/edition
+  return { config };
+}
+
+/**
+ * Liste de toutes les definitions visibles dans l'UI : celles posees en fichier
+ * (default-trackers seedees dans config/trackers/) PLUS les trackers custom qui
+ * n'existent qu'en base (ajoutes via le formulaire, sans fichier sur le volume).
+ * Sans ce merge, un tracker perso enregistre via /api/trackers serait invisible
+ * dans « Configurer les actifs » et n'aurait jamais d'identifiants.
+ */
+function listAllTrackerSummaries(): Array<{ id: string; name: string; baseUrl: string; file: string; enabled: boolean }> {
+  const fromFiles = listTrackerDefinitionFiles();
+  const seen = new Set(fromFiles.map(d => d.id));
+  const dbOnly = loadTrackerConfigsFromDb()
+    .filter(cfg => !seen.has(cfg.id))
+    .map(cfg => ({
+      id: cfg.id,
+      name: cfg.name,
+      baseUrl: cfg.baseUrl,
+      file: `${cfg.id} (perso)`,
+      enabled: cfg.enabled !== false,
+    }));
+  return [...fromFiles, ...dbOnly];
+}
+
 
 function proxyAllowsTrackerConnections(): boolean {
   const proxy = loadProxySettings();
@@ -3101,13 +3308,15 @@ export async function start(): Promise<void> {
     importLegacyTrackersIfNeeded();
     trackers = normalizeTrackerConfigs();
     const configured = new Map(trackers.map(tracker => [tracker.id, tracker]));
-    const definitions = listTrackerDefinitionFiles()
+    const definitions = listAllTrackerSummaries()
       .map(definition => {
         const configuredTracker = configured.get(definition.id);
         return {
           ...definition,
           enabled: Boolean(configuredTracker && configuredTracker.enabled !== false),
           configured: Boolean(configuredTracker),
+          isDefault: isDefaultTracker(definition.id),
+          isCustom: !isDefaultTracker(definition.id),
         };
       })
       .sort((a, b) => a.name.localeCompare(b.name, 'fr', { sensitivity: 'base' }));
@@ -3152,12 +3361,19 @@ export async function start(): Promise<void> {
 
   app.post('/api/trackers', (req, res) => {
     try {
-      const config = req.body as TrackerConfig;
-      if (!config.id || !config.name || !config.baseUrl || !config.login || !config.fetch) {
-        return res.status(400).json({ ok: false, error: 'Config tracker incomplete' });
+      const { config, error } = sanitizeTrackerConfigInput(req.body, { isNew: !isDefaultTracker(String(req.body?.id ?? '')) });
+      if (!config) return res.status(400).json({ ok: false, error });
+
+      // Interdit d'ecraser une definition embarquee via ce formulaire : ses champs
+      // techniques (login/fetch/curlBinary) seraient de toute facon reecrits par
+      // normalizeTrackerConfigs() au prochain boot. Les trackers integres se gerent
+      // via « Ajouter / Configurer les actifs », pas via ce formulaire de creation.
+      if (isDefaultTracker(config.id)) {
+        return res.status(409).json({ ok: false, error: `L'identifiant « ${config.id} » est reserve a un tracker integre. Configure-le depuis « Configurer les actifs ».` });
       }
+
       saveTrackerConfig(config);
-      trackers = loadTrackerConfigsFromDb();
+      trackers = normalizeTrackerConfigs();
       res.json({ ok: true, tracker: config });
     } catch (err: unknown) {
       res.status(400).json({
@@ -3165,6 +3381,170 @@ export async function start(): Promise<void> {
         error: err instanceof Error ? err.message : String(err),
       });
     }
+  });
+
+  // Test reel d'une definition de tracker AVANT enregistrement : on tente un
+  // login + fetch complet avec la vraie mecanique (fetchTracker), sans persister
+  // la config. On sauvegarde temporairement la config + identifiants pour que les
+  // helpers de session/cookie/TOTP (indexes par tracker.id) fonctionnent, puis on
+  // restaure l'etat anterieur quoi qu'il arrive.
+  app.post('/api/trackers/test', async (req, res) => {
+    const body = req.body ?? {};
+    const { config, error } = sanitizeTrackerConfigInput(body.config, { isNew: true });
+    if (!config) return res.status(400).json({ ok: false, error });
+
+    const username = typeof body.username === 'string' ? body.username.trim() : '';
+    const password = typeof body.password === 'string' ? body.password : '';
+    const cookie = typeof body.cookie === 'string' ? body.cookie : '';
+    const totp = typeof body.totp === 'string' ? body.totp : '';
+
+    if (!config.login.cookieOnly && (!username || !password)) {
+      return res.status(400).json({ ok: false, error: 'Utilisateur et mot de passe requis pour tester (sauf mode cookie uniquement).' });
+    }
+    if (config.login.cookieOnly && !cookie) {
+      return res.status(400).json({ ok: false, error: 'Mode cookie uniquement : colle un cookie de session pour tester.' });
+    }
+
+    // Snapshot de l'etat existant pour restauration.
+    const existing = loadTrackerConfigsFromDb().find(t => t.id === config.id) ?? null;
+    const prevCookie = getTrackerCookie(config.id);
+    const prevTotp = getTrackerTotpSecret(config.id);
+    const prevCreds = getTrackerCredentials(config.id);
+
+    try {
+      saveTrackerConfig({ ...config, enabled: true });
+      if (cookie) setTrackerCookie(config.id, cookie);
+      if (totp) setTrackerTotpSecret(config.id, totp);
+      if (username && password) saveTrackerCredentials(config.id, username, password);
+      invalidateSession(config.id);
+
+      // Meme garde qu'en production : si aucun proxy et connexion directe interdite,
+      // le test doit le signaler clairement plutot que d'echouer de maniere opaque.
+      if (!proxyAllowsTrackerConnections()) {
+        return res.status(200).json({
+          ok: false,
+          error: 'Connexions aux trackers bloquees : aucun proxy actif et connexion directe non autorisee. Active un proxy ou autorise la connexion directe dans Proxies.',
+        });
+      }
+
+      const stat = await fetchTracker(
+        { ...config, enabled: true },
+        { username, password },
+      );
+      const fields = stat.fields ?? {};
+      if (stat.status !== 'ok' || Object.keys(fields).length === 0) {
+        return res.status(200).json({
+          ok: false,
+          error: stat.error || 'Aucune donnee extraite — verifie les regex/chemins des champs.',
+        });
+      }
+      res.json({ ok: true, stat: { fields, status: stat.status, byteUnit: stat.byteUnit } });
+    } catch (err: unknown) {
+      res.status(200).json({
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      // Restauration de l'etat anterieur (la config testee ne doit pas fuiter).
+      invalidateSession(config.id);
+      if (existing) saveTrackerConfig(existing);
+      else deleteTrackerConfig(config.id);
+      setTrackerCookie(config.id, prevCookie);
+      setTrackerTotpSecret(config.id, prevTotp);
+      if (prevCreds) saveTrackerCredentials(config.id, prevCreds.username, prevCreds.password);
+      else if (!existing) deleteTrackerCredentials(config.id);
+      trackers = normalizeTrackerConfigs();
+    }
+  });
+
+  app.delete('/api/trackers/:trackerId', (req, res) => {
+    const trackerId = req.params.trackerId;
+    if (isDefaultTracker(trackerId)) {
+      return res.status(403).json({ ok: false, error: 'Tracker integre : non supprimable (utilise « Retirer » pour le desactiver).' });
+    }
+    const exists = loadTrackerConfigsFromDb().some(t => t.id === trackerId);
+    if (!exists) return res.status(404).json({ ok: false, error: 'Tracker introuvable' });
+
+    invalidateSession(trackerId);
+    deleteTrackerConfig(trackerId);
+    setTrackerCookie(trackerId, '');
+    setTrackerTotpSecret(trackerId, '');
+    trackers = normalizeTrackerConfigs();
+    res.json({ ok: true });
+  });
+
+  // Liste des moteurs disponibles pour le mode guidé (sans les presets volumineux).
+  app.get('/api/tracker-engines', (_req, res) => {
+    res.json({ ok: true, engines: listEngines() });
+  });
+
+  // Renvoie le preset complet (login/fetch/dashboard…) d'un moteur donné.
+  app.get('/api/tracker-engines/:engineId/preset', (req, res) => {
+    const tpl = getEngineTemplate(req.params.engineId);
+    if (!tpl) return res.status(404).json({ ok: false, error: 'Moteur inconnu' });
+    res.json({ ok: true, engine: tpl.id, preset: tpl.preset, hint: tpl.hint, label: tpl.label });
+  });
+
+  // Détection auto du moteur depuis l'URL du site : GET HTTP d'abord, navigateur
+  // en repli si le HTTP échoue ou ne suffit pas (JS/Cloudflare). Fallback déclaratif
+  // côté client si on ne détecte rien. Best-effort, ne persiste rien.
+  app.post('/api/tracker-engines/detect', async (req, res) => {
+    let baseUrl = String(req.body?.baseUrl ?? '').trim();
+    if (!/^https?:\/\//i.test(baseUrl)) {
+      return res.status(400).json({ ok: false, error: 'URL invalide : commence par http:// ou https://' });
+    }
+    baseUrl = baseUrl.replace(/\/+$/, '');
+
+    // On tente quelques pages probables de login (là où les marqueurs sont les plus nets).
+    const candidates = [`${baseUrl}/login`, `${baseUrl}/login.php`, baseUrl];
+    let html = '';
+    let via: 'http' | 'browser' | null = null;
+    let reachable = false;
+
+    // 1) GET HTTP rapide (UA navigateur), sur chaque candidate jusqu'à obtenir du HTML.
+    for (const url of candidates) {
+      try {
+        const r = await axios.get(url, {
+          timeout: 12_000,
+          maxRedirects: 5,
+          validateStatus: () => true,
+          responseType: 'text',
+          headers: { 'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:135.0) Gecko/20100101 Firefox/135.0', 'Accept': 'text/html,*/*;q=0.8' },
+        });
+        if (typeof r.data === 'string' && r.data.length > 0) {
+          reachable = true;
+          html = r.data;
+          via = 'http';
+          if (detectEngineFromHtml(html, baseUrl)) break; // marqueur trouvé, inutile de continuer
+        }
+      } catch {
+        // candidate suivante
+      }
+    }
+
+    let engine = detectEngineFromHtml(html, baseUrl);
+
+    // 2) Repli navigateur si le HTTP n'a rien donné de concluant (JS/anti-bot).
+    if (!engine) {
+      for (const url of candidates) {
+        const rendered = await fetchRawHtmlWithBrowser(url).catch(() => '');
+        if (rendered && rendered.length > 0) {
+          reachable = true;
+          html = rendered;
+          via = 'browser';
+          engine = detectEngineFromHtml(rendered, baseUrl);
+          if (engine) break;
+        }
+      }
+    }
+
+    res.json({
+      ok: true,
+      reachable,
+      via,                 // 'http' | 'browser' | null
+      engine,              // EngineId | null (null => fallback déclaratif côté UI)
+      preset: engine ? getEngineTemplate(engine)?.preset ?? null : null,
+    });
   });
 
   // ── Proxy settings ─────────────────────────────────────────────────────────
@@ -3204,7 +3584,7 @@ export async function start(): Promise<void> {
     const credentials = new Map(listTrackerCredentialSummaries().map(c => [c.trackerId, c]));
     const configured = new Map(trackers.map(tracker => [tracker.id, tracker]));
     res.json({
-      credentials: listTrackerDefinitionFiles()
+      credentials: listAllTrackerSummaries()
         .map(definition => {
           const tracker = configured.get(definition.id);
           return {
@@ -3422,7 +3802,7 @@ export async function start(): Promise<void> {
   // ── Cookie de session manuel (sites a CAPTCHA / Cloudflare Turnstile) ──────
   app.post('/api/trackers/:trackerId/cookie', async (req, res) => {
     const id = req.params.trackerId;
-    if (!new Set(listTrackerDefinitionFiles().map(t => t.id)).has(id)) {
+    if (!new Set(listAllTrackerSummaries().map(t => t.id)).has(id)) {
       return res.status(404).json({ ok: false, error: 'Tracker inconnu' });
     }
     const cookie = typeof req.body?.cookie === 'string' ? req.body.cookie : '';
@@ -3439,7 +3819,7 @@ export async function start(): Promise<void> {
   // ── Secret TOTP (2FA) par tracker ─────────────────────────────────────────
   app.post('/api/trackers/:trackerId/totp', (req, res) => {
     const id = req.params.trackerId;
-    if (!new Set(listTrackerDefinitionFiles().map(t => t.id)).has(id)) {
+    if (!new Set(listAllTrackerSummaries().map(t => t.id)).has(id)) {
       return res.status(404).json({ ok: false, error: 'Tracker inconnu' });
     }
     const secret = typeof req.body?.secret === 'string' ? req.body.secret : '';

--- a/src/trackerTemplates.ts
+++ b/src/trackerTemplates.ts
@@ -1,0 +1,279 @@
+// ─── Templates de moteurs de trackers (mode guidé) ────────────────────────────
+// Chaque template encode la structure login + fetch typique d'une famille de
+// logiciels de tracker. Les valeurs proviennent des définitions réelles présentes
+// dans config/trackers/ (Redacted pour Gazelle, Seedpool/TheOldSchool pour UNIT3D,
+// TorrentLeech, MyAnonamouse, C411 pour l'API JSON) — pas de devinette.
+//
+// Un template fournit des DÉFAUTS pré-remplis dans le formulaire guidé : l'utilisateur
+// n'a plus qu'à renseigner nom, URL et identifiants. Il peut tout ajuster ensuite.
+
+import { type TrackerConfig } from './types.js';
+
+export type EngineId = 'unit3d' | 'gazelle' | 'torrentleech' | 'mam' | 'jsonapi' | 'other';
+
+export interface EngineTemplate {
+  id: EngineId;
+  label: string;
+  /** Description courte affichée dans le sélecteur du mode guidé. */
+  description: string;
+  /** Exemples de trackers connus tournant sous ce moteur (aide à la reconnaissance). */
+  examples: string[];
+  /** Aide spécifique : comment reconnaître ce moteur, où trouver les infos. */
+  hint: string;
+  /** Fragment de config pré-rempli (login + fetch + options), sans id/name/baseUrl. */
+  preset: Pick<TrackerConfig, 'login' | 'fetch'> & Partial<Pick<TrackerConfig, 'curlBinary' | 'ratioless' | 'dashboard'>>;
+}
+
+export const ENGINE_TEMPLATES: Record<EngineId, EngineTemplate> = {
+  unit3d: {
+    id: 'unit3d',
+    label: 'UNIT3D',
+    description: 'Moteur moderne très répandu (interface épurée, barre de ratio en haut).',
+    examples: ['Seedpool', 'Aither', 'Blutopia', 'GenerationFree', 'TheOldSchool'],
+    hint: "Si la page de connexion affiche un formulaire « auth-form » et que ton profil montre une barre Uploaded/Downloaded/Ratio stylée, c'est UNIT3D. Login : ton nom d'utilisateur + mot de passe.",
+    preset: {
+      login: {
+        url: 'login',
+        method: 'POST',
+        contentType: 'form',
+        preStep: {
+          url: 'login',
+          includeHiddenInputs: true,
+          extract: {
+            _csrf: { regex: '(?:name="_token"[^>]*?\\svalue="|name="csrf-token"[^>]*?\\scontent=")(?<value>[^"]+)"' },
+          },
+        },
+        body: {
+          _token: '{{_csrf}}',
+          username: '{{username}}',
+          password: '{{password}}',
+          remember: 'on',
+        },
+        failurePatterns: [
+          'auth-form__form',
+          'type="password"',
+          'name="password"',
+        ],
+      },
+      fetch: {
+        url: '/',
+        mode: 'browser',
+        responseType: 'html',
+        fields: {
+          uploadedBytes:   { regex: 'ratio-bar__uploaded[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,]+\\s*[KMGTPE]?i?B)', transform: 'bytes' },
+          downloadedBytes: { regex: 'ratio-bar__downloaded[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,]+\\s*[KMGTPE]?i?B)', transform: 'bytes' },
+          ratio:           { regex: 'ratio-bar__ratio[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,]+)', transform: 'number' },
+          seeding:         { regex: 'ratio-bar__seeding[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>\\d+)', transform: 'integer' },
+          leeching:        { regex: 'ratio-bar__leeching[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>\\d+)', transform: 'integer' },
+        },
+      },
+      dashboard: { byteUnit: 'binary' },
+    },
+  },
+
+  gazelle: {
+    id: 'gazelle',
+    label: 'Gazelle',
+    description: 'Moteur historique (musique/general), pages login.php / index.php.',
+    examples: ['Redacted', 'Orpheus', 'BrokenStones', 'HD-Forever'],
+    hint: "Si les URLs du site finissent en .php (login.php, index.php) et que tes stats sont en haut de page (Uploaded / Downloaded / Ratio), c'est Gazelle. Login : nom d'utilisateur + mot de passe.",
+    preset: {
+      login: {
+        url: 'login.php',
+        method: 'POST',
+        contentType: 'form',
+        preStep: { url: 'login.php', extract: {}, includeHiddenInputs: true },
+        body: {
+          username: '{{username}}',
+          password: '{{password}}',
+          keeplogged: '1',
+          login: 'Log in',
+        },
+        otpField: 'qrcode_confirm',
+        failurePatterns: ['type="password"', 'name="password"'],
+      },
+      fetch: {
+        url: 'index.php',
+        mode: 'browser',
+        responseType: 'html',
+        fields: {
+          uploadedBytes:   { regex: 'id="stats_seeding"[^>]*title="Uploaded: (?<value>[^"]+)"', transform: 'bytes' },
+          downloadedBytes: { regex: 'id="stats_leeching"[^>]*title="Downloaded: (?<value>[^"]+)"', transform: 'bytes' },
+          ratio:           { regex: 'id="stats_ratio"[^>]*title="Ratio: (?<value>[^"]+)"', transform: 'number' },
+        },
+      },
+      dashboard: { byteUnit: 'binary' },
+    },
+  },
+
+  torrentleech: {
+    id: 'torrentleech',
+    label: 'TorrentLeech (et similaires)',
+    description: 'Login simple sans token, stats dans la barre du haut (title="Uploaded…").',
+    examples: ['TorrentLeech'],
+    hint: "Login direct nom d'utilisateur + mot de passe, sans étape intermédiaire. Les stats sont dans des éléments avec un attribut title (Uploaded, Downloaded, Ratio).",
+    preset: {
+      login: {
+        url: 'user/account/login/',
+        method: 'POST',
+        contentType: 'form',
+        body: { username: '{{username}}', password: '{{password}}' },
+        failurePatterns: ['Invalid Username and/or Password'],
+      },
+      fetch: {
+        url: '/',
+        mode: 'browser',
+        responseType: 'html',
+        fields: {
+          uploadedBytes:   { regex: 'title="Uploaded \\(Seeding\\)"[\\s\\S]*?<span[^>]*>(?<value>[\\d\\s.,]+\\s*(?:[KMGTPE](?:B|io|o)|B))</span>', transform: 'bytes' },
+          downloadedBytes: { regex: 'title="Downloaded \\(Leeching\\)"[\\s\\S]*?<span[^>]*>(?<value>[\\d\\s.,]+\\s*(?:[KMGTPE](?:B|io|o)|B))</span>', transform: 'bytes' },
+          ratio:           { regex: 'title="Ratio"[\\s\\S]*?<i[^>]*></i>\\s*(?<value>[\\d\\s.,]+)', transform: 'number' },
+        },
+      },
+      dashboard: { byteUnit: 'decimal' },
+    },
+  },
+
+  mam: {
+    id: 'mam',
+    label: 'MyAnonamouse (MAM)',
+    description: 'Login par email, page login.php, conservation de session recommandée.',
+    examples: ['MyAnonamouse'],
+    hint: "MAM utilise ton ADRESSE EMAIL comme identifiant (pas le pseudo). Le site plafonne les logins automatiques : si possible, colle plutôt un cookie de session (option « Cookie uniquement »).",
+    preset: {
+      login: {
+        url: 'login.php?returnto=%2Fu%2F',
+        method: 'POST',
+        contentType: 'form',
+        preStep: { url: 'login.php?returnto=%2Fu%2F', extract: {}, includeHiddenInputs: true },
+        body: {
+          email: '{{username}}',
+          password: '{{password}}',
+          rememberMe: 'yes',
+          returnto: '/u/',
+        },
+        failurePatterns: ['Not logged in!', 'name="password"', 'loginIssueBlock'],
+      },
+      fetch: {
+        url: '/u/',
+        mode: 'browser',
+        responseType: 'html',
+        fields: {
+          uploadedBytes:   { regex: 'Uploaded:[\\s\\S]{0,120}?(?<value>[\\d\\s.,]+\\s*(?:[KMGTPE]i?B|B))', transform: 'bytes' },
+          downloadedBytes: { regex: 'Downloaded:[\\s\\S]{0,120}?(?<value>[\\d\\s.,]+\\s*(?:[KMGTPE]i?B|B))', transform: 'bytes' },
+          ratio:           { regex: 'Ratio:[\\s\\S]{0,120}?(?<value>[\\d.,]+)', transform: 'number' },
+        },
+      },
+      dashboard: { byteUnit: 'binary' },
+    },
+  },
+
+  jsonapi: {
+    id: 'jsonapi',
+    label: 'API JSON (avancé)',
+    description: 'Tracker exposant une API JSON (login + stats en JSON, ex: C411).',
+    examples: ['C411'],
+    hint: "À choisir seulement si tu sais que le tracker expose une API JSON (login via /api/auth/login, stats via /api/auth/me…). Les champs s'extraient par chemin (ex: user.uploaded), pas par regex.",
+    preset: {
+      login: {
+        url: 'login',
+        postUrl: 'api/auth/login',
+        method: 'POST',
+        contentType: 'json',
+        preStep: {
+          url: 'login',
+          extract: { _csrf: { regex: '<meta name="csrf-token" content="(?<value>[^"]+)"' } },
+        },
+        csrfHeader: 'csrf-token',
+        body: { username: '{{username}}', password: '{{password}}' },
+        successField: 'authenticated',
+        failurePatterns: ['"message":"Unauthenticated', '"authenticated":false'],
+      },
+      fetch: {
+        url: 'api/auth/me',
+        mode: 'http',
+        responseType: 'json',
+        fields: {
+          uploadedBytes:   { path: 'user.uploaded', transform: 'bytes' },
+          downloadedBytes: { path: 'user.downloaded', transform: 'bytes' },
+          ratio:           { path: 'user.ratio', transform: 'number' },
+        },
+      },
+      dashboard: { byteUnit: 'decimal' },
+    },
+  },
+
+  other: {
+    id: 'other',
+    label: 'Autre / inconnu',
+    description: "Le moteur n'est pas dans la liste : formulaire guidé champ par champ, à remplir soi-même.",
+    examples: [],
+    hint: "On part d'un formulaire de login classique (nom d'utilisateur + mot de passe). Tu ajusteras les champs et les regex de stats selon ton site. Le bouton « Tester » t'aidera à valider.",
+    preset: {
+      login: {
+        url: 'login.php',
+        method: 'POST',
+        contentType: 'form',
+        body: { username: '{{username}}', password: '{{password}}' },
+        failurePatterns: ['type="password"', 'name="password"'],
+      },
+      fetch: {
+        url: '/',
+        mode: 'browser',
+        responseType: 'html',
+        fields: {
+          uploadedBytes:   { regex: '(?<value>[\\d.,]+\\s*[KMGTP]?i?B)', transform: 'bytes' },
+          ratio:           { regex: 'Ratio[:\\s]*(?<value>[\\d.,]+)', transform: 'number' },
+        },
+      },
+      dashboard: { byteUnit: 'decimal' },
+    },
+  },
+};
+
+/** Liste publique (pour l'UI) sans les presets volumineux. */
+export function listEngines(): Array<Pick<EngineTemplate, 'id' | 'label' | 'description' | 'examples' | 'hint'>> {
+  return Object.values(ENGINE_TEMPLATES).map(({ id, label, description, examples, hint }) => ({
+    id, label, description, examples, hint,
+  }));
+}
+
+export function getEngineTemplate(id: string): EngineTemplate | null {
+  return (ENGINE_TEMPLATES as Record<string, EngineTemplate>)[id] ?? null;
+}
+
+/**
+ * Détecte le moteur à partir du HTML d'une page (login de préférence) et de l'URL.
+ * Heuristiques basées sur des marqueurs distinctifs. Renvoie null si rien de sûr.
+ * Volontairement conservateur : mieux vaut « inconnu » qu'un faux positif qui
+ * pré-remplirait de mauvaises regex.
+ */
+export function detectEngineFromHtml(html: string, baseUrl: string): EngineId | null {
+  const h = (html || '').toLowerCase();
+  const url = (baseUrl || '').toLowerCase();
+
+  // UNIT3D : classe de formulaire très spécifique + Laravel _token.
+  if (h.includes('auth-form__form') || (h.includes('name="_token"') && h.includes('unit3d'))) {
+    return 'unit3d';
+  }
+  // TorrentLeech : domaine ou endpoint de login caractéristique.
+  if (url.includes('torrentleech') || h.includes('user/account/login')) {
+    return 'torrentleech';
+  }
+  // MyAnonamouse : libellé/branding distinctif.
+  if (url.includes('myanonamouse') || h.includes('my anonamouse') || h.includes('loginissueblock')) {
+    return 'mam';
+  }
+  // Gazelle : le champ "keeplogged" est très spécifique à Gazelle. On exige ce
+  // marqueur précis plutôt qu'un simple "login.php + username + password" qui
+  // matcherait beaucoup de moteurs maison (IPTorrents, TBDev, XBTit…).
+  if (h.includes('name="keeplogged"') || h.includes("name='keeplogged'")) {
+    return 'gazelle';
+  }
+  // UNIT3D (repli) : barre de ratio spécifique. On NE retombe PAS sur un
+  // "auth-form" générique seul, trop ambigu.
+  if (h.includes('ratio-bar__')) {
+    return 'unit3d';
+  }
+  return null;
+}


### PR DESCRIPTION
Cette PR permet à chaque utilisateur d'ajouter son propre tracker absent de la configuration intégrée, entièrement depuis l'UI, sans toucher au code ni à l'image Docker. Elle corrige aussi l'affichage des unités d'octets.

## Ajout de trackers personnalisés

Deux parcours, accessibles depuis le menu **Configuration** :

- **Mode guidé (assistant)** — flux en 4 étapes : *adresse → détection automatique du moteur → identifiants → vérification*. La détection lit la page de login du site (GET HTTP, puis navigateur en repli si protection anti-bot) et reconnaît **UNIT3D**, **Gazelle**, **TorrentLeech**, **MyAnonamouse** et les **API JSON**, avec repli déclaratif si le moteur n'est pas reconnu. Préremplit toute la configuration à partir de modèles extraits des définitions réelles du dépôt.
- **Mode expert** — formulaire complet exposant *tous* les champs (login avec corps clé/valeur, preStep CSRF, 2FA, fetch avec champs dynamiques regex/JSON, transforms…), pour les cas non couverts par un modèle.

Les deux disposent d'un bouton **« Tester la connexion »** qui exécute un vrai login + fetch avant l'enregistrement, sans rien persister.

## Stockage

Les trackers persos sont stockés en base **SQLite** (`tracker_configs`), sur le volume monté — **jamais dans l'image**. Ils survivent aux mises à jour d'image et ne sont jamais écrasés par `normalizeTrackerConfigs()` (qui ne resynchronise que les trackers embarqués dans `default-trackers/`).

Routes ajoutées : création, test, suppression (réservée aux trackers persos), liste et détection des moteurs. Les trackers présents *uniquement en base* sont désormais fusionnés dans « Configurer les actifs » pour pouvoir y poser identifiants, cookie et 2FA.

## Unités d'octets fidèles au site

L'unité d'affichage (GB décimal vs GiB binaire) est désormais **détectée automatiquement au scraping** depuis la chaîne lue (`10 GB` → décimal, `10 GiB` → binaire) et **persistée par tracker**. Plus de réglage manuel : chaque tracker affiche dans sa propre convention.

Sur la page **Graphiques** :
- les graphes d'un seul tracker suivent l'unité de ce tracker ;
- les graphes superposant plusieurs trackers imposent une **unité commune** (décimal par défaut, car une comparaison exige le même axe) ;
- un sélecteur d'unité (*Auto / Décimale / Binaire*) a été ajouté.

## Fichiers

| Fichier | Rôle |
|---|---|
| `src/trackerTemplates.ts` *(nouveau)* | Modèles de moteurs + détection |
| `src/server.ts` | Routes de gestion des trackers persos, validation |
| `src/db.ts` | Helpers suppression / détection tracker intégré |
| `src/fetcher.ts` | Détection et persistance de l'unité d'octets |
| `src/browserFetcher.ts` | Récupération HTML éphémère pour la détection |
| `public/index.html` | UI guidée + expert, sélecteur d'unité des graphiques |

## Tests

- `tsc` sans erreur, syntaxe JS frontend validée
- 50 contrats d'intégration front↔back
- Détection de moteur **8/8**, détection d'unité **11/11**
- Flux complet bout-en-bout sur serveur réel : création → test → identifiants → cookie/2FA → suppression ; bascule d'unité GB/GiB persistée au refresh
- ✅ **Validé en conditions réelles avec IPTorrents** via le mode guidé : ajout depuis l'UI (stocké en base, absent du code), lecture correcte de l'upload, et affichage de l'unité aligné sur le site (`10 GB`) après détection automatique