### PR TITLE
fix(trackers): ne plus afficher comme actifs les trackers par défaut sans identifiants

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -252,6 +252,39 @@ export function importLegacyTrackersIfNeeded(): void {
   syncDefaultTrackerDefinitions();
 }
 
+// Migration corrective unique. L'import legacy (importLegacyTrackersIfNeeded) inscrit en
+// base TOUS les fichiers de trackers livres avec l'image, avec enabled=true, y compris ceux
+// que l'utilisateur n'a jamais configures. Resultat : des trackers sans aucun identifiant
+// apparaissaient comme « actifs » dans le menu « Configurer les actifs » et dans les
+// tableaux de graphiques, et manquaient dans « Ajouter un tracker ». On les remet une seule
+// fois en « disponibles » (enabled=false). On ne touche jamais :
+//   - un tracker perso (non livre dans l'image, isDefaultTracker === false) ;
+//   - un tracker reellement configure (mot de passe, cookie de session ou secret 2FA).
+const DISABLE_UNCREDENTIALED_DEFAULTS_KEY = 'migration_disable_uncredentialed_default_trackers_v1';
+
+export function disableUncredentialedDefaultTrackersOnce(): void {
+  if (getJsonSetting(DISABLE_UNCREDENTIALED_DEFAULTS_KEY, { done: false }).done) return;
+
+  const withPassword = new Set(
+    listTrackerCredentialSummaries()
+      .filter(credential => credential.hasPassword)
+      .map(credential => credential.trackerId),
+  );
+  const hasAnyCredential = (trackerId: string): boolean =>
+    withPassword.has(trackerId)
+    || hasTrackerCookie(trackerId)
+    || hasTrackerTotpSecret(trackerId);
+
+  for (const config of loadTrackerConfigsFromDb()) {
+    if (config.enabled === false) continue;        // deja disponible
+    if (!isDefaultTracker(config.id)) continue;    // tracker perso : on n'y touche pas
+    if (hasAnyCredential(config.id)) continue;     // reellement configure : reste actif
+    saveTrackerConfig({ ...config, enabled: false });
+  }
+
+  setJsonSetting(DISABLE_UNCREDENTIALED_DEFAULTS_KEY, { done: true });
+}
+
 export function syncDefaultTrackerDefinitions(): void {
   if (!fs.existsSync(DEFAULT_TRACKERS_DIR)) return;
   const trackersDir = path.join(CONFIG_DIR, 'trackers');

--- a/src/server.ts
+++ b/src/server.ts
@@ -29,6 +29,7 @@ import {
   deleteTrackerConfig,
   isDefaultTracker,
   getTrackerCredentials,
+  disableUncredentialedDefaultTrackersOnce,
   importLegacyCredentialsIfNeeded,
   importLegacySettingsIfNeeded,
   importLegacyTrackersIfNeeded,
@@ -3017,6 +3018,7 @@ export async function start(): Promise<void> {
   importLegacySettingsIfNeeded();
   importLegacyCredentialsIfNeeded();
   importLegacyTrackersIfNeeded();
+  disableUncredentialedDefaultTrackersOnce();
   let trackers = normalizeTrackerConfigs();
 
   const app = express();


### PR DESCRIPTION
## Contexte

Corrige les issues #66 et #67, deux symptômes d'une même cause.

L'import initial des trackers (`importLegacyTrackersIfNeeded`) inscrit en base **tous** les fichiers de trackers livrés avec l'image, avec `enabled=true` — y compris ceux que l'utilisateur n'a jamais configurés. Conséquences pour une base passée par ce seed :

- **#67** : ces trackers apparaissent dans « Configurer les actifs » et manquent dans « Ajouter un tracker », car les menus se basent sur le flag `enabled`.
- **#66** : étant activés, ils sont rafraîchis et polluent les tableaux de graphiques.

## Correctif

Migration corrective **unique** (`disableUncredentialedDefaultTrackersOnce`), verrouillée par un flag en `settings`, jouée une seule fois au démarrage après l'import legacy. Elle repasse en `enabled=false` les trackers **par défaut** activés qui n'ont **aucun identifiant** (ni mot de passe, ni cookie de session, ni secret 2FA).

Garde-fous :

- ne touche jamais un tracker perso (`isDefaultTracker === false`) ;
- ne touche jamais un tracker réellement configuré ;
- one-shot : le flux « j'ajoute un tracker puis je saisis ses identifiants » reste intact.

Un tracker désactivé n'étant plus rafraîchi, il disparaît aussi des graphes : les deux issues tombent avec ce seul changement.

## Validation

- `npm run build`
- `npm run check:integration`
- `git diff --check`

Closes #66
Closes #67
