### PR TITLE
feat(trackers): ajout IPTorrents

### DIFF
--- a/config/trackers/iptorrents.json
+++ b/config/trackers/iptorrents.json
@@ -4,7 +4,7 @@
   "baseUrl": "https://www.iptorrents.com",
   "enabled": true,
   "login": {
-    "url": "take_login.php",
+    "url": "do-login.php",
     "method": "POST",
     "contentType": "form",
     "body": {
@@ -12,12 +12,12 @@
       "password": "{{password}}"
     },
     "failurePatterns": [
-      "take_login.php",
+      "do-login.php",
+      "iPT &ndash; Sign In",
+      "iPT – Sign In",
       "name=\"password\"",
-      "name='password'",
       "type=\"password\""
-    ],
-    "cookieOnly": true
+    ]
   },
   "fetch": {
     "url": "/",

--- a/config/trackers/iptorrents.json
+++ b/config/trackers/iptorrents.json
@@ -1,0 +1,48 @@
+{
+  "id": "iptorrents",
+  "name": "IPTorrents",
+  "baseUrl": "https://www.iptorrents.com",
+  "enabled": true,
+  "login": {
+    "url": "take_login.php",
+    "method": "POST",
+    "contentType": "form",
+    "body": {
+      "username": "{{username}}",
+      "password": "{{password}}"
+    },
+    "failurePatterns": [
+      "take_login.php",
+      "name=\"password\"",
+      "name='password'",
+      "type=\"password\""
+    ],
+    "cookieOnly": true
+  },
+  "fetch": {
+    "url": "/",
+    "mode": "browser",
+    "responseType": "html",
+    "fields": {
+      "uploadedBytes": {
+        "regex": ">Uploaded</div>\\s*<i[^>]*></i>\\s*(?<value>[\\d.,]+\\s*(?:[KMGTPE]i?B|B))",
+        "transform": "bytes"
+      },
+      "downloadedBytes": {
+        "regex": ">Downloaded</div>\\s*<i[^>]*></i>\\s*(?<value>[\\d.,]+\\s*(?:[KMGTPE]i?B|B))",
+        "transform": "bytes"
+      },
+      "ratio": {
+        "regex": "c_ratio[\\s\\S]{0,120}?</i>\\s*(?<value>[\\d.,]+)",
+        "transform": "number"
+      },
+      "seedBonus": {
+        "regex": ">Bonus Points</div>\\s*<i[^>]*></i>\\s*(?<value>[\\d.,]+)",
+        "transform": "string"
+      }
+    }
+  },
+  "dashboard": {
+    "byteUnit": "decimal"
+  }
+}


### PR DESCRIPTION
## Résumé
Ajoute IPTorrents à la bibliothèque de trackers intégrés (`config/trackers/iptorrents.json`).

## Détails techniques
- **Moteur** : IPTorrents (legacy PHP).
- **Login** : automatique via POST sur `do-login.php` (champs `username` / `password`). Pas de CAPTCHA ni de token CSRF — login direct, aucune intervention manuelle requise.
- **Fetch** : `mode: browser`, parsing des stats de la barre supérieure ancré sur les libellés (`Uploaded` / `Downloaded` / `Bonus Points`) + ratio via `c_ratio`.
- **Unité** : `decimal` (IPTorrents affiche « GB » sans `i`).

## Tests
- Regex validées sur le HTML réel de la barre de stats.
- Login automatique validé depuis un état vierge (profil navigateur supprimé, sans cookie pré-injecté) : `Login+fetch OK` → `Stats OK` (uploadedBytes, downloadedBytes, seedBonus remontent correctement).
- Ratio : non capturé sur un compte sans download (le site affiche `-`), l'interface affiche alors `∞`. Se remplira dès qu'il y aura du download — comportement attendu, pas un bug.

## Migration
Les users qui avaient ajouté IPTorrents manuellement (custom) récupèrent automatiquement cette définition au prochain boot via `normalizeTrackerConfigs()` (écrasement de `login`/`fetch`/`curlBinary`). Identifiants et préférences préservés.