### PR TITLE
fix(webui): masquer réellement les entrées Graphiques/Calendrier désactivées

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -198,6 +198,9 @@
       text-align: left;
       transition: color .15s, background .15s;
     }
+    /* L'attribut [hidden] doit l'emporter sur le display:flex de .nav-item (meme
+       specificite : sans cette regle, masquer une entree via el.hidden reste sans effet). */
+    .nav-item[hidden], .nav-group[hidden] { display: none !important; }
     .nav-item:hover { color: var(--text); background: color-mix(in srgb, var(--bg) 60%, transparent); }
     .nav-item.active { color: var(--accent); border-left-color: var(--accent); background: rgba(74,222,128,.06); }
     .nav-icon { width: 16px; text-align: center; font-size: 14px; flex-shrink: 0; }


### PR DESCRIPTION
## Problème

Sur la page **Affichage**, cocher/décocher « Activer les graphiques » / « Activer le calendrier » puis enregistrer ne changeait rien dans la barre latérale : les entrées restaient visibles.

## Cause

`applyBetaFeatureVisibility()` masque les entrées via `el.hidden = true`. Or le bouton porte la classe `.nav-item { display: flex }`, de **même spécificité** que la règle navigateur `[hidden] { display: none }` mais déclarée **après** dans la feuille de styles — elle l'emporte donc, et l'attribut `hidden` reste sans effet visuel. Le réglage était bien enregistré côté serveur, seul l'affichage ne suivait pas.

## Correctif

Ajoute une règle CSS ciblée :

```css
.nav-item[hidden], .nav-group[hidden] { display: none !important; }
```

Le masquage par `hidden` prend désormais effet. Les sections de page (`.tab-view`) sont pilotées par la classe `.active` et ne sont pas concernées.

## Validation

- `npm run check:integration`
- `git diff --check`
