### PR TITLE
feat(webui): régler la taille des cartes du dashboard

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -149,6 +149,11 @@
     }
     .nav-subcontrol:hover { color: var(--text); background: color-mix(in srgb, var(--bg) 60%, transparent); }
     .nav-subcontrol .nav-subcontrol-icon { width: 16px; text-align: center; flex-shrink: 0; }
+    /* Curseur de taille des cartes (visible uniquement en vue cartes) */
+    .nav-cardsize { cursor: default; gap: 10px; }
+    .nav-cardsize:hover { background: none; color: var(--text2); }
+    .nav-cardsize input[type="range"] { flex: 1; min-width: 0; height: 4px; accent-color: var(--accent); cursor: pointer; }
+    .nav-cardsize #cardsize-value { font-variant-numeric: tabular-nums; min-width: 36px; text-align: right; }
     /* Bas de barre : horodatage + bascule de thème */
     .sidebar-updated { padding: 8px 16px 2px; font-size: 11px; color: var(--muted); text-align: center; }
     .theme-switch {
@@ -330,7 +335,7 @@
 
     #grid {
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(320px, 320px));
+      grid-template-columns: repeat(auto-fit, minmax(var(--card-width, 320px), var(--card-width, 320px)));
       justify-content: center;
       align-content: start;
       align-items: stretch;
@@ -340,7 +345,7 @@
     }
     #beta-grid {
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(320px, 320px));
+      grid-template-columns: repeat(auto-fit, minmax(var(--card-width, 320px), var(--card-width, 320px)));
       justify-content: center;
       align-content: start;
       align-items: stretch;
@@ -1766,6 +1771,10 @@
   <button class="nav-subcontrol" id="view-toggle" onclick="toggleViewMode()" type="button" title="Basculer entre vue cartes et vue lignes">
     <span class="nav-subcontrol-icon">▦</span> <span id="view-toggle-label">Vue lignes</span>
   </button>
+  <div class="nav-subcontrol nav-cardsize" id="cardsize-control" title="Taille des cartes (100% = taille par défaut)">
+    <input id="cardsize-range" type="range" min="60" max="160" step="5" value="100" oninput="applyCardWidth(this.value)" aria-label="Taille des cartes" />
+    <span id="cardsize-value">100%</span>
+  </div>
 
   <button class="nav-item" data-nav="graphs" onclick="showView('graphs')" type="button">
     <span class="nav-icon">▤</span> Graphiques
@@ -5328,11 +5337,38 @@
     localStorage.setItem('tracker-dashboard-view', viewMode);
     const label = document.getElementById('view-toggle-label');
     if (label) label.textContent = viewMode === 'rows' ? 'Vue cartes' : 'Vue lignes';
+    // Le curseur de taille n'a de sens qu'en vue cartes.
+    const cardsize = document.getElementById('cardsize-control');
+    if (cardsize) cardsize.hidden = viewMode === 'rows';
     renderGrid();
   }
 
   function loadViewMode() {
     applyViewMode(localStorage.getItem('tracker-dashboard-view') || 'cards');
+  }
+
+  // ── Taille des cartes (vue cartes) ──────────────────────────────────────────
+  // 100% = largeur par defaut (320px). Reglage persiste en localStorage : il
+  // survit a la fermeture de l'onglet comme au redemarrage du serveur.
+  const CARD_WIDTH_BASE_PX = 320;
+  const CARD_WIDTH_MIN_PCT = 60;
+  const CARD_WIDTH_MAX_PCT = 160;
+
+  function applyCardWidth(pct) {
+    const value = Math.round(Number(pct));
+    const clamped = Math.min(CARD_WIDTH_MAX_PCT, Math.max(CARD_WIDTH_MIN_PCT, Number.isFinite(value) ? value : 100));
+    const widthPx = Math.round(CARD_WIDTH_BASE_PX * clamped / 100);
+    document.documentElement.style.setProperty('--card-width', widthPx + 'px');
+    const range = document.getElementById('cardsize-range');
+    if (range && Number(range.value) !== clamped) range.value = clamped;
+    const label = document.getElementById('cardsize-value');
+    if (label) label.textContent = clamped + '%';
+    localStorage.setItem('tracker-dashboard-card-width', String(clamped));
+  }
+
+  function loadCardWidth() {
+    const saved = parseInt(localStorage.getItem('tracker-dashboard-card-width') || '100', 10);
+    applyCardWidth(Number.isFinite(saved) ? saved : 100);
   }
 
   function toggleViewMode() {
@@ -6504,6 +6540,7 @@
     loadTheme();
     await showMigrationNoticeIfNeeded();
     loadViewMode();
+    loadCardWidth();
     loadBetaSettings();
     await loadBetaSettingsFromServer();
     loadActiveView();


### PR DESCRIPTION
## Objectif

Permettre de redimensionner les cartes du dashboard en vue cartes, avec un réglage persistant.

## Fonctionnement

- Un curseur est ajouté dans la barre latérale, juste sous le bouton **Vue** (cartes/lignes).
- Échelle en **pourcentage** : 100 % = taille par défaut (320 px), plage **60 % – 160 %**, pas de 5 %.
- La largeur est pilotée par une variable CSS `--card-width` appliquée à `#grid` et `#beta-grid` (valeur de repli 320px conservée).
- Le curseur n'apparaît **qu'en vue cartes** (masqué en vue lignes).

## Persistance

Le réglage est mémorisé dans `localStorage` (clé `tracker-dashboard-card-width`), exactement comme le choix cartes/lignes existant (`tracker-dashboard-view`). Il est donc conservé :

- à la fermeture puis réouverture de l'onglet/navigateur ;
- au redémarrage du serveur (le réglage est côté client).

L'initialisation se fait dans `init()` via `loadCardWidth()`, avant tout appel réseau, donc robuste même si l'API n'a pas encore répondu.

## Validation

- `npm run check:integration`
- `git diff --check`
- Vérification de syntaxe du script inline (0 erreur)

## Test manuel suggéré

Sur le dashboard en vue cartes : déplacer le curseur → les cartes s'élargissent/rétrécissent en direct, la valeur en % se met à jour. Recharger la page → la taille est conservée. Passer en vue lignes → le curseur disparaît.
