### PR TITLE
Corriger le tar embarqué par npm dans l'image Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM node:22-bookworm-slim AS builder
 
 WORKDIR /app
+ARG NPM_VERSION=11.17.0
+RUN npm install -g "npm@${NPM_VERSION}" \
+  && node -e "const v=require('/usr/local/lib/node_modules/npm/node_modules/tar/package.json').version; const [a,b,c]=v.split('.').map(Number); if (a < 7 || (a === 7 && (b < 5 || (b === 5 && c < 16)))) throw new Error('npm embeds vulnerable tar '+v); console.log('npm tar', v);"
 COPY package*.json tsconfig.json ./
 RUN npm install && npm install --no-save playwright@1.60.0 top-user-agents@2.1.111
 COPY src/ ./src/
@@ -10,6 +13,9 @@ RUN npm run build
 FROM node:22-bookworm-slim
 
 WORKDIR /app
+ARG NPM_VERSION=11.17.0
+RUN npm install -g "npm@${NPM_VERSION}" \
+  && node -e "const v=require('/usr/local/lib/node_modules/npm/node_modules/tar/package.json').version; const [a,b,c]=v.split('.').map(Number); if (a < 7 || (a === 7 && (b < 5 || (b === 5 && c < 16)))) throw new Error('npm embeds vulnerable tar '+v); console.log('npm tar', v);"
 ARG APP_IMAGE_SOURCE=local
 ARG APP_IMAGE_VERSION=dev
 ARG APP_IMAGE_REVISION=unknown


### PR DESCRIPTION
﻿## Résumé

- met à jour `npm` vers `11.17.0` dans les deux stages Docker
- corrige le `tar` embarqué par npm afin de couvrir `CVE-2026-53655`
- ajoute un contrôle de build qui échoue si le `tar` embarqué reste inférieur à `7.5.16`

## Validation

- `npm.cmd run build`
- `npm.cmd run check:integration`
- `git diff --check`

## Note

- Le build image et le scan Trivy seront validés par les checks GitHub.
