### PR TITLE
chore: ignorer logos auto, .DS_Store, @eaDir Synology et compose dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ config/credentials.json
 config/tracker-dashboard.sqlite*
 config/browser-profile/
 config/debug/
+config/logos/auto/
+.DS_Store
+@eaDir/
+docker-compose.dev.yml


### PR DESCRIPTION
Ajoute au .gitignore :
- `config/logos/auto/` — logos téléchargés automatiquement au runtime
- `.DS_Store` — fichiers macOS
- `@eaDir/` — vignettes Synology
- `docker-compose.dev.yml` — compose de dev local (chemins spécifiques NAS)

Nettoie le `git status` (ces fichiers apparaissaient en untracked).