### PR TITLE
Gusdezup/member class batch2

### DIFF
--- a/config/trackers/abnormal.json
+++ b/config/trackers/abnormal.json
@@ -53,6 +53,10 @@
       "unreadMessages": {
         "regex": "(?<value>\\d+|\\bun) nouveau\\(x\\) message",
         "transform": "string"
+      },
+      "memberClass": {
+        "regex": "class=\"userclass_(?<value>[A-Za-z0-9]+)",
+        "transform": "string"
       }
     }
   },

--- a/config/trackers/c411.json
+++ b/config/trackers/c411.json
@@ -37,9 +37,10 @@
     "mode": "http",
     "responseType": "json",
     "fields": {
-      "downloadedBytes": { "path": "user.downloaded", "transform": "bytes" },
-      "uploadedBytes":   { "path": "user.uploaded",   "transform": "bytes" },
-      "ratio":           { "path": "user.ratio",      "transform": "number" }
+      "downloadedBytes": { "path": "user.downloaded",  "transform": "bytes" },
+      "uploadedBytes":   { "path": "user.uploaded",    "transform": "bytes" },
+      "ratio":           { "path": "user.ratio",       "transform": "number" },
+      "memberClass":     { "path": "user.badge.label", "transform": "string" }
     },
     "unreadFetch": { "url": "api/messages/unread-count", "responseType": "json", "path": "total", "transform": "integer" }
   },

--- a/config/trackers/iptorrents.json
+++ b/config/trackers/iptorrents.json
@@ -40,6 +40,15 @@
         "regex": ">Bonus Points</div>\\s*<i[^>]*></i>\\s*(?<value>[\\d.,]+)",
         "transform": "string"
       }
+    },
+    "extraFetch": {
+      "idExtract": {
+        "regex": "href=\"/u/(?<value>\\d+)\""
+      },
+      "url": "u/{{id}}",
+      "field": "memberClass",
+      "regex": "class=\"up-class-badge\">[\\s\\S]*?<\\/svg>\\s*(?<value>[^<]+?)\\s*<\\/span>",
+      "transform": "string"
     }
   },
   "dashboard": {

--- a/config/trackers/nexum.json
+++ b/config/trackers/nexum.json
@@ -40,6 +40,12 @@
       "level":         { "regex": "Niveau\\s*(?<value>\\d+)", "transform": "integer" },
       "xp":            { "regex": "Niveau\\s*\\d+\\s*·\\s*(?<value>[\\d\\s]+?)\\s*XP", "transform": "string" },
       "unreadMessages": { "regex": "id=['\"]pm-badge['\"][^>]*>(?<value>\\d+)", "transform": "integer" }
+    },
+    "extraFetch": {
+      "url": "user/{{username}}",
+      "field": "memberClass",
+      "regex": "class=\"user-badge[^\"]*\">(?<value>[^<]+)</span>",
+      "transform": "string"
     }
   },
   "dashboard": { "byteUnit": "binary" }

--- a/config/trackers/theoldschool.json
+++ b/config/trackers/theoldschool.json
@@ -4,5 +4,13 @@
   "baseUrl": "https://theoldschool.cc",
   "enabled": true,
   "engine": "unit3d",
-  "login": {}
+  "login": {},
+  "fetch": {
+    "extraFetch": {
+      "url": "users/{{username}}",
+      "field": "memberClass",
+      "regex": "profile__username[\\s\\S]*?title=\"(?<value>[^\"]+)\"",
+      "transform": "string"
+    }
+  }
 }

--- a/config/trackers/torr9.json
+++ b/config/trackers/torr9.json
@@ -26,7 +26,8 @@
     "fields": {
       "downloadedBytes": { "path": "total_downloaded_bytes", "transform": "bytes" },
       "uploadedBytes":   { "path": "total_uploaded_bytes",   "transform": "bytes" },
-      "seedBonus":       { "path": "jeton_balance",          "transform": "integer" }
+      "seedBonus":       { "path": "jeton_balance",          "transform": "integer" },
+      "memberClass":     { "path": "role",                   "transform": "string" }
     },
     "unreadFetch": { "url": "https://api.torr9.net/api/v1/chat/unread-counts", "responseType": "json", "path": "total_dms", "transform": "integer" }
   },

--- a/config/trackers/tr4ker.json
+++ b/config/trackers/tr4ker.json
@@ -38,6 +38,12 @@
         "regex": ">DOWNLOAD<[\\s\\S]{0,180}?_statValue[^>]*>\\s*(?<value>\\d[\\d\\s.,]*\\s*(?:[KMGTPE](?:i?B|io|o)|B|o))\\s*<",
         "transform": "bytes"
       }
+    },
+    "extraFetch": {
+      "url": "api/me",
+      "field": "memberClass",
+      "regex": "\"role\":\"(?<value>[^\"]+)\"",
+      "transform": "string"
     }
   },
   "dashboard": {

--- a/config/trackers/yggreborn.json
+++ b/config/trackers/yggreborn.json
@@ -32,6 +32,10 @@
       "downloadedBytes": {
         "regex": "(?<value>\\d[\\d\\s.,]*\\s*(?:[KMGTPE](?:i?B|io|o)|B|o))\\s*</div>[\\s\\S]{0,180}?>Download<",
         "transform": "bytes"
+      },
+      "memberClass": {
+        "regex": ">R[oô]le</span>[\\s\\S]*?uppercase\"[\\s\\S]*?>(?<value>[^<]+)</span>",
+        "transform": "string"
       }
     }
   },

--- a/src/browserFetcher.ts
+++ b/src/browserFetcher.ts
@@ -767,7 +767,7 @@ async function ensureLoggedIn(
 export async function fetchWithBrowser(
   tracker: TrackerConfig,
   credentials: { username: string; password: string },
-): Promise<{ html: string; url: string; authConfirmed: boolean }> {
+): Promise<{ html: string; url: string; authConfirmed: boolean; extraHtml?: string }> {
   const context = await getContext(tracker);
   const page = await context.newPage();
   const url = resolveUrl(tracker.baseUrl, interpolate(tracker.fetch.url, {
@@ -803,7 +803,32 @@ export async function fetchWithBrowser(
       await revealMilkieStats(page);
     }
     const authConfirmed = await waitForTrackerContent(tracker, page);
-    return { html: await safeContent(page), url: page.url(), authConfirmed };
+    const html = await safeContent(page);
+
+    let extraHtml: string | undefined;
+    const ef = tracker.fetch.extraFetch;
+    if (ef) {
+      try {
+        const vars: Record<string, string> = { username: credentials.username };
+        if (ef.idExtract) {
+          const idMatch = new RegExp(ef.idExtract.regex, 's').exec(html);
+          const id = idMatch?.groups?.['value'];
+          if (id) vars.id = id;
+        }
+        if (!ef.idExtract || vars.id) {
+          const extraUrl = resolveUrl(tracker.baseUrl, interpolate(ef.url, vars));
+          await page.goto(extraUrl, { waitUntil: 'commit', timeout: 45_000 });
+          await page.waitForLoadState('domcontentloaded', { timeout: 30_000 }).catch(() => {});
+          await page.waitForLoadState('networkidle', { timeout: 10_000 }).catch(() => {});
+          extraHtml = await safeContent(page);
+        }
+      } catch {
+        // Best-effort : la page secondaire (ex. classe de membre) ne doit jamais
+        // invalider le fetch principal, deja capture dans `html`.
+      }
+    }
+
+    return { html, url: page.url(), authConfirmed, extraHtml };
   } finally {
     await page.close().catch(() => {});
     // Fermer le contexte (= le process Chromium) apres chaque fetch. Sinon, avec

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -247,6 +247,72 @@ async function fetchUnreadMessagesViaCurl(
   }, headers);
 }
 
+// Requête secondaire générique (fetch.extraFetch) : récupère un champ absent de la page
+// principale (ex. la classe de membre sur IPTorrents, exposée uniquement sur la page de
+// profil /u/<id>). Si idExtract est fourni, l'identifiant est extrait du HTML/JSON de la
+// page principale puis injecté dans extraFetch.url via le placeholder {{id}}.
+// Best-effort : toute erreur renvoie null (champ absent), sans invalider le tracker.
+export async function fetchExtraField(
+  tracker: TrackerConfig,
+  primaryBody: string,
+  request: UnreadMessagesRequest,
+  headers: Record<string, string>,
+): Promise<{ field: string; value: string | number } | null> {
+  const ef = tracker.fetch.extraFetch;
+  if (!ef) return null;
+  try {
+    let targetUrl = ef.url;
+    if (ef.idExtract) {
+      const idMatch = new RegExp(ef.idExtract.regex, 's').exec(primaryBody);
+      const id = idMatch?.groups?.['value'];
+      if (!id) return null;
+      targetUrl = targetUrl.replace('{{id}}', id);
+    }
+    const url = resolveUrl(tracker.baseUrl, targetUrl);
+    const res = await request(url, headers);
+    if (!res || res.status >= 400) return null;
+    const single: Record<string, FieldExtractor> = {
+      [ef.field]: { path: ef.path, regex: ef.regex, transform: ef.transform },
+    };
+    const rt = ef.responseType ?? (ef.path ? 'json' : 'html');
+    let out: { values: Record<string, string | number>; byteUnit: 'decimal' | 'binary' | null };
+    if (rt === 'json') {
+      let json: unknown;
+      try { json = JSON.parse(res.body); } catch { return null; }
+      out = extractJson(json, single);
+    } else {
+      out = extractHtml(res.body, single);
+    }
+    const value = out.values[ef.field];
+    return value !== undefined && value !== '' ? { field: ef.field, value } : null;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchExtraFieldViaAxios(
+  client: AxiosInstance,
+  tracker: TrackerConfig,
+  primaryBody: string,
+  headers: Record<string, string>,
+): Promise<{ field: string; value: string | number } | null> {
+  return fetchExtraField(tracker, primaryBody, async (url, requestHeaders) => {
+    const res = await client.get<string>(url, { responseType: 'text', headers: requestHeaders });
+    return { status: res.status, body: res.data };
+  }, headers);
+}
+
+async function fetchExtraFieldViaCurl(
+  session: CurlSession,
+  tracker: TrackerConfig,
+  primaryBody: string,
+  headers: Record<string, string>,
+): Promise<{ field: string; value: string | number } | null> {
+  return fetchExtraField(tracker, primaryBody, async (url, requestHeaders) => {
+    return session.request(url, { headers: requestHeaders, timeoutMs: 30_000 });
+  }, headers);
+}
+
 function writeDebugDump(
   tracker: TrackerConfig,
   url: string,
@@ -1074,6 +1140,10 @@ export async function fetchTracker(
           if (tracker.fetch.unreadFetch) {
             stats.fields.unreadMessages = await fetchUnreadMessagesViaCurl(sess, tracker, fetchHeaders);
           }
+          if (tracker.fetch.extraFetch) {
+            const extra = await fetchExtraFieldViaCurl(sess, tracker, fetchRes.body, fetchHeaders);
+            if (extra) stats.fields[extra.field] = extra.value;
+          }
           console.log(`  [${tracker.name}] Login+fetch via curl-impersonate OK (JSON/MFA)`);
           return stats;
         } catch {
@@ -1117,6 +1187,10 @@ export async function fetchTracker(
             tracker,
             { Referer: loginUrl },
           );
+        }
+        if (tracker.fetch.extraFetch) {
+          const extra = await fetchExtraFieldViaCurl(sess, tracker, fetchRes.body, { Referer: loginUrl });
+          if (extra) stats.fields[extra.field] = extra.value;
         }
         console.log(`  [${tracker.name}] Login+fetch via curl-impersonate OK (axios evite)`);
         return stats;
@@ -1258,6 +1332,12 @@ export async function fetchTracker(
     // MP non lus via requête secondaire (ex. C411) — best-effort, n'invalide pas le tracker.
     if (tracker.fetch.unreadFetch) {
       fields.unreadMessages = await fetchUnreadMessagesViaAxios(session.client, tracker, fetchHeaders);
+    }
+
+    // Champ secondaire générique (ex. classe de membre IPTorrents, page /u/<id>).
+    if (tracker.fetch.extraFetch) {
+      const extra = await fetchExtraFieldViaAxios(session.client, tracker, res.data, fetchHeaders);
+      if (extra) fields[extra.field] = extra.value;
     }
 
     const resolvedByteUnit = detectedByteUnit ?? tracker.dashboard?.byteUnit ?? 'binary';

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -923,7 +923,7 @@ export async function fetchTracker(
     password: creds.password,
   };
 
-  const buildStatsFromHtml = (url: string, html: string): TrackerStats => {
+  const buildStatsFromHtml = (url: string, html: string, extraHtml?: string): TrackerStats => {
     if (isAnubisChallenge(html)) {
       const dumpPath = writeDebugDump(tracker, url, html, {}, 'anubis');
       const suffix = dumpPath ? ` - dump: ${dumpPath}` : '';
@@ -954,6 +954,15 @@ export async function fetchTracker(
     if (missingFields.length > 0) {
       const dumpPath = writeDebugDump(tracker, url, html, fields, 'partial');
       console.log(`  [${tracker.name}] Champs manquants: ${missingFields.join(', ')}${dumpPath ? ` - dump: ${dumpPath}` : ''}`);
+    }
+
+    // Champ secondaire générique capturé via une page navigateur distincte (ex. classe
+    // de membre TR4KER, profil hydraté en JS sur une autre route). Best-effort.
+    const ef = tracker.fetch.extraFetch;
+    if (ef && extraHtml) {
+      const extra = extractHtml(extraHtml, { [ef.field]: { path: ef.path, regex: ef.regex, transform: ef.transform } });
+      const value = extra.values[ef.field];
+      if (value !== undefined && value !== '') fields[ef.field] = value;
     }
 
     // L'unité d'affichage suit ce que le site écrit réellement (« GB » -> décimal,
@@ -1238,7 +1247,7 @@ export async function fetchTracker(
         const suffix = dumpPath ? ` - dump: ${dumpPath}` : '';
         throw new Error(`Session navigateur non authentifiee - verifier les credentials ou valider le challenge dans le profil navigateur${suffix}`);
       }
-      return buildStatsFromHtml(browserResult.url, browserResult.html);
+      return buildStatsFromHtml(browserResult.url, browserResult.html, browserResult.extraHtml);
     }
 
     // Mode HTTP : on tente d'abord le login+fetch via curl-impersonate (empreinte

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -249,26 +249,28 @@ async function fetchUnreadMessagesViaCurl(
 
 // Requête secondaire générique (fetch.extraFetch) : récupère un champ absent de la page
 // principale (ex. la classe de membre sur IPTorrents, exposée uniquement sur la page de
-// profil /u/<id>). Si idExtract est fourni, l'identifiant est extrait du HTML/JSON de la
-// page principale puis injecté dans extraFetch.url via le placeholder {{id}}.
+// profil /u/<id>, ou sur Nexum via /user/<pseudo>). Le placeholder {{username}} est
+// toujours disponible (credentials du tracker) ; {{id}} est disponible si idExtract est
+// fourni (extrait du HTML/JSON de la page principale).
 // Best-effort : toute erreur renvoie null (champ absent), sans invalider le tracker.
 export async function fetchExtraField(
   tracker: TrackerConfig,
   primaryBody: string,
   request: UnreadMessagesRequest,
   headers: Record<string, string>,
+  creds: { username: string; password: string },
 ): Promise<{ field: string; value: string | number } | null> {
   const ef = tracker.fetch.extraFetch;
   if (!ef) return null;
   try {
-    let targetUrl = ef.url;
+    const vars: Record<string, string> = { username: creds.username };
     if (ef.idExtract) {
       const idMatch = new RegExp(ef.idExtract.regex, 's').exec(primaryBody);
       const id = idMatch?.groups?.['value'];
       if (!id) return null;
-      targetUrl = targetUrl.replace('{{id}}', id);
+      vars.id = id;
     }
-    const url = resolveUrl(tracker.baseUrl, targetUrl);
+    const url = resolveUrl(tracker.baseUrl, interpolate(ef.url, vars));
     const res = await request(url, headers);
     if (!res || res.status >= 400) return null;
     const single: Record<string, FieldExtractor> = {
@@ -295,11 +297,12 @@ async function fetchExtraFieldViaAxios(
   tracker: TrackerConfig,
   primaryBody: string,
   headers: Record<string, string>,
+  creds: { username: string; password: string },
 ): Promise<{ field: string; value: string | number } | null> {
   return fetchExtraField(tracker, primaryBody, async (url, requestHeaders) => {
     const res = await client.get<string>(url, { responseType: 'text', headers: requestHeaders });
     return { status: res.status, body: res.data };
-  }, headers);
+  }, headers, creds);
 }
 
 async function fetchExtraFieldViaCurl(
@@ -307,10 +310,11 @@ async function fetchExtraFieldViaCurl(
   tracker: TrackerConfig,
   primaryBody: string,
   headers: Record<string, string>,
+  creds: { username: string; password: string },
 ): Promise<{ field: string; value: string | number } | null> {
   return fetchExtraField(tracker, primaryBody, async (url, requestHeaders) => {
     return session.request(url, { headers: requestHeaders, timeoutMs: 30_000 });
-  }, headers);
+  }, headers, creds);
 }
 
 function writeDebugDump(
@@ -1141,7 +1145,7 @@ export async function fetchTracker(
             stats.fields.unreadMessages = await fetchUnreadMessagesViaCurl(sess, tracker, fetchHeaders);
           }
           if (tracker.fetch.extraFetch) {
-            const extra = await fetchExtraFieldViaCurl(sess, tracker, fetchRes.body, fetchHeaders);
+            const extra = await fetchExtraFieldViaCurl(sess, tracker, fetchRes.body, fetchHeaders, creds);
             if (extra) stats.fields[extra.field] = extra.value;
           }
           console.log(`  [${tracker.name}] Login+fetch via curl-impersonate OK (JSON/MFA)`);
@@ -1189,7 +1193,7 @@ export async function fetchTracker(
           );
         }
         if (tracker.fetch.extraFetch) {
-          const extra = await fetchExtraFieldViaCurl(sess, tracker, fetchRes.body, { Referer: loginUrl });
+          const extra = await fetchExtraFieldViaCurl(sess, tracker, fetchRes.body, { Referer: loginUrl }, creds);
           if (extra) stats.fields[extra.field] = extra.value;
         }
         console.log(`  [${tracker.name}] Login+fetch via curl-impersonate OK (axios evite)`);
@@ -1336,7 +1340,7 @@ export async function fetchTracker(
 
     // Champ secondaire générique (ex. classe de membre IPTorrents, page /u/<id>).
     if (tracker.fetch.extraFetch) {
-      const extra = await fetchExtraFieldViaAxios(session.client, tracker, res.data, fetchHeaders);
+      const extra = await fetchExtraFieldViaAxios(session.client, tracker, res.data, fetchHeaders, creds);
       if (extra) fields[extra.field] = extra.value;
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -130,10 +130,11 @@ export interface FetchStep {
   /**
    * Requête secondaire générique pour un champ absent de la page principale (ex:
    * la classe de membre sur IPTorrents, exposée uniquement sur la page de profil
-   * /u/<id>, pas sur la page d'accueil). Si `idExtract` est fourni, son resultat
-   * remplace le placeholder {{id}} dans `url` (extrait depuis le HTML/JSON de la
-   * page principale, avant la requête secondaire). Le champ extrait (path JSON ou
-   * regex HTML + transform) alimente fields.<field>.
+   * /u/<id> ; ou sur Nexum, exposée sur /user/<pseudo>). `url` supporte les
+   * placeholders {{username}} (toujours disponible, credentials du tracker) et
+   * {{id}} (disponible si `idExtract` est fourni, extrait depuis le HTML/JSON de
+   * la page principale avant la requête secondaire). Le champ extrait (path JSON
+   * ou regex HTML + transform) alimente fields.<field>.
    * Best-effort : un échec n'invalide jamais le tracker.
    */
   extraFetch?: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -127,6 +127,23 @@ export interface FetchStep {
     url: string;
     responseType?: 'json' | 'html';
   } & FieldExtractor;
+  /**
+   * Requête secondaire générique pour un champ absent de la page principale (ex:
+   * la classe de membre sur IPTorrents, exposée uniquement sur la page de profil
+   * /u/<id>, pas sur la page d'accueil). Si `idExtract` est fourni, son resultat
+   * remplace le placeholder {{id}} dans `url` (extrait depuis le HTML/JSON de la
+   * page principale, avant la requête secondaire). Le champ extrait (path JSON ou
+   * regex HTML + transform) alimente fields.<field>.
+   * Best-effort : un échec n'invalide jamais le tracker.
+   */
+  extraFetch?: {
+    url: string;
+    responseType?: 'json' | 'html';
+    /** Regex avec groupe nommé (?<value>...), appliquée sur la page principale. */
+    idExtract?: { regex: string };
+    /** Nom du champ de fields.* alimenté par cette requête (ex: "memberClass"). */
+    field: string;
+  } & FieldExtractor;
 }
 
 /** Famille de moteur de tracker — voir ENGINE_TEMPLATES dans trackerTemplates.ts. */


### PR DESCRIPTION
  ## Summary
  Suite de la feature "classe de membre" (PR #94, famille Gazelle). 

Couvre les sites suivants : ABN, YGG Reborn, Nexum, C411, TR4KER, The Old School, Torr9
  
  - `ABNormal` : classe encodée dans l'attribut `class` lui-même (`userclass_VIP`), ajoutée directement en JSON
  (pas de `engine: gazelle`, flow de login ASP.NET différent).
  scrapée. Introduit `fetch.extraFetch`, un mécanisme générique de requête secondaire (généralisation de
  `unreadFetch`, jusqu'ici limité aux MP non lus) : extrait un identifiant depuis la page principale
  (`idExtract`), l'injecte dans une URL secondaire, puis alimente un champ arbitraire de `fields.*`.
  - `YGGReborn` : champ déjà présent sur la page `/account/` déjà scrapée, pas de fetch secondaire.
  - `Nexum` : généralise `extraFetch` pour supporter le placeholder `{{username}}` (déjà connu via les
  credentials), en plus de `{{id}}` — classe exposée sur `/user/<pseudo>`.
  - `C411` : champ déjà présent dans la réponse JSON `api/auth/me` (`user.badge.label`), pas de fetch
  secondaire.
  - `TR4KER` : SPA nécessitant une hydratation JS pour les stats principales (`fetch.mode: browser`). Étend
  `fetchWithBrowser` pour naviguer vers une page secondaire dans la même session authentifiée après le fetch
  principal (classe exposée en JSON brut sur `/api/me`, extraite par regex direct).
  - `The Old School` : classe exposée sur `/users/<pseudo>`, page rendue côté serveur — passe par le mécanisme
  HTTP `extraFetch` existant. 
  - `Torr9` : champ déjà présent dans `api/v1/users/me` (`role`). Valeur brute affichée (ex: `userplus`), ne
  correspond pas littéralement aux libellés de la FAQ Torr9
  (Nouveau/Membre/Uploader/Releaser/Modérateur/Administrateur) — correspondance exacte à affiner plus tard.

  
  ## Test plan
  - [x] `tsc --noEmit` OK sur chaque commit
  - [x] `node scripts/check-integration.mjs` OK
  - [x] Toutes les regex testées contre des échantillons HTML/JSON réels (dumps de debug ou extraits fournis)
  - [x] Chaque site testé manuellement sur l'instance dev (port 3003) et validé un par un avant commit
  - [x] Bug corrigé en cours de route : regex IPTorrents avec capture gourmande (`[\s\S]*`) qui matchait
  jusqu'au dernier `</span>` de la page au lieu du plus proche — remplacée par une classe bornée (`[^<]+`)