### PR TITLE
feat(trackers): presets moteur reutilisables (UNIT3D/Gazelle/...) via le champ engine JSON

### DIFF
--- a/public/login.html
+++ b/public/login.html
@@ -8,12 +8,13 @@
   <title>Tracker Dashboard - Login</title>
   <style>
     :root {
-      --bg: #0f1117;
-      --surface: #1a1d27;
-      --border: #2a2d3a;
-      --text: #e2e4ed;
-      --muted: #6b7280;
-      --blue: #3b82f6;
+      --bg: #0d0f12;
+      --surface: #13161b;
+      --border: #252a35;
+      --text: #c8d0de;
+      --muted: #6b7a95;
+      --green: #4ade80;
+      --green-hover: #22c55e;
       --red: #ef4444;
     }
     * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -58,23 +59,26 @@
       font-size: 14px;
       margin-bottom: 14px;
     }
-    input:focus { outline: none; border-color: var(--blue); }
+    input:focus { outline: none; border-color: var(--green); }
     button {
       width: 100%;
-      background: var(--blue);
-      color: #fff;
+      background: var(--green);
+      color: #0d0f12;
       border: 0;
       border-radius: 8px;
       padding: 10px 14px;
       font-size: 14px;
+      font-weight: 600;
       cursor: pointer;
+      transition: background 0.15s;
     }
+    button:hover { background: var(--green-hover); }
     #error { color: var(--red); min-height: 18px; margin-top: 12px; font-size: 13px; }
   </style>
 </head>
 <body>
   <form onsubmit="submitAuth(event)">
-    <img class="login-logo" src="/logo.png" alt="Tracker Dashboard" />
+    <img class="login-logo" src="/logo-dark.png" alt="Tracker Dashboard" />
     <h1 id="title">Tracker Dashboard</h1>
     <p id="subtitle">Connexion requise</p>
     <label for="username">Utilisateur</label>

--- a/src/server.ts
+++ b/src/server.ts
@@ -704,6 +704,51 @@ const COOKIE_ONLY_TRACKERS = new Set([
   'tr4ker',       // Cloudflare + login SPA
   'yggreborn',    // Cloudflare Turnstile
 ]);
+
+/**
+ * Applique le preset moteur (ENGINE_TEMPLATES) à une config qui déclare `engine`.
+ * RÈGLE D'OR : le JSON du tracker gagne TOUJOURS sur le preset, champ par champ.
+ * - login / dashboard / curlBinary / ratioless : le bloc du JSON, s'il est présent,
+ *   remplace celui du preset (au niveau du bloc login, on fusionne clé par clé pour
+ *   qu'un tracker puisse surcharger seulement `url` sans réécrire body/preStep/…).
+ * - fetch.fields : MERGE field par field (preset d'abord, JSON ensuite) pour qu'un
+ *   site au skin modifié puisse surcharger 2 fields sur 9 sans réécrire les 7 autres.
+ * - fetch (hors fields) : le JSON gagne champ par champ.
+ * Un tracker sans `engine`, ou avec un `engine` inconnu, est renvoyé inchangé.
+ * Idempotent : ré-appliquer ne change rien.
+ */
+function applyEnginePreset(config: TrackerConfig): TrackerConfig {
+  if (!config.engine) return config;
+  const tpl = getEngineTemplate(config.engine);
+  if (!tpl) return config;
+  const preset = tpl.preset;
+
+  // login : preset comme base, le JSON surcharge clé par clé.
+  const mergedLogin = { ...preset.login, ...config.login };
+
+  // fetch : preset comme base, le JSON surcharge clé par clé, SAUF fields qui mergent.
+  const mergedFields = {
+    ...(preset.fetch?.fields ?? {}),
+    ...(config.fetch?.fields ?? {}),
+  };
+  const mergedFetch = { ...preset.fetch, ...config.fetch, fields: mergedFields };
+
+  // dashboard : preset comme base, JSON surcharge clé par clé.
+  const mergedDashboard =
+    config.dashboard || preset.dashboard
+      ? { ...(preset.dashboard ?? {}), ...(config.dashboard ?? {}) }
+      : undefined;
+
+  return {
+    ...config,
+    curlBinary: config.curlBinary ?? preset.curlBinary,
+    ratioless: config.ratioless ?? preset.ratioless,
+    login: mergedLogin,
+    fetch: mergedFetch,
+    ...(mergedDashboard ? { dashboard: mergedDashboard } : {}),
+  };
+}
+
 function normalizeTrackerConfigs(): TrackerConfig[] {
   const trackers = loadTrackerConfigsFromDb();
   for (const tracker of trackers) {
@@ -728,6 +773,33 @@ function normalizeTrackerConfigs(): TrackerConfig[] {
       }
       if (tracker.curlBinary !== definition.curlBinary) {
         tracker.curlBinary = definition.curlBinary;
+        changed = true;
+      }
+    }
+    // Mécanisme `engine` : si le tracker déclare une famille de moteur, on applique
+    // le preset (ENGINE_TEMPLATES) — le JSON gagne toujours sur le preset (cf.
+    // applyEnginePreset). Tant qu'aucun JSON ne porte `engine`, ceci est un no-op.
+    // À terme, ce mécanisme remplace les patches par-tracker ci-dessous.
+    if (tracker.engine) {
+      const merged = applyEnginePreset(tracker);
+      if (JSON.stringify(merged.login) !== JSON.stringify(tracker.login)) {
+        tracker.login = merged.login;
+        changed = true;
+      }
+      if (JSON.stringify(merged.fetch) !== JSON.stringify(tracker.fetch)) {
+        tracker.fetch = merged.fetch;
+        changed = true;
+      }
+      if (JSON.stringify(merged.dashboard) !== JSON.stringify(tracker.dashboard)) {
+        tracker.dashboard = merged.dashboard;
+        changed = true;
+      }
+      if (merged.curlBinary !== tracker.curlBinary) {
+        tracker.curlBinary = merged.curlBinary;
+        changed = true;
+      }
+      if (merged.ratioless !== tracker.ratioless) {
+        tracker.ratioless = merged.ratioless;
         changed = true;
       }
     }
@@ -1166,6 +1238,14 @@ function sanitizeTrackerConfigInput(
   if (input.ratioless) config.ratioless = true;
   if (input.curlBinary === 'curl_firefox133' || input.curlBinary === 'curl_firefox135') {
     config.curlBinary = input.curlBinary;
+  }
+  // engine (famille de moteur) : optionnel, doit correspondre à un preset connu.
+  if (input.engine != null && String(input.engine).trim()) {
+    const eng = String(input.engine).trim();
+    if (!getEngineTemplate(eng)) {
+      return fail(`Moteur « ${eng} » inconnu (valeurs : unit3d, gazelle, torrentleech, mam, jsonapi, other).`);
+    }
+    config.engine = eng as TrackerConfig['engine'];
   }
   const byteUnit = input.dashboard?.byteUnit;
   if (byteUnit === 'binary' || byteUnit === 'decimal') {

--- a/src/server.ts
+++ b/src/server.ts
@@ -3035,6 +3035,10 @@ export async function start(): Promise<void> {
     res.sendFile(path.join(PUBLIC_DIR, 'logo.png'));
   });
 
+  app.get('/logo-dark.png', (_req, res) => {
+    res.sendFile(path.join(PUBLIC_DIR, 'logo-dark.png'));
+  });
+
   app.get('/favicon.png', (_req, res) => {
     res.sendFile(path.join(PUBLIC_DIR, 'favicon.png'));
   });

--- a/src/trackerTemplates.ts
+++ b/src/trackerTemplates.ts
@@ -7,9 +7,9 @@
 // Un template fournit des DÉFAUTS pré-remplis dans le formulaire guidé : l'utilisateur
 // n'a plus qu'à renseigner nom, URL et identifiants. Il peut tout ajuster ensuite.
 
-import { type TrackerConfig } from './types.js';
+import { type TrackerConfig, type EngineId } from './types.js';
 
-export type EngineId = 'unit3d' | 'gazelle' | 'torrentleech' | 'mam' | 'jsonapi' | 'other';
+export type { EngineId };
 
 export interface EngineTemplate {
   id: EngineId;
@@ -65,6 +65,13 @@ export const ENGINE_TEMPLATES: Record<EngineId, EngineTemplate> = {
           ratio:           { regex: 'ratio-bar__ratio[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,]+)', transform: 'number' },
           seeding:         { regex: 'ratio-bar__seeding[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>\\d+)', transform: 'integer' },
           leeching:        { regex: 'ratio-bar__leeching[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>\\d+)', transform: 'integer' },
+          seedBonus:       { regex: 'ratio-bar__points[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,\\u202f]+)', transform: 'string' },
+          bufferBytes:     { regex: 'ratio-bar__buffer[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>[\\d\\s.,]+\\s*[KMGTPE]?i?B)', transform: 'bytes' },
+          tokens:          { regex: 'ratio-bar__tokens[\\s\\S]*?<i[^>]*>[\\s\\S]*?</i>\\s*(?<value>\\d+)', transform: 'integer' },
+          // MP non lus : UNIT3D affiche une sphère animée (<animate>) près de l'icône
+          // envelope quand il y a des MP non lus. Pas de compteur : on capture la durée
+          // d'animation comme signal de présence ; toute valeur non vide => 1 MP.
+          unreadMessages:  { regex: 'Boîte de réception(?:(?!<\\/a>)[\\s\\S])*?<animate[^>]*?dur="(?<value>[^"]+)"', transform: 'string' },
         },
       },
       dashboard: { byteUnit: 'binary' },

--- a/src/types.ts
+++ b/src/types.ts
@@ -117,11 +117,21 @@ export interface FetchStep {
   } & FieldExtractor;
 }
 
+/** Famille de moteur de tracker — voir ENGINE_TEMPLATES dans trackerTemplates.ts. */
+export type EngineId = 'unit3d' | 'gazelle' | 'torrentleech' | 'mam' | 'jsonapi' | 'other';
+
 export interface TrackerConfig {
   id: string;
   name: string;
   baseUrl: string;
   enabled?: boolean;
+  /**
+   * Famille de moteur. Si présent, les blocs login/fetch/dashboard héritent du
+   * preset moteur (ENGINE_TEMPLATES) ; les champs déclarés dans ce JSON
+   * surchargent le preset (le JSON gagne toujours, champ par champ ;
+   * fetch.fields est mergé field par field).
+   */
+  engine?: EngineId;
   /** Tracker sans systeme de ratio (HD-Only, Nostradamus, etc.) */
   ratioless?: boolean;
   /** Profil curl-impersonate autorise pour le login HTTP complet. */


### PR DESCRIPTION
Première moitié de la migration « tout en JSON » (étape 2, PR A).
Met en place le mécanisme engine sans encore l'utiliser : aucun JSON ne déclare engine, donc zéro effet runtime sur les trackers existants (vérifié : applyEnginePreset est un no-op sans engine, boot dev identique).

types.ts : type EngineId (source unique) + champ engine? sur TrackerConfig.
trackerTemplates.ts : preset unit3d enrichi de 5 à 9 fields (alignés sur la version runtime vivante) ; EngineId ré-exporté depuis types.
server.ts : applyEnginePreset (fusion preset ← JSON, le JSON gagne champ par champ, fetch.fields mergé), branché en no-op dans normalizeTrackerConfigs, et champ engine validé dans sanitizeTrackerConfigInput.

Seul effet visible : un nouveau tracker UNIT3D ajouté via le mode guidé a désormais les 9 fields (MP, bonus, buffer, tokens) au lieu de 5. Le runtime continue d'utiliser le hardcode existant — sa suppression et la bascule des JSON sur engine viendront en PR B, avec diff de non-régression.