### PR TITLE
chore(deps): bump undici (corrige la vuln high bloquant la CI)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2237,9 +2237,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"


### PR DESCRIPTION
## Problème

L'étape CI `npm audit --omit=dev --audit-level=high` (job *Node build*) échouait sur **toutes** les PR (ex. #74, #75) à cause d'une vulnérabilité **high** dans `undici` (transitif via `cheerio`) :
- GHSA-vmh5-mc38-953g — bypass de validation de certificat TLS via SOCKS5 ProxyAgent ;
- GHSA-pr7r-676h-xcf6 — fuite d'info via cache.

## Correctif

`npm audit fix` : `undici` 7.25.0 → **7.28.0** (patché). Seul `package-lock.json` change (3 lignes), `package.json` inchangé.

## Validation
- `npm ci` puis `npm audit --omit=dev --audit-level=high` : **0 vulnérabilité**.
- `npm run build` : OK · `npm run check:integration` : OK.