### PR TITLE
chore(trackers): aligner les JSON sur les fields hardcodes (preparation migration)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ config/credentials.json
 config/tracker-dashboard.sqlite*
 config/browser-profile/
 config/debug/
+config/logos/auto/
+.DS_Store
+@eaDir/
+docker-compose.dev.yml

--- a/config/trackers/abnormal.json
+++ b/config/trackers/abnormal.json
@@ -10,14 +10,16 @@
     "preStep": {
       "url": "Home/Login",
       "extract": {
-        "_csrf": { "regex": "name=\"__RequestVerificationToken\"[^>]*value=\"(?<value>[^\"]+)\"" }
+        "_csrf": {
+          "regex": "name=\"__RequestVerificationToken\"[^>]*value=\"(?<value>[^\"]+)\""
+        }
       }
     },
     "body": {
-      "Username":                   "{{username}}",
-      "Password":                   "{{password}}",
+      "Username": "{{username}}",
+      "Password": "{{password}}",
       "__RequestVerificationToken": "{{_csrf}}",
-      "RememberMe":                 "false"
+      "RememberMe": "false"
     },
     "failurePatterns": [
       "Mot de passe ou nom d'utilisateur incorrect",
@@ -28,11 +30,29 @@
     "url": "/",
     "responseType": "html",
     "fields": {
-      "uploadedBytes":   { "regex": "Up\\s*:[\\s\\S]{0,360}?text-green[\\s\\S]{0,120}?(?<value>[\\d\\s.,]+\\s*(?:[KMGTPE](?:i?B|io|o)|B))",   "transform": "bytes"  },
-      "downloadedBytes": { "regex": "Down\\s*:[\\s\\S]{0,360}?text-green[\\s\\S]{0,120}?(?<value>[\\d\\s.,]+\\s*(?:[KMGTPE](?:i?B|io|o)|B))", "transform": "bytes"  },
-      "ratio":           { "regex": "Ratio\\s*:[\\s\\S]{0,360}?text-green[\\s\\S]{0,120}?(?<value>[\\d\\s.,]+)",                             "transform": "number" },
-      "seedBonus":       { "regex": "Choco's\\s*:[\\s\\S]{0,360}?text-green[\\s\\S]{0,120}?(?<value>[\\d\\s.,]+)",                            "transform": "string" }
+      "uploadedBytes": {
+        "regex": "Up\\s*:[\\s\\S]{0,360}?text-green[\\s\\S]{0,120}?(?<value>[\\d\\s.,]+\\s*(?:[KMGTPE](?:i?B|io|o)|B))",
+        "transform": "bytes"
+      },
+      "downloadedBytes": {
+        "regex": "Down\\s*:[\\s\\S]{0,360}?text-green[\\s\\S]{0,120}?(?<value>[\\d\\s.,]+\\s*(?:[KMGTPE](?:i?B|io|o)|B))",
+        "transform": "bytes"
+      },
+      "ratio": {
+        "regex": "Ratio\\s*:[\\s\\S]{0,360}?text-green[\\s\\S]{0,120}?(?<value>[\\d\\s.,]+)",
+        "transform": "number"
+      },
+      "seedBonus": {
+        "regex": "Choco's\\s*:[\\s\\S]{0,360}?text-green[\\s\\S]{0,120}?(?<value>[\\d\\s.,]+)",
+        "transform": "string"
+      },
+      "unreadMessages": {
+        "regex": "(?<value>\\d+|\\bun) nouveau\\(x\\) message",
+        "transform": "string"
+      }
     }
   },
-  "dashboard": { "byteUnit": "decimal" }
+  "dashboard": {
+    "byteUnit": "decimal"
+  }
 }

--- a/config/trackers/g3mini.json
+++ b/config/trackers/g3mini.json
@@ -10,7 +10,9 @@
     "preStep": {
       "url": "login",
       "extract": {
-        "_csrf": { "regex": "name=\"_token\"\\s+value=\"(?<value>[^\"]+)\"" }
+        "_csrf": {
+          "regex": "name=\"_token\"\\s+value=\"(?<value>[^\"]+)\""
+        }
       },
       "includeHiddenInputs": true
     },
@@ -32,15 +34,45 @@
     "url": "/",
     "responseType": "html",
     "fields": {
-      "uploadedBytes":   { "regex": "ratio-bar__uploaded[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,]+\\s*[KMGTPE]?i?B)",   "transform": "bytes"   },
-      "downloadedBytes": { "regex": "ratio-bar__downloaded[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,]+\\s*[KMGTPE]?i?B)", "transform": "bytes"   },
-      "ratio":           { "regex": "ratio-bar__ratio[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,]+)",                   "transform": "number"  },
-      "seeding":         { "regex": "ratio-bar__seeding[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>\\d+)",                      "transform": "integer" },
-      "leeching":        { "regex": "ratio-bar__leeching[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>\\d+)",                     "transform": "integer" },
-      "seedBonus":       { "regex": "ratio-bar__points[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,\\u202f]+)",           "transform": "string"  },
-      "bufferBytes":     { "regex": "ratio-bar__buffer[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,]+\\s*[KMGTPE]?i?B)",   "transform": "bytes"   },
-      "tokens":          { "regex": "ratio-bar__tokens[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>\\d+)",                       "transform": "integer" }
+      "uploadedBytes": {
+        "regex": "ratio-bar__uploaded[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,]+\\s*[KMGTPE]?i?B)",
+        "transform": "bytes"
+      },
+      "downloadedBytes": {
+        "regex": "ratio-bar__downloaded[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,]+\\s*[KMGTPE]?i?B)",
+        "transform": "bytes"
+      },
+      "ratio": {
+        "regex": "ratio-bar__ratio[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,]+)",
+        "transform": "number"
+      },
+      "seeding": {
+        "regex": "ratio-bar__seeding[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>\\d+)",
+        "transform": "integer"
+      },
+      "leeching": {
+        "regex": "ratio-bar__leeching[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>\\d+)",
+        "transform": "integer"
+      },
+      "seedBonus": {
+        "regex": "ratio-bar__points[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,\\u202f]+)",
+        "transform": "string"
+      },
+      "bufferBytes": {
+        "regex": "ratio-bar__buffer[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,]+\\s*[KMGTPE]?i?B)",
+        "transform": "bytes"
+      },
+      "tokens": {
+        "regex": "ratio-bar__tokens[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>\\d+)",
+        "transform": "integer"
+      },
+      "unreadMessages": {
+        "regex": "Boîte de réception(?:(?!<\\/a>)[\\s\\S])*?<animate[^>]*?dur=\"(?<value>[^\"]+)\"",
+        "transform": "string"
+      }
     }
   },
-  "dashboard": { "byteUnit": "binary" }
+  "dashboard": {
+    "byteUnit": "binary"
+  }
 }

--- a/config/trackers/generationfree.json
+++ b/config/trackers/generationfree.json
@@ -10,7 +10,9 @@
     "preStep": {
       "url": "login",
       "extract": {
-        "_csrf": { "regex": "name=\"_token\"\\s+value=\"(?<value>[^\"]+)\"" }
+        "_csrf": {
+          "regex": "name=\"_token\"\\s+value=\"(?<value>[^\"]+)\""
+        }
       },
       "includeHiddenInputs": true
     },
@@ -30,15 +32,45 @@
     "url": "/",
     "responseType": "html",
     "fields": {
-      "uploadedBytes":   { "regex": "ratio-bar__uploaded[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,]+\\s*[KMGTPE]?i?B)",   "transform": "bytes"   },
-      "downloadedBytes": { "regex": "ratio-bar__downloaded[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,]+\\s*[KMGTPE]?i?B)", "transform": "bytes"   },
-      "ratio":           { "regex": "ratio-bar__ratio[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,]+)",                   "transform": "number"  },
-      "seeding":         { "regex": "ratio-bar__seeding[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>\\d+)",                      "transform": "integer" },
-      "leeching":        { "regex": "ratio-bar__leeching[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>\\d+)",                     "transform": "integer" },
-      "seedBonus":       { "regex": "ratio-bar__points[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,\\u202f]+)",           "transform": "string"  },
-      "bufferBytes":     { "regex": "ratio-bar__buffer[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,]+\\s*[KMGTPE]?i?B)",   "transform": "bytes"   },
-      "tokens":          { "regex": "ratio-bar__tokens[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>\\d+)",                       "transform": "integer" }
+      "uploadedBytes": {
+        "regex": "ratio-bar__uploaded[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,]+\\s*[KMGTPE]?i?B)",
+        "transform": "bytes"
+      },
+      "downloadedBytes": {
+        "regex": "ratio-bar__downloaded[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,]+\\s*[KMGTPE]?i?B)",
+        "transform": "bytes"
+      },
+      "ratio": {
+        "regex": "ratio-bar__ratio[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,]+)",
+        "transform": "number"
+      },
+      "seeding": {
+        "regex": "ratio-bar__seeding[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>\\d+)",
+        "transform": "integer"
+      },
+      "leeching": {
+        "regex": "ratio-bar__leeching[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>\\d+)",
+        "transform": "integer"
+      },
+      "seedBonus": {
+        "regex": "ratio-bar__points[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,\\u202f]+)",
+        "transform": "string"
+      },
+      "bufferBytes": {
+        "regex": "ratio-bar__buffer[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,]+\\s*[KMGTPE]?i?B)",
+        "transform": "bytes"
+      },
+      "tokens": {
+        "regex": "ratio-bar__tokens[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>\\d+)",
+        "transform": "integer"
+      },
+      "unreadMessages": {
+        "regex": "Boîte de réception(?:(?!<\\/a>)[\\s\\S])*?<animate[^>]*?dur=\"(?<value>[^\"]+)\"",
+        "transform": "string"
+      }
     }
   },
-  "dashboard": { "byteUnit": "binary" }
+  "dashboard": {
+    "byteUnit": "binary"
+  }
 }

--- a/config/trackers/hdforever.json
+++ b/config/trackers/hdforever.json
@@ -44,8 +44,14 @@
       "seedBonus": {
         "regex": "action=rate[^>]+>(?<value>[\\d,]+)<",
         "transform": "string"
+      },
+      "unreadMessages": {
+        "regex": "data-notification-type=['\"]Inbox['\"][^>]*>[^<]*?(?<value>\\d+|\\bun) nouveau",
+        "transform": "string"
       }
     }
   },
-  "dashboard": { "byteUnit": "decimal" }
+  "dashboard": {
+    "byteUnit": "decimal"
+  }
 }

--- a/config/trackers/hdonly.json
+++ b/config/trackers/hdonly.json
@@ -9,10 +9,10 @@
     "method": "POST",
     "contentType": "form",
     "body": {
-      "username":   "{{username}}",
-      "password":   "{{password}}",
+      "username": "{{username}}",
+      "password": "{{password}}",
       "keeplogged": "1",
-      "login":      "Se connecter"
+      "login": "Se connecter"
     },
     "failurePatterns": [
       "Identifiant ou mot de passe incorrect",
@@ -23,9 +23,21 @@
     "url": "index.php",
     "responseType": "html",
     "fields": {
-      "uploadedBytes":   { "regex": "Envoy[ée]\\s*:\\s*(?<value>[\\d\\.,]+\\s*[KMGTPE]?i?B)", "transform": "bytes" },
-      "downloadedBytes": { "regex": "Re[çc]u\\s*:\\s*(?<value>[\\d\\.,]+\\s*[KMGTPE]?i?B)",   "transform": "bytes" }
+      "uploadedBytes": {
+        "regex": "Envoy[\\s\\S]{0,160}?(?<value>[\\d\\s.,]+\\s*[KMGTPE]?i?B)",
+        "transform": "bytes"
+      },
+      "downloadedBytes": {
+        "regex": "Re[\\s\\S]{0,160}?(?<value>[\\d\\s.,]+\\s*[KMGTPE]?i?B)",
+        "transform": "bytes"
+      },
+      "unreadMessages": {
+        "regex": "data-notification-type=['\"]Inbox['\"][^>]*>[^<]*?(?<value>\\d+|\\bun) nouveau",
+        "transform": "string"
+      }
     }
   },
-  "dashboard": { "byteUnit": "decimal" }
+  "dashboard": {
+    "byteUnit": "decimal"
+  }
 }

--- a/config/trackers/seedpool.json
+++ b/config/trackers/seedpool.json
@@ -10,11 +10,13 @@
     "preStep": {
       "url": "login",
       "extract": {
-        "_csrf": { "regex": "name=\"_token\"\\s+value=\"(?<value>[^\"]+)\"" }
+        "_csrf": {
+          "regex": "name=\"_token\"\\s+value=\"(?<value>[^\"]+)\""
+        }
       }
     },
     "body": {
-      "_token":   "{{_csrf}}",
+      "_token": "{{_csrf}}",
       "username": "{{username}}",
       "password": "{{password}}",
       "remember": "on"
@@ -33,13 +35,45 @@
     "mode": "browser",
     "responseType": "html",
     "fields": {
-      "uploadedBytes":   { "regex": "ratio-bar__uploaded[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,]+\\s*[KMGTPE]?i?B)",  "transform": "bytes"   },
-      "downloadedBytes": { "regex": "ratio-bar__downloaded[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,]+\\s*[KMGTPE]?i?B)", "transform": "bytes"   },
-      "ratio":           { "regex": "ratio-bar__ratio[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,]+)",                      "transform": "number"  },
-      "seeding":         { "regex": "ratio-bar__seeding[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>\\d+)",                           "transform": "integer" },
-      "leeching":        { "regex": "ratio-bar__leeching[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>\\d+)",                          "transform": "integer" },
-      "seedBonus":       { "regex": "ratio-bar__points[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,\\u202f]+)",              "transform": "string"  }
+      "uploadedBytes": {
+        "regex": "ratio-bar__uploaded[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,]+\\s*[KMGTPE]?i?B)",
+        "transform": "bytes"
+      },
+      "downloadedBytes": {
+        "regex": "ratio-bar__downloaded[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,]+\\s*[KMGTPE]?i?B)",
+        "transform": "bytes"
+      },
+      "ratio": {
+        "regex": "ratio-bar__ratio[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,]+)",
+        "transform": "number"
+      },
+      "seeding": {
+        "regex": "ratio-bar__seeding[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>\\d+)",
+        "transform": "integer"
+      },
+      "leeching": {
+        "regex": "ratio-bar__leeching[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>\\d+)",
+        "transform": "integer"
+      },
+      "seedBonus": {
+        "regex": "ratio-bar__points[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,\\u202f]+)",
+        "transform": "string"
+      },
+      "bufferBytes": {
+        "regex": "ratio-bar__buffer[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,]+\\s*[KMGTPE]?i?B)",
+        "transform": "bytes"
+      },
+      "tokens": {
+        "regex": "ratio-bar__tokens[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>\\d+)",
+        "transform": "integer"
+      },
+      "unreadMessages": {
+        "regex": "Boîte de réception(?:(?!<\\/a>)[\\s\\S])*?<animate[^>]*?dur=\"(?<value>[^\"]+)\"",
+        "transform": "string"
+      }
     }
   },
-  "dashboard": { "byteUnit": "binary" }
+  "dashboard": {
+    "byteUnit": "binary"
+  }
 }

--- a/config/trackers/sextorrent.json
+++ b/config/trackers/sextorrent.json
@@ -10,11 +10,13 @@
     "preStep": {
       "url": "login",
       "extract": {
-        "_csrf": { "regex": "name=\"_token\"\\s+value=\"(?<value>[^\"]+)\"" }
+        "_csrf": {
+          "regex": "name=\"_token\"\\s+value=\"(?<value>[^\"]+)\""
+        }
       }
     },
     "body": {
-      "_token":   "{{_csrf}}",
+      "_token": "{{_csrf}}",
       "username": "{{username}}",
       "password": "{{password}}",
       "remember": "on"
@@ -31,13 +33,45 @@
     "url": "/",
     "responseType": "html",
     "fields": {
-      "uploadedBytes":   { "regex": "ratio-bar__uploaded[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,]+\\s*[KMGTPE]?i?B)",  "transform": "bytes"   },
-      "downloadedBytes": { "regex": "ratio-bar__downloaded[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,]+\\s*[KMGTPE]?i?B)", "transform": "bytes"   },
-      "ratio":           { "regex": "ratio-bar__ratio[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,]+)",                      "transform": "number"  },
-      "seeding":         { "regex": "ratio-bar__seeding[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>\\d+)",                           "transform": "integer" },
-      "leeching":        { "regex": "ratio-bar__leeching[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>\\d+)",                          "transform": "integer" },
-      "seedBonus":       { "regex": "ratio-bar__points[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,\\u202f]+)",              "transform": "string"  }
+      "uploadedBytes": {
+        "regex": "ratio-bar__uploaded[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,]+\\s*[KMGTPE]?i?B)",
+        "transform": "bytes"
+      },
+      "downloadedBytes": {
+        "regex": "ratio-bar__downloaded[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,]+\\s*[KMGTPE]?i?B)",
+        "transform": "bytes"
+      },
+      "ratio": {
+        "regex": "ratio-bar__ratio[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,]+)",
+        "transform": "number"
+      },
+      "seeding": {
+        "regex": "ratio-bar__seeding[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>\\d+)",
+        "transform": "integer"
+      },
+      "leeching": {
+        "regex": "ratio-bar__leeching[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>\\d+)",
+        "transform": "integer"
+      },
+      "seedBonus": {
+        "regex": "ratio-bar__points[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,\\u202f]+)",
+        "transform": "string"
+      },
+      "bufferBytes": {
+        "regex": "ratio-bar__buffer[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,]+\\s*[KMGTPE]?i?B)",
+        "transform": "bytes"
+      },
+      "tokens": {
+        "regex": "ratio-bar__tokens[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>\\d+)",
+        "transform": "integer"
+      },
+      "unreadMessages": {
+        "regex": "Boîte de réception(?:(?!<\\/a>)[\\s\\S])*?<animate[^>]*?dur=\"(?<value>[^\"]+)\"",
+        "transform": "string"
+      }
     }
   },
-  "dashboard": { "byteUnit": "binary" }
+  "dashboard": {
+    "byteUnit": "binary"
+  }
 }

--- a/config/trackers/teamflix.json
+++ b/config/trackers/teamflix.json
@@ -10,7 +10,9 @@
     "preStep": {
       "url": "login",
       "extract": {
-        "_csrf": { "regex": "name=\"_token\"\\s+value=\"(?<value>[^\"]+)\"" }
+        "_csrf": {
+          "regex": "name=\"_token\"\\s+value=\"(?<value>[^\"]+)\""
+        }
       },
       "includeHiddenInputs": true
     },
@@ -30,15 +32,45 @@
     "url": "/",
     "responseType": "html",
     "fields": {
-      "uploadedBytes":   { "regex": "ratio-bar__uploaded[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,]+\\s*[KMGTPE]?i?B)",   "transform": "bytes"   },
-      "downloadedBytes": { "regex": "ratio-bar__downloaded[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,]+\\s*[KMGTPE]?i?B)", "transform": "bytes"   },
-      "ratio":           { "regex": "ratio-bar__ratio[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,]+)",                   "transform": "number"  },
-      "seeding":         { "regex": "ratio-bar__seeding[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>\\d+)",                      "transform": "integer" },
-      "leeching":        { "regex": "ratio-bar__leeching[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>\\d+)",                     "transform": "integer" },
-      "seedBonus":       { "regex": "ratio-bar__points[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,\\u202f]+)",           "transform": "string"  },
-      "bufferBytes":     { "regex": "ratio-bar__buffer[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,]+\\s*[KMGTPE]?i?B)",   "transform": "bytes"   },
-      "tokens":          { "regex": "ratio-bar__tokens[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>\\d+)",                       "transform": "integer" }
+      "uploadedBytes": {
+        "regex": "ratio-bar__uploaded[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,]+\\s*[KMGTPE]?i?B)",
+        "transform": "bytes"
+      },
+      "downloadedBytes": {
+        "regex": "ratio-bar__downloaded[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,]+\\s*[KMGTPE]?i?B)",
+        "transform": "bytes"
+      },
+      "ratio": {
+        "regex": "ratio-bar__ratio[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,]+)",
+        "transform": "number"
+      },
+      "seeding": {
+        "regex": "ratio-bar__seeding[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>\\d+)",
+        "transform": "integer"
+      },
+      "leeching": {
+        "regex": "ratio-bar__leeching[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>\\d+)",
+        "transform": "integer"
+      },
+      "seedBonus": {
+        "regex": "ratio-bar__points[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,\\u202f]+)",
+        "transform": "string"
+      },
+      "bufferBytes": {
+        "regex": "ratio-bar__buffer[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,]+\\s*[KMGTPE]?i?B)",
+        "transform": "bytes"
+      },
+      "tokens": {
+        "regex": "ratio-bar__tokens[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>\\d+)",
+        "transform": "integer"
+      },
+      "unreadMessages": {
+        "regex": "Boîte de réception(?:(?!<\\/a>)[\\s\\S])*?<animate[^>]*?dur=\"(?<value>[^\"]+)\"",
+        "transform": "string"
+      }
     }
   },
-  "dashboard": { "byteUnit": "binary" }
+  "dashboard": {
+    "byteUnit": "binary"
+  }
 }

--- a/config/trackers/theoldschool.json
+++ b/config/trackers/theoldschool.json
@@ -10,11 +10,13 @@
     "preStep": {
       "url": "login",
       "extract": {
-        "_csrf": { "regex": "name=\"_token\"\\s+value=\"(?<value>[^\"]+)\"" }
+        "_csrf": {
+          "regex": "name=\"_token\"\\s+value=\"(?<value>[^\"]+)\""
+        }
       }
     },
     "body": {
-      "_token":   "{{_csrf}}",
+      "_token": "{{_csrf}}",
       "username": "{{username}}",
       "password": "{{password}}"
     },
@@ -27,13 +29,45 @@
     "url": "/",
     "responseType": "html",
     "fields": {
-      "uploadedBytes":   { "regex": "top-nav__stats-up[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\.,]+\\s*[KMGTPE]?i?B)",       "transform": "bytes"   },
-      "downloadedBytes": { "regex": "top-nav__stats-down[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\.,]+\\s*[KMGTPE]?i?B)",     "transform": "bytes"   },
-      "ratio":           { "regex": "top-nav__stats-ratio[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\.,]+)",                   "transform": "number"  },
-      "seeding":         { "regex": "ratio-bar__seeding[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>\\d+)",                          "transform": "integer" },
-      "leeching":        { "regex": "ratio-bar__leeching[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>\\d+)",                         "transform": "integer" },
-      "seedBonus":       { "regex": "ratio-bar__points[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s., ]+)",                   "transform": "string"  }
+      "uploadedBytes": {
+        "regex": "ratio-bar__uploaded[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,]+\\s*[KMGTPE]?i?B)",
+        "transform": "bytes"
+      },
+      "downloadedBytes": {
+        "regex": "ratio-bar__downloaded[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,]+\\s*[KMGTPE]?i?B)",
+        "transform": "bytes"
+      },
+      "ratio": {
+        "regex": "ratio-bar__ratio[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,]+)",
+        "transform": "number"
+      },
+      "seeding": {
+        "regex": "ratio-bar__seeding[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>\\d+)",
+        "transform": "integer"
+      },
+      "leeching": {
+        "regex": "ratio-bar__leeching[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>\\d+)",
+        "transform": "integer"
+      },
+      "seedBonus": {
+        "regex": "ratio-bar__points[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,\\u202f]+)",
+        "transform": "string"
+      },
+      "bufferBytes": {
+        "regex": "ratio-bar__buffer[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,]+\\s*[KMGTPE]?i?B)",
+        "transform": "bytes"
+      },
+      "tokens": {
+        "regex": "ratio-bar__tokens[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>\\d+)",
+        "transform": "integer"
+      },
+      "unreadMessages": {
+        "regex": "Boîte de réception(?:(?!<\\/a>)[\\s\\S])*?<animate[^>]*?dur=\"(?<value>[^\"]+)\"",
+        "transform": "string"
+      }
     }
   },
-  "dashboard": { "byteUnit": "binary" }
+  "dashboard": {
+    "byteUnit": "binary"
+  }
 }


### PR DESCRIPTION


    Première étape de la consolidation « tout en JSON » .

    Aligne 9 fichiers config/trackers/*.json sur la valeur  actuellement portée par knownTrackerFields dans server.ts : regex corrigées (hdonly, theoldschool) et ajout des fields manquants (unreadMessages sur 9 trackers, bufferBytes/tokens sur les UNIT3D concernés).

    Aucun effet runtime : knownTrackerFields écrase toujours ces champs au boot. C'est une préparation sans risque, mergeable seule. La suppression du hardcode et le mécanisme engine viendront dans une PR dédiée (étape 2).

    Vérifié : les 9 JSON sont strictement identiques au hardcode (0 écart, regex + transform), JSON valides, et le rebuild dev démarre proprement sans erreur de normalisation.