### PR TITLE
feat(gazelle): afficher la classe de membre courante

### DIFF
--- a/config/trackers/hdforever.json
+++ b/config/trackers/hdforever.json
@@ -51,6 +51,10 @@
       "unreadMessages": {
         "regex": "data-notification-type=['\"]Inbox['\"][^>]*>[^<]*?(?<value>\\d+|\\bun) nouveau",
         "transform": "string"
+      },
+      "memberClass": {
+        "regex": "class=\"userclass\">\\((?<value>[^)]+)\\)",
+        "transform": "string"
       }
     }
   },

--- a/config/trackers/hdonly.json
+++ b/config/trackers/hdonly.json
@@ -32,6 +32,10 @@
       "unreadMessages": {
         "regex": "data-notification-type=['\"]Inbox['\"][^>]*>[^<]*?(?<value>\\d+|\\bun) nouveau",
         "transform": "string"
+      },
+      "memberClass": {
+        "regex": "id=\"pseudo\"[\\s\\S]*?\\((?<value>[^)]+)\\)",
+        "transform": "string"
       }
     }
   },

--- a/public/index.html
+++ b/public/index.html
@@ -1132,6 +1132,7 @@
     .badge-ratioless { background: color-mix(in srgb, var(--purple) 16%, transparent); color: var(--purple); }
     .badge-incident { background: color-mix(in srgb, var(--muted) 18%, transparent); color: var(--muted); }
     .badge-mp { background: color-mix(in srgb, var(--blue) 22%, transparent); color: var(--blue); }
+    .badge-memberclass { background: color-mix(in srgb, var(--muted) 18%, transparent); color: var(--muted); }
     .incident-box {
       margin: 8px 18px 12px;
       padding: 8px 10px;
@@ -2701,6 +2702,14 @@
     const n = unreadMessagesCount(stat);
     return n > 0
       ? `<span class="badge badge-mp" title="${n} message(s) prive(s) non lu(s)">MP : ${n}</span>`
+      : '';
+  }
+
+  // Classe de membre courante (champ optionnel memberClass, regex par site/preset).
+  function memberClassBadge(stat) {
+    const cls = (stat.fields || {}).memberClass;
+    return hasStatValue(cls)
+      ? `<span class="badge badge-memberclass" title="Classe de membre">${escapeHtml(String(cls))}</span>`
       : '';
   }
 
@@ -5655,7 +5664,7 @@
             ${cardRefreshButton(stat)}
           </div>
         </div>
-        <div class="card-badges">${mpBadge(stat)}${staleBadge(stat)}${ratiolessBadge(stat)}</div>
+        <div class="card-badges">${mpBadge(stat)}${memberClassBadge(stat)}${staleBadge(stat)}${ratiolessBadge(stat)}</div>
 
         <div class="stats">${hasXpFields ? xpGrid : standardGrid}
         </div>

--- a/src/trackerTemplates.ts
+++ b/src/trackerTemplates.ts
@@ -105,6 +105,10 @@ export const ENGINE_TEMPLATES: Record<EngineId, EngineTemplate> = {
           uploadedBytes:   { regex: 'id="stats_seeding"[^>]*title="Uploaded: (?<value>[^"]+)"', transform: 'bytes' },
           downloadedBytes: { regex: 'id="stats_leeching"[^>]*title="Downloaded: (?<value>[^"]+)"', transform: 'bytes' },
           ratio:           { regex: 'id="stats_ratio"[^>]*title="Ratio: (?<value>[^"]+)"', transform: 'number' },
+          // Classe de membre courante, affichee dans le header utilisateur sur la plupart
+          // des skins Gazelle (Redacted, Orpheus, Phoenix Project...). Surchargee par site
+          // quand le skin diverge (ex: HD-Forever, classe entre parentheses).
+          memberClass:     { regex: 'class="hidden userclass">(?<value>[^<]+)<', transform: 'string' },
         },
       },
       dashboard: { byteUnit: 'binary' },


### PR DESCRIPTION
  Description :
  ## Summary
  - Ajoute le champ `memberClass` dans le preset `gazelle` (`src/trackerTemplates.ts`), avec la regex commune
  `class="hidden userclass">` qui couvre Orpheus, Redacted, Phoenix Project, Empornium, KuFirc, HappyFappy et
  BrokenStones par héritage du preset.
  - Surcharge spécifique pour HD-Forever (classe entre parenthèses) et HD-Only (`li#pseudo`), dont le skin
  diffère du preset commun.
  - Affichage en badge discret sur la carte tracker du dashboard (`public/index.html`).
  - `ABNormal` volontairement exclu pour le moment : ne déclare pas `engine: gazelle` (flow de login ASP.NET différent) et
  aucun échantillon HTML confirmé.
  
  ## Test plan
  - [x] `tsc --noEmit` OK
  - [x] `node scripts/check-integration.mjs` OK
  - [x] Regex testées contre les échantillons HTML réels (Redacted, Orpheus, Phoenix Project, HD-Forever,
  HD-Only)
  - [x] Vérifié sur l'instance dev (port 3003) après rebuild — fonctionne du premier coup