### PR TITLE
feat(trackers): duplication de tracker pour plusieurs comptes par site

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Au premier accès, l'application demande de créer le compte administrateur de l
 
 ## Changements récents
 
+- **Plusieurs comptes par tracker** : duplication d'un tracker pour suivre plusieurs comptes d'un même site, regroupés sous le site dans la barre latérale.
 - Refonte de la navigation : barre latérale unique, thème clair/sombre/système, nouveau logo.
 - Fiches de trackers enrichies : statut clair, courbes d'évolution UP/DL/ratio (buffer en option), erreurs en cours / récentes / historique.
 - Menu **Calendrier** des refreshs (OK/KO par jour, accès à la config en cas de KO).
@@ -80,6 +81,16 @@ Pour les trackers en 2FA basée sur le temps (TOTP), le dashboard génère lui-m
 - **Flux en une étape** : `login.otpField` ou placeholder `{{otp}}` dans le corps de login.
 
 Laissez le champ vide pour les trackers sans 2FA.
+
+## Plusieurs comptes par tracker
+
+Pour suivre **plusieurs comptes sur un même site**, dupliquez un tracker : dans **Configuration → Configurer les actifs → (le tracker)**, cliquez sur **Dupliquer**. Un nouveau compte « (compte 2) » est créé, prêt à recevoir ses identifiants.
+
+- Le duplicata reprend la **même mécanique de login** que le tracker d'origine et **hérite automatiquement** des corrections de login publiées par la suite.
+- **Identifiants, cookie, 2FA, profil navigateur, statistiques, planning et notifications sont indépendants** entre comptes.
+- Dans la barre latérale (« Configurer les actifs » et « Trackers activés »), les comptes d'un même site sont **regroupés sous le nom du site**, dépliable.
+- Un compte dupliqué est **supprimable** (bouton **Supprimer** sur sa fiche) ; le tracker intégré d'origine, lui, ne peut être que désactivé.
+- Limite : la liaison des torrents qBittorrent se fait par hôte d'annonce ; deux comptes du même site partageant le même hôte, un torrent ne se rattache qu'à l'un des deux. Les statistiques du site restent justes.
 
 ## Captures d'écran
 

--- a/public/index.html
+++ b/public/index.html
@@ -284,6 +284,15 @@
     .nav-sub-item .nav-sub-dot.bad { background: var(--red); }
     .nav-sub-item .nav-sub-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     .nav-sub-empty { padding: 6px 16px 6px 38px; font-size: 11px; color: var(--muted); }
+    /* Regroupement par site quand un tracker a plusieurs comptes (duplicatas) */
+    .nav-sub-group { display: flex; flex-direction: column; }
+    .nav-sub-group > summary { list-style: none; }
+    .nav-sub-group > summary::-webkit-details-marker { display: none; }
+    .nav-sub-group-summary .nav-sub-caret { margin-left: auto; transition: transform .15s; font-size: 10px; color: var(--muted); }
+    .nav-sub-group[open] > summary .nav-sub-caret { transform: rotate(90deg); }
+    .nav-sub-group-count { font-size: 10px; color: var(--muted); }
+    .nav-sub-group-body > .nav-sub-item { padding-left: 50px; }
+    .nav-sub-item .tracker-logo, .nav-sub-group-summary .tracker-logo { width: 14px; height: 14px; border-radius: 3px; flex-shrink: 0; object-fit: contain; }
     .definition-row-highlight { box-shadow: 0 0 0 2px var(--accent); border-radius: 8px; transition: box-shadow .3s; }
     .nav-item.proxy-on::after {
       content: '';
@@ -3081,7 +3090,10 @@
     const statuses = new Map((betaOverview?.trackerStatuses || []).map(item => [item.id, item]));
     const trackers = activeTrackerStats();
     if (!betaSelectedTrackerId && trackers[0]) betaSelectedTrackerId = trackers[0].id;
-    subFiche.innerHTML = trackers.map(stat => {
+    const baseById = new Map(trackerConfig.map(t => [t.id, t.baseId]));
+    const nameById = new Map(trackerConfig.map(t => [t.id, t.name]));
+    const itemHtml = item => {
+      const stat = item.stat;
       const status = statuses.get(stat.id);
       const mode = trackerModeLabel(status);
       // Pastille binaire OK / NOK uniquement (vert = fonctionne, rouge = en
@@ -3094,7 +3106,39 @@
           <i class="nav-sub-dot ${dot}"></i>
           <span class="nav-sub-name">${escapeHtml(stat.name)}</span>
         </button>`;
-    }).join('') || '<p class="nav-sub-empty">Aucun tracker activé.</p>';
+    };
+    const items = trackers.map(stat => ({ id: stat.id, name: stat.name, baseId: baseById.get(stat.id), stat }));
+    subFiche.innerHTML = groupTrackersByBase(items, nameById).map(group => navGroupHtml(group, itemHtml)).join('')
+      || '<p class="nav-sub-empty">Aucun tracker activé.</p>';
+  }
+
+  // Regroupe des entrées { id, baseId, name } par site (baseId || id) pour afficher
+  // les comptes multiples (duplicatas) sous un nœud parent. Renvoie une liste triée
+  // de groupes { key, label, members } ; label = nom du tracker source.
+  function groupTrackersByBase(items, nameById) {
+    const groups = new Map();
+    for (const item of items) {
+      const key = item.baseId || item.id;
+      if (!groups.has(key)) groups.set(key, []);
+      groups.get(key).push(item);
+    }
+    return [...groups.entries()]
+      .map(([key, members]) => ({
+        key,
+        label: nameById.get(key) || members[0].name,
+        members: members.slice().sort((a, b) => a.name.localeCompare(b.name, 'fr', { sensitivity: 'base' })),
+      }))
+      .sort((a, b) => a.label.localeCompare(b.label, 'fr', { sensitivity: 'base' }));
+  }
+
+  // Rend un groupe : entrée à plat s'il n'y a qu'un compte, sinon nœud dépliable
+  // (logo + nom du site + compteur) contenant les comptes.
+  function navGroupHtml(group, itemHtml) {
+    if (group.members.length === 1) return itemHtml(group.members[0]);
+    return `<details class="nav-sub-group" open>
+        <summary class="nav-sub-item nav-sub-group-summary">${trackerLogo(group.key)}<span class="nav-sub-name">${escapeHtml(group.label)}</span><span class="nav-sub-group-count">${group.members.length}</span><span class="nav-sub-caret">▸</span></summary>
+        <div class="nav-sub-group-body">${group.members.map(itemHtml).join('')}</div>
+      </details>`;
   }
 
   // Accordéons « Ajouter un tracker » (non activés) et « Configurer les actifs »
@@ -3103,17 +3147,19 @@
     const subAdd = document.getElementById('nav-sub-add');
     const subConfigure = document.getElementById('nav-sub-configure');
     if (!subAdd && !subConfigure) return;
-    const defs = [...cachedTrackerDefinitions].sort((a, b) => a.name.localeCompare(b.name, 'fr', { sensitivity: 'base' }));
+    const nameById = new Map(cachedTrackerDefinitions.map(def => [def.id, def.name]));
     const itemHtml = def => `
       <button class="nav-sub-item ${currentView === 'trackers' && def.id === configSelectedTrackerId ? 'active' : ''}" onclick="openTrackerConfig('${escapeHtml(def.id)}')" type="button">
         <span class="nav-sub-name">${escapeHtml(def.name)}</span>
       </button>`;
     if (subAdd) {
-      subAdd.innerHTML = defs.filter(def => !def.enabled).map(itemHtml).join('')
+      const groups = groupTrackersByBase(cachedTrackerDefinitions.filter(def => !def.enabled), nameById);
+      subAdd.innerHTML = groups.map(group => navGroupHtml(group, itemHtml)).join('')
         || '<p class="nav-sub-empty">Tous les trackers sont activés.</p>';
     }
     if (subConfigure) {
-      subConfigure.innerHTML = defs.filter(def => def.enabled).map(itemHtml).join('')
+      const groups = groupTrackersByBase(cachedTrackerDefinitions.filter(def => def.enabled), nameById);
+      subConfigure.innerHTML = groups.map(group => navGroupHtml(group, itemHtml)).join('')
         || '<p class="nav-sub-empty">Aucun tracker activé.</p>';
     }
   }
@@ -5905,7 +5951,7 @@
     return `
               <div class="definition-row" id="tracker-def-${safeId}">
                 <div class="definition-info">
-                  <strong>${trackerLogo(definition.id)}${escapeHtml(definition.name)}${cookieOnly ? ' <span class="definition-badge definition-badge-cookie" title="Login automatique désactivé : ce tracker nécessite un cookie de session (CAPTCHA/anti-bot). Renseigne-le dans Options avancées.">Cookie uniquement</span>' : ''}</strong>
+                  <strong>${trackerLogo(definition.id)}${escapeHtml(definition.name)}${definition.baseId ? ' <span class="definition-badge" title="Compte dupliqué : même site et même login que le tracker source, identifiants et stats indépendants.">Copie</span>' : ''}${cookieOnly ? ' <span class="definition-badge definition-badge-cookie" title="Login automatique désactivé : ce tracker nécessite un cookie de session (CAPTCHA/anti-bot). Renseigne-le dans Options avancées.">Cookie uniquement</span>' : ''}</strong>
                   <small>${escapeHtml(definition.file)} · <a href="${escapeHtml(definition.baseUrl)}" target="_blank" rel="noreferrer noopener">${escapeHtml(definition.baseUrl)}</a></small>
                 </div>
                 ${isNew ? '<span class="definition-badge">Nouveau</span>' : '<span class="definition-new-slot"></span>'}
@@ -5928,8 +5974,14 @@
                 <div class="definition-actions">
                   <button class="btn-test" style="padding:6px 10px" onclick="setTrackerEnabled('${safeId}', ${isEnabled ? 'false' : 'true'})">${isEnabled ? 'Retirer' : 'Ajouter'}</button>
                 </div>
-                ${definition.isCustom ? `<div class="definition-actions">
+                <div class="definition-actions">
+                  <button class="btn-test" style="padding:6px 10px" title="Créer un autre compte sur ce site (même login, identifiants et stats indépendants)" onclick="duplicateTracker('${safeId}')">Dupliquer</button>
+                </div>
+                ${definition.isCustom && !definition.baseId ? `<div class="definition-actions">
                   <button class="btn-test" style="padding:6px 10px" title="Modifier la définition technique de ce tracker perso" onclick="ntEditCustomTracker('${safeId}')">Éditer la définition</button>
+                </div>` : ''}
+                ${definition.baseId ? `<div class="definition-actions">
+                  <button class="btn-test" style="padding:6px 10px; color:var(--red); border-color:var(--red)" title="Supprimer ce compte dupliqué et ses données (identifiants, historique)" onclick="deleteDuplicateTracker('${safeId}')">Supprimer</button>
                 </div>` : ''}
                 <details class="definition-advanced" style="grid-column:1/-1">
                   <summary>Options avancées${credential.hasCookie ? ' · <b style="color:var(--green)">cookie défini</b>' : ''}${credential.hasTotp ? ' · <b style="color:var(--green)">2FA défini</b>' : ''}</summary>
@@ -6059,6 +6111,39 @@
     await loadTrackerDefinitionsPanel();
     await loadConfig();
     await loadStats();
+  }
+
+  // Duplique un tracker pour gerer un compte supplementaire sur le meme site.
+  async function duplicateTracker(trackerId) {
+    try {
+      const r = await fetch(`/api/trackers/${encodeURIComponent(trackerId)}/duplicate`, { method: 'POST' });
+      const data = await r.json();
+      if (!data.ok) throw new Error(data.error || 'Erreur');
+      await loadTrackerDefinitionsPanel();
+      await loadConfig();
+      await loadStats();
+      // Ouvre la fiche du nouveau compte, pret a recevoir ses identifiants.
+      if (data.tracker?.id) openTrackerConfig(data.tracker.id);
+    } catch (e) {
+      alert('Duplication impossible : ' + e.message);
+    }
+  }
+
+  // Supprime un compte duplique (et ses donnees). Reserve aux duplicatas : le
+  // bouton n'apparait que pour eux.
+  async function deleteDuplicateTracker(trackerId) {
+    if (!confirm(`Supprimer définitivement le compte « ${trackerId} » et ses données (identifiants, historique) ?`)) return;
+    try {
+      const r = await fetch(`/api/trackers/${encodeURIComponent(trackerId)}`, { method: 'DELETE' });
+      const data = await r.json();
+      if (!data.ok) throw new Error(data.error || 'Erreur');
+      if (configSelectedTrackerId === trackerId) configSelectedTrackerId = null;
+      await loadTrackerDefinitionsPanel();
+      await loadConfig();
+      await loadStats();
+    } catch (e) {
+      alert('Suppression impossible : ' + e.message);
+    }
   }
 
   async function saveTrackerCredential(trackerId) {

--- a/scripts/check-integration.mjs
+++ b/scripts/check-integration.mjs
@@ -75,7 +75,7 @@ if (!html.includes('<h2>🔀 Proxy</h2>')) {
 }
 
 const synchronizesAllBundledTrackers = (
-  server.includes('const definition = loadDefaultTrackerDefinition(tracker.id);')
+  server.includes('const definition = loadDefaultTrackerDefinition(tracker.baseId ?? tracker.id);')
   && !server.includes('CANONICAL_CONNECTION_TRACKERS')
 );
 if (redacted.fetch?.fields?.requiredRatio && !synchronizesAllBundledTrackers) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -291,7 +291,9 @@ function normalizeTrackerConfigs(): TrackerConfig[] {
     // n'est pas touche : loadDefaultTrackerDefinition renvoie null.
     // Sans ce mecanisme, une install deployee garde eternellement les vieilles
     // definitions en base, meme apres une mise a jour d'image qui les corrige.
-    const definition = loadDefaultTrackerDefinition(tracker.id);
+    // Un duplicata (baseId defini) herite de la definition de son tracker source,
+    // donc des memes corrections de login que l'original.
+    const definition = loadDefaultTrackerDefinition(tracker.baseId ?? tracker.id);
     if (definition) {
       if (JSON.stringify(tracker.login) !== JSON.stringify(definition.login)) {
         tracker.login = definition.login;
@@ -517,7 +519,7 @@ function sanitizeTrackerConfigInput(
  * Sans ce merge, un tracker perso enregistre via /api/trackers serait invisible
  * dans « Configurer les actifs » et n'aurait jamais d'identifiants.
  */
-function listAllTrackerSummaries(): Array<{ id: string; name: string; baseUrl: string; file: string; enabled: boolean }> {
+function listAllTrackerSummaries(): Array<{ id: string; name: string; baseUrl: string; file: string; enabled: boolean; baseId?: string }> {
   const fromFiles = listTrackerDefinitionFiles();
   const seen = new Set(fromFiles.map(d => d.id));
   const dbOnly = loadTrackerConfigsFromDb()
@@ -526,8 +528,9 @@ function listAllTrackerSummaries(): Array<{ id: string; name: string; baseUrl: s
       id: cfg.id,
       name: cfg.name,
       baseUrl: cfg.baseUrl,
-      file: `${cfg.id} (perso)`,
+      file: cfg.baseId ? `${cfg.id} (copie de ${cfg.baseId})` : `${cfg.id} (perso)`,
       enabled: cfg.enabled !== false,
+      baseId: cfg.baseId,
     }));
   return [...fromFiles, ...dbOnly];
 }
@@ -2511,13 +2514,14 @@ export async function start(): Promise<void> {
 
   app.get('/api/config', (_req, res) => {
     trackers = normalizeTrackerConfigs();
-    const safe = trackers.map(({ id, name, baseUrl, enabled, dashboard, ratioless }) => ({
+    const safe = trackers.map(({ id, name, baseUrl, enabled, dashboard, ratioless, baseId }) => ({
       id,
       name,
       baseUrl,
       enabled: enabled !== false,
       byteUnit: dashboard?.byteUnit ?? 'binary',
       ratioless: Boolean(ratioless),
+      baseId,
     }));
     res.json({ trackers: safe });
   });
@@ -2675,6 +2679,7 @@ export async function start(): Promise<void> {
           configured: Boolean(configuredTracker),
           isDefault: isDefaultTracker(definition.id),
           isCustom: !isDefaultTracker(definition.id),
+          baseId: configuredTracker?.baseId ?? definition.baseId,
         };
       })
       .sort((a, b) => a.name.localeCompare(b.name, 'fr', { sensitivity: 'base' }));
@@ -2715,6 +2720,47 @@ export async function start(): Promise<void> {
     saveTrackerConfig(tracker);
     trackers = normalizeTrackerConfigs();
     res.json({ ok: true, tracker });
+  });
+
+  // Duplique un tracker pour gerer plusieurs comptes sur un meme site. Le duplicata
+  // reprend la definition technique de la source (via baseId, donc il herite des
+  // corrections de login amont) mais possede son propre id : identifiants, cookie,
+  // 2FA, profil navigateur, stats, planning et notifications sont independants.
+  app.post('/api/trackers/:trackerId/duplicate', (req, res) => {
+    importLegacyTrackersIfNeeded();
+    const sourceId = req.params.trackerId;
+    const source = loadTrackerConfigsFromDb().find(t => t.id === sourceId)
+      ?? loadTrackerDefinitionFile(sourceId);
+    if (!source) return res.status(404).json({ ok: false, error: 'Tracker introuvable' });
+
+    const baseId = source.baseId ?? source.id;
+    const summaries = listAllTrackerSummaries();
+    const existingIds = new Set(summaries.map(summary => summary.id));
+    const baseName = summaries.find(summary => summary.id === baseId)?.name ?? source.name;
+
+    let n = 2;
+    while (existingIds.has(`${baseId}-${n}`)) n += 1;
+    const newId = `${baseId}-${n}`;
+
+    const duplicate: TrackerConfig = {
+      ...source,
+      id: newId,
+      name: `${baseName} (compte ${n})`,
+      baseId,
+      enabled: true,
+    };
+    saveTrackerConfig(duplicate);
+
+    // Inserer dans l'ordre d'affichage juste apres la source.
+    const order = getJsonSetting(TRACKER_ORDER_KEY, { ids: [] as string[] });
+    const ids = (Array.isArray(order.ids) ? order.ids : []).filter(id => id !== newId);
+    const at = ids.indexOf(sourceId);
+    if (at >= 0) ids.splice(at + 1, 0, newId);
+    else ids.push(newId);
+    setJsonSetting(TRACKER_ORDER_KEY, { ids });
+
+    trackers = normalizeTrackerConfigs();
+    res.json({ ok: true, tracker: duplicate });
   });
 
   app.post('/api/trackers', (req, res) => {
@@ -3205,7 +3251,13 @@ export async function start(): Promise<void> {
 
   // ── Logos trackers (favicon en cache + logos manuels) ─────────────────────
   app.get('/api/tracker-logo/:id', (req, res) => {
-    const file = resolveLogoPath(req.params.id);
+    // Un duplicata (id ex. c411-2) n'a pas de logo propre : on retombe sur celui
+    // de son tracker source (baseId).
+    let file = resolveLogoPath(req.params.id);
+    if (!file) {
+      const baseId = loadTrackerConfigsFromDb().find(t => t.id === req.params.id)?.baseId;
+      if (baseId) file = resolveLogoPath(baseId);
+    }
     if (!file) {
       res.status(404).end();
       return;

--- a/src/types.ts
+++ b/src/types.ts
@@ -156,6 +156,15 @@ export interface TrackerConfig {
   baseUrl: string;
   enabled?: boolean;
   /**
+   * Duplicata : id du tracker source dont cette entree reprend la definition
+   * technique (login/fetch/engine). Permet d'avoir plusieurs comptes sur un meme
+   * site. Les champs techniques sont rafraichis depuis la definition de `baseId`
+   * (voir normalizeTrackerConfigs), donc un duplicata d'un tracker integre herite
+   * des corrections de login amont. Identifiants, cookie, 2FA, stats, planning et
+   * notifications restent propres a l'`id` de ce duplicata.
+   */
+  baseId?: string;
+  /**
    * Famille de moteur. Si présent, les blocs login/fetch/dashboard héritent du
    * preset moteur (ENGINE_TEMPLATES) ; les champs déclarés dans ce JSON
    * surchargent le preset (le JSON gagne toujours, champ par champ ;


### PR DESCRIPTION
## Objectif

Permettre de suivre **plusieurs comptes sur un même tracker** (ex. deux comptes C411).

## Principe

Tout le système étant indexé par `id`, un compte supplémentaire = une nouvelle entrée tracker avec un `id` distinct, reliée à la définition d'origine par un nouveau champ `baseId`.

- **Lié, pas figé** : [`normalizeTrackerConfigs`](src/server.ts) relit la définition technique via `loadDefaultTrackerDefinition(baseId ?? id)`. Un duplicata d'un tracker intégré hérite donc des corrections de login publiées ensuite.
- **Indépendance** : identifiants, cookie, 2FA, profil navigateur, statistiques, planning et notifications sont propres à chaque compte (clés par `id`).

## Modifications

- Type `TrackerConfig` : champ optionnel `baseId`.
- Endpoint `POST /api/trackers/:id/duplicate` : génère un `id` libre (`c411-2`, `-3`…), nom « (compte N) », `enabled=true`, identifiants vides, insertion dans l'ordre juste après la source.
- `baseId` exposé par `/api/config` et `/api/tracker-definitions` ; logo des duplicatas résolu via `baseId` (repli serveur).
- Barre latérale : les comptes d'un même site sont **regroupés sous un nœud dépliable** (logo + nom du site + compteur), dans « Configurer les actifs » et « Trackers activés ». Un seul compte reste affiché à plat.
- Fiche de configuration : bouton **Dupliquer** (sur tous), badge **Copie** et bouton **Supprimer** (sur les duplicatas uniquement ; le tracker intégré d'origine reste seulement désactivable).
- README : section « Plusieurs comptes par tracker » + mention de la limite qBittorrent (liaison par hôte).
- `scripts/check-integration.mjs` : garde de synchronisation des trackers intégrés mise à jour pour refléter l'appel `baseId ?? id` (comportement inchangé pour un tracker sans `baseId`).

## Limite connue

La liaison des torrents qBittorrent se fait par hôte d'annonce. Deux comptes du même site partagent le même hôte, donc un torrent ne se rattache qu'à l'un des deux. Les statistiques du site restent justes.

## Validation

- `npm run build`
- `npm run check:integration` (54 appels)
- `git diff --check`, contrôle d'encodage, syntaxe du script inline (0 erreur)
