### PR TITLE
feat(trackers): renommage des comptes et attribution des torrents par passkey

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Au premier accès, l'application demande de créer le compte administrateur de l
 
 ## Changements récents
 
-- **Plusieurs comptes par tracker** : duplication d'un tracker pour suivre plusieurs comptes d'un même site, regroupés sous le site dans la barre latérale.
+- **Plusieurs comptes par tracker** : duplication d'un tracker, noms d'affichage personnalisables, regroupement sous le site, et attribution des torrents par passkey entre comptes.
 - Refonte de la navigation : barre latérale unique, thème clair/sombre/système, nouveau logo.
 - Fiches de trackers enrichies : statut clair, courbes d'évolution UP/DL/ratio (buffer en option), erreurs en cours / récentes / historique.
 - Menu **Calendrier** des refreshs (OK/KO par jour, accès à la config en cas de KO).
@@ -84,13 +84,17 @@ Laissez le champ vide pour les trackers sans 2FA.
 
 ## Plusieurs comptes par tracker
 
-Pour suivre **plusieurs comptes sur un même site**, dupliquez un tracker : dans **Configuration → Configurer les actifs → (le tracker)**, cliquez sur **Dupliquer**. Un nouveau compte « (compte 2) » est créé, prêt à recevoir ses identifiants.
+Pour suivre **plusieurs comptes sur un même site**, dupliquez un tracker : dans **Configuration → Configurer les actifs → (le tracker)**, cliquez sur **Dupliquer**. Un nouveau compte « (2) » est créé, prêt à recevoir ses identifiants.
 
 - Le duplicata reprend la **même mécanique de login** que le tracker d'origine et **hérite automatiquement** des corrections de login publiées par la suite.
 - **Identifiants, cookie, 2FA, profil navigateur, statistiques, planning et notifications sont indépendants** entre comptes.
+- **Nom d'affichage modifiable** : sur la fiche de configuration de chaque compte, champ **Nom d'affichage** + **Renommer** (ex. « C411 », « C411 Alex », « C411 Ishem »).
 - Dans la barre latérale (« Configurer les actifs » et « Trackers activés »), les comptes d'un même site sont **regroupés sous le nom du site**, dépliable.
 - Un compte dupliqué est **supprimable** (bouton **Supprimer** sur sa fiche) ; le tracker intégré d'origine, lui, ne peut être que désactivé.
-- Limite : la liaison des torrents qBittorrent se fait par hôte d'annonce ; deux comptes du même site partageant le même hôte, un torrent ne se rattache qu'à l'un des deux. Les statistiques du site restent justes.
+
+### Attribution des torrents par passkey
+
+Quand un site a plusieurs comptes, les torrents de vos clients BitTorrent sont ventilés par **passkey** (celle présente dans l'URL d'annonce). Sur la **fiche** d'un compte, la section **Attribution des annonces** liste les passkeys détectées (affichées masquées) ; attribuez chacune au bon compte. Les torrents correspondants — et leurs statistiques — suivent alors le compte choisi. Avec un seul compte, rien ne change : l'attribution automatique par hôte reste utilisée.
 
 ## Captures d'écran
 

--- a/public/index.html
+++ b/public/index.html
@@ -1556,6 +1556,12 @@
       justify-content: stretch;
     }
     .definition-actions button { width: 100%; }
+    .definition-extra-actions { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin-top: 8px; }
+    .definition-extra-actions button { white-space: nowrap; }
+    .definition-rename { display: flex; align-items: center; gap: 6px; }
+    .definition-rename label { font-size: 11px; color: var(--muted); }
+    .definition-rename input { width: 180px; }
+    .definition-delete { color: var(--red); border-color: var(--red); }
     .definition-badge {
       color: var(--green);
       background: color-mix(in srgb, var(--green) 16%, transparent);
@@ -3968,7 +3974,25 @@
     const configured = trackerConfig.find(t => t.id === stat.id);
     const trackerUrl = stat.trackerUrl || configured?.baseUrl || '';
     const host = trackerHostFromUrl(trackerUrl);
-    const qbits = (betaOverview?.qbitStats || []).filter(item => item.trackerId === stat.id || item.trackerHost === host);
+    // Comptes multiples : tous les trackers partageant la meme base (baseId || id).
+    const baseKey = configured?.baseId || stat.id;
+    const siblings = trackerConfig.filter(t => (t.baseId || t.id) === baseKey);
+    const multiAccount = siblings.length >= 2;
+    // Passkeys distinctes detectees pour ce site (a attribuer a un compte).
+    const siteAnnounceGroups = [];
+    if (multiAccount) {
+      const seenKeys = new Set();
+      for (const item of (betaOverview?.qbitStats || [])) {
+        if (item.trackerHost !== host || !item.announceKey || seenKeys.has(item.announceKey)) continue;
+        seenKeys.add(item.announceKey);
+        const mapping = (betaSettings.accountAnnounceMappings || []).find(m => m.key === item.announceKey);
+        siteAnnounceGroups.push({ key: item.announceKey, label: item.announceLabel || item.announceKey, assigned: mapping?.trackerId || item.trackerId || '' });
+      }
+    }
+    // En multi-comptes, on n'affiche que les torrents resolus vers ce compte (sinon
+    // tous les comptes du site partageraient le meme hote). En compte unique, on garde
+    // le repli par hote pour les annonces non encore reliees.
+    const qbits = (betaOverview?.qbitStats || []).filter(item => item.trackerId === stat.id || (!multiAccount && item.trackerHost === host));
     const suggestedQbits = (betaOverview?.qbitStats || []).filter(item => !item.trackerId && betaTrackerMatchForHost(item.trackerHost)?.tracker.id === stat.id);
     const torrents = qbits.flatMap(item => (item.torrents || []).map(torrent => ({ ...torrent, clientLabel: item.clientLabel, clientBaseUrl: item.clientBaseUrl })));
     const suggestedTorrents = suggestedQbits.flatMap(item => (item.torrents || []).map(torrent => ({ ...torrent, trackerHost: item.trackerHost, clientLabel: item.clientLabel })));
@@ -4077,6 +4101,22 @@
           })()}
         </div>
       </div>
+      ${multiAccount && siteAnnounceGroups.length ? `
+      <div style="margin-top:12px">
+        <h3>Attribution des annonces (comptes multiples)</h3>
+        <p class="beta-note">Ce site a plusieurs comptes. Attribuez chaque passkey détectée dans vos clients BitTorrent au bon compte ; les torrents correspondants suivront le compte choisi.</p>
+        <table class="beta-mini-table">
+          <thead><tr><th>Annonce (passkey)</th><th>Compte attribué</th></tr></thead>
+          <tbody>${siteAnnounceGroups.map(g => `
+            <tr>
+              <td><code>${escapeHtml(g.label)}</code></td>
+              <td><select onchange="assignAnnounceToAccount('${escapeHtml(g.key)}', this.value)">
+                <option value="">— Automatique —</option>
+                ${siblings.map(s => `<option value="${escapeHtml(s.id)}" ${g.assigned === s.id ? 'selected' : ''}>${escapeHtml(s.name)}</option>`).join('')}
+              </select></td>
+            </tr>`).join('')}</tbody>
+        </table>
+      </div>` : ''}
       <div style="margin-top:12px">
         <h3>Torrents liés dans les clients BitTorrent</h3>
         <table class="beta-mini-table">
@@ -5974,15 +6014,16 @@
                 <div class="definition-actions">
                   <button class="btn-test" style="padding:6px 10px" onclick="setTrackerEnabled('${safeId}', ${isEnabled ? 'false' : 'true'})">${isEnabled ? 'Retirer' : 'Ajouter'}</button>
                 </div>
-                <div class="definition-actions">
+                <div class="definition-extra-actions" style="grid-column:1/-1">
+                  <div class="definition-rename">
+                    <label for="rename-${safeId}">Nom d'affichage</label>
+                    <input class="tracker-input" id="rename-${safeId}" value="${escapeHtml(definition.name)}" autocomplete="off" maxlength="80">
+                    <button class="btn-save" style="padding:6px 10px" onclick="renameTracker('${safeId}', this)">Renommer</button>
+                  </div>
                   <button class="btn-test" style="padding:6px 10px" title="Créer un autre compte sur ce site (même login, identifiants et stats indépendants)" onclick="duplicateTracker('${safeId}')">Dupliquer</button>
+                  ${definition.isCustom && !definition.baseId ? `<button class="btn-test" style="padding:6px 10px" title="Modifier la définition technique de ce tracker perso" onclick="ntEditCustomTracker('${safeId}')">Éditer la définition</button>` : ''}
+                  ${definition.baseId ? `<button class="btn-test definition-delete" style="padding:6px 10px" title="Supprimer ce compte dupliqué et ses données (identifiants, historique)" onclick="deleteDuplicateTracker('${safeId}')">Supprimer</button>` : ''}
                 </div>
-                ${definition.isCustom && !definition.baseId ? `<div class="definition-actions">
-                  <button class="btn-test" style="padding:6px 10px" title="Modifier la définition technique de ce tracker perso" onclick="ntEditCustomTracker('${safeId}')">Éditer la définition</button>
-                </div>` : ''}
-                ${definition.baseId ? `<div class="definition-actions">
-                  <button class="btn-test" style="padding:6px 10px; color:var(--red); border-color:var(--red)" title="Supprimer ce compte dupliqué et ses données (identifiants, historique)" onclick="deleteDuplicateTracker('${safeId}')">Supprimer</button>
-                </div>` : ''}
                 <details class="definition-advanced" style="grid-column:1/-1">
                   <summary>Options avancées${credential.hasCookie ? ' · <b style="color:var(--green)">cookie défini</b>' : ''}${credential.hasTotp ? ' · <b style="color:var(--green)">2FA défini</b>' : ''}</summary>
                   <div class="definition-advanced-body">
@@ -6143,6 +6184,55 @@
       await loadStats();
     } catch (e) {
       alert('Suppression impossible : ' + e.message);
+    }
+  }
+
+  // Renomme le libellé d'affichage d'un compte/tracker.
+  async function renameTracker(trackerId, btn) {
+    const input = document.getElementById(`rename-${trackerId}`);
+    const name = input ? input.value.trim() : '';
+    if (!name) { if (input) input.focus(); return; }
+    const previous = btn.textContent;
+    btn.disabled = true;
+    btn.textContent = '...';
+    try {
+      const r = await fetch(`/api/trackers/${encodeURIComponent(trackerId)}/name`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name }),
+      });
+      const data = await r.json();
+      if (!data.ok) throw new Error(data.error || 'Erreur');
+      await loadTrackerDefinitionsPanel();
+      await loadConfig();
+      await loadStats();
+    } catch (e) {
+      alert('Renommage impossible : ' + e.message);
+    } finally {
+      btn.disabled = false;
+      btn.textContent = previous;
+    }
+  }
+
+  // Attribue (ou délie) une annonce/passkey à un compte, puis recharge l'overview
+  // pour que les torrents soient ré-attribués.
+  async function assignAnnounceToAccount(key, trackerId) {
+    const mappings = (betaSettings.accountAnnounceMappings || []).filter(m => m.key !== key);
+    if (trackerId) mappings.push({ key, trackerId });
+    const settings = { ...betaSettings, accountAnnounceMappings: mappings };
+    try {
+      const r = await fetch('/api/beta/settings', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(settings),
+      });
+      const data = await r.json();
+      if (!data.ok) throw new Error(data.error || 'Erreur');
+      betaSettings = data.settings;
+      await loadBetaData();
+      renderBetaTrackerPage();
+    } catch (e) {
+      alert('Attribution impossible : ' + e.message);
     }
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -221,9 +221,17 @@ interface BetaAnnounceMapping {
   trackerId: string;
 }
 
+// Attribution d'une annonce precise (identifiee par sa passkey, via un hash stable)
+// a un compte, pour ventiler les torrents entre plusieurs comptes d'un meme site.
+interface BetaAccountAnnounceMapping {
+  key: string;
+  trackerId: string;
+}
+
 interface BetaSettings {
   qbitClients: BetaQbitClient[];
   announceMappings: BetaAnnounceMapping[];
+  accountAnnounceMappings: BetaAccountAnnounceMapping[];
   notificationTargets: BetaNotificationTarget[];
   features: {
     graphsEnabled: boolean;
@@ -248,6 +256,8 @@ interface QbitTrackerAggregate {
   clientLabel: string;
   clientBaseUrl: string;
   trackerHost: string;
+  announceKey?: string;
+  announceLabel?: string;
   torrentCount: number;
   seedingCount: number;
   leechingCount: number;
@@ -1544,6 +1554,7 @@ function defaultBetaSettings(): BetaSettings {
   return {
     qbitClients: [],
     announceMappings: [],
+    accountAnnounceMappings: [],
     notificationTargets: [],
     features: {
       graphsEnabled: true,
@@ -1601,6 +1612,7 @@ function loadBetaSettings(): BetaSettings {
     features: { ...defaultBetaSettings().features, ...(settings.features ?? {}) },
     qbitClients: Array.isArray(settings.qbitClients) ? settings.qbitClients : [],
     announceMappings: Array.isArray(settings.announceMappings) ? settings.announceMappings : [],
+    accountAnnounceMappings: Array.isArray(settings.accountAnnounceMappings) ? settings.accountAnnounceMappings : [],
     notificationTargets: Array.isArray(settings.notificationTargets) ? settings.notificationTargets : [],
     scheduleOverrides: Array.isArray(settings.scheduleOverrides) ? settings.scheduleOverrides : [],
     schedule: { ...defaultBetaSettings().schedule, ...(settings.schedule ?? {}) },
@@ -1693,6 +1705,14 @@ function saveBetaSettingsPayload(raw: unknown): BetaSettings {
       trackerId: String(mapping.trackerId || '').trim(),
     };
   }).filter(mapping => mapping.announceHost && mapping.announceHost !== 'unknown' && mapping.trackerId) : current.announceMappings;
+
+  const accountAnnounceMappings: BetaAccountAnnounceMapping[] = Array.isArray(body.accountAnnounceMappings) ? body.accountAnnounceMappings.map(rawMapping => {
+    const mapping = rawMapping as Partial<BetaAccountAnnounceMapping>;
+    return {
+      key: String(mapping.key || '').trim(),
+      trackerId: String(mapping.trackerId || '').trim(),
+    };
+  }).filter(mapping => mapping.key && mapping.trackerId) : current.accountAnnounceMappings;
 
   const rawTrackerAlerts = (body.trackerAlerts && typeof body.trackerAlerts === 'object') ? body.trackerAlerts as Record<string, Partial<BetaTrackerAlert>> : current.trackerAlerts;
   const trackerAlerts: Record<string, BetaTrackerAlert> = {};
@@ -1818,7 +1838,7 @@ function saveBetaSettingsPayload(raw: unknown): BetaSettings {
     sessionDays: Number.isFinite(Number(rawGlobal.sessionDays)) ? Number(rawGlobal.sessionDays) : 30,
   };
 
-  const next = { qbitClients, announceMappings, notificationTargets, features, schedule, scheduleOverrides, notificationPreferences, trackerAlerts, globalAlerts, defaults };
+  const next = { qbitClients, announceMappings, accountAnnounceMappings, notificationTargets, features, schedule, scheduleOverrides, notificationPreferences, trackerAlerts, globalAlerts, defaults };
   setJsonSetting(BETA_SETTINGS_KEY, next);
   return next;
 }
@@ -1881,6 +1901,54 @@ function betaTrackerIdForAnnounceHost(announceHost: string, trackerHosts: Map<st
   return best && best.score >= 45 ? best.tracker.id : null;
 }
 
+// Identifiant stable (hash) + libelle masque derives d'une URL d'annonce. Sert a
+// distinguer plusieurs comptes d'un meme site par leur passkey, sans exposer la
+// passkey en clair cote client (seul le hash et un libelle tronque transitent).
+function announceAccountKey(announce: string): { key: string; label: string } {
+  const raw = String(announce || '').trim();
+  if (!raw) return { key: '', label: '' };
+  let token = '';
+  let host = trackerHost(raw);
+  try {
+    const url = new URL(raw);
+    if (host === 'unknown') host = url.host;
+    for (const name of ['passkey', 'authkey', 'torrent_pass', 'auth', 'apikey', 'secret', 'pid', 'rss_key', 'key']) {
+      const value = url.searchParams.get(name);
+      if (value && value.length >= 8) { token = value; break; }
+    }
+    if (!token) {
+      token = url.pathname.split('/').filter(Boolean)
+        .filter(segment => /^[A-Za-z0-9]{16,}$/.test(segment))
+        .sort((a, b) => b.length - a.length)[0] || '';
+    }
+  } catch {
+    return { key: '', label: '' };
+  }
+  const basis = token || raw;
+  const key = crypto.createHash('sha1').update(basis).digest('hex').slice(0, 16);
+  // Libelle masque : on revele juste assez de la passkey pour l'identifier. Sans
+  // passkey reconnue, on suffixe un fragment du hash pour rester distinct entre comptes.
+  const masked = token
+    ? (token.length <= 8 ? token : `${token.slice(0, 4)}…${token.slice(-4)}`)
+    : `#${key.slice(0, 6)}`;
+  return { key, label: `${host} · ${masked}` };
+}
+
+// Resout le compte (trackerId) d'un agregat de torrents : d'abord par attribution
+// manuelle de la passkey a un compte, sinon par l'heuristique host -> tracker.
+function resolveTorrentTrackerId(
+  item: QbitTrackerAggregate,
+  trackerHosts: Map<string, string>,
+  accountByKey: Map<string, string>,
+  trackers: TrackerConfig[],
+): string | null {
+  if (item.announceKey) {
+    const mapped = accountByKey.get(item.announceKey);
+    if (mapped && trackers.some(tracker => tracker.id === mapped)) return mapped;
+  }
+  return betaTrackerIdForAnnounceHost(item.trackerHost, trackerHosts, trackers);
+}
+
 function betaClientLogName(client: BetaQbitClient): string {
   return `${client.label || client.id || 'Client BitTorrent'} (${client.type === 'rutorrent' ? 'ruTorrent/rTorrent' : 'qBittorrent'})`;
 }
@@ -1906,8 +1974,9 @@ function qbitSeedingByTrackerId(trackers: TrackerConfig[]): Map<string, { count:
     trackerHosts.set(host, mapping.trackerId);
     trackerHosts.set(hostDomainKey(host), mapping.trackerId);
   }
+  const accountByKey = new Map(settings.accountAnnounceMappings.map(mapping => [mapping.key, mapping.trackerId]));
   for (const item of betaQbitStats) {
-    const trackerId = betaTrackerIdForAnnounceHost(item.trackerHost, trackerHosts, trackers);
+    const trackerId = resolveTorrentTrackerId(item, trackerHosts, accountByKey, trackers);
     if (!trackerId) continue;
     const entry = result.get(trackerId) ?? { count: 0, types: new Set<string>() };
     entry.count += item.seedingCount;
@@ -2093,11 +2162,17 @@ async function fetchQbitClient(client: BetaQbitClient): Promise<QbitTrackerAggre
       unknownSkipped += 1;
       continue;
     }
-    const existing = groups.get(host) ?? {
+    // Groupe par hote + passkey : deux comptes d'un meme site (memes hote mais
+    // passkeys differentes) forment deux agregats distincts, ventilables par compte.
+    const account = announceAccountKey(announce);
+    const groupKey = account.key ? `${host}|${account.key}` : host;
+    const existing = groups.get(groupKey) ?? {
       clientId: client.id,
       clientLabel: client.label,
       clientBaseUrl: baseUrl,
       trackerHost: host,
+      announceKey: account.key || undefined,
+      announceLabel: account.label || undefined,
       torrentCount: 0,
       seedingCount: 0,
       leechingCount: 0,
@@ -2126,7 +2201,7 @@ async function fetchQbitClient(client: BetaQbitClient): Promise<QbitTrackerAggre
       downloadedBytes: Number.isFinite(down) ? down : 0,
       ratio: Number.isFinite(Number(torrent.ratio)) ? Number(torrent.ratio) : null,
     });
-    groups.set(host, existing);
+    groups.set(groupKey, existing);
   }
   if (missingAnnounce || trackerDetailCalls || unknownSkipped) {
     betaLog(`${betaClientLogName(client)}: annonces absentes dans torrents/info ${missingAnnounce}, appels detail trackers ${trackerDetailCalls}, torrents sans hote ${unknownSkipped}`);
@@ -2211,14 +2286,18 @@ async function fetchRutorrentClient(client: BetaQbitClient): Promise<QbitTracker
     }
     const host = trackerHost(announce);
     if (host === 'unknown') unknownSkipped += 1;
+    const account = announceAccountKey(announce);
+    const groupKey = account.key ? `${host}|${account.key}` : host;
     const up = Number(upRaw) || 0;
     const down = Number(downRaw) || 0;
     const complete = completeRaw === '1';
-    const existing = groups.get(host) ?? {
+    const existing = groups.get(groupKey) ?? {
       clientId: client.id,
       clientLabel: client.label,
       clientBaseUrl: baseUrl,
       trackerHost: host,
+      announceKey: account.key || undefined,
+      announceLabel: account.label || undefined,
       torrentCount: 0,
       seedingCount: 0,
       leechingCount: 0,
@@ -2244,7 +2323,7 @@ async function fetchRutorrentClient(client: BetaQbitClient): Promise<QbitTracker
       downloadedBytes: down,
       ratio: Number.isFinite(Number(ratioRaw)) ? Number(ratioRaw) / 1000 : null,
     });
-    groups.set(host, existing);
+    groups.set(groupKey, existing);
   }
   if (trackerDetailCalls || unknownSkipped) {
     betaLog(`${betaClientLogName(client)}: appels detail trackers ${trackerDetailCalls}, torrents sans hote ${unknownSkipped}`);
@@ -2540,9 +2619,10 @@ export async function start(): Promise<void> {
       trackerHosts.set(host, mapping.trackerId);
       trackerHosts.set(hostDomainKey(host), mapping.trackerId);
     }
+    const accountByKey = new Map(settings.accountAnnounceMappings.map(mapping => [mapping.key, mapping.trackerId]));
     const qbitByTracker = betaQbitStats.map(item => ({
       ...item,
-      trackerId: betaTrackerIdForAnnounceHost(item.trackerHost, trackerHosts, trackers),
+      trackerId: resolveTorrentTrackerId(item, trackerHosts, accountByKey, trackers),
     }));
     const cookieSummaries = listTrackerDefinitionFiles().map(definition => {
       const configured = trackers.find(tracker => tracker.id === definition.id);
@@ -2722,6 +2802,23 @@ export async function start(): Promise<void> {
     res.json({ ok: true, tracker });
   });
 
+  // Renomme le libelle d'affichage d'un tracker (utile pour distinguer plusieurs
+  // comptes : « C411 », « C411 Alex »…). Le nom n'est pas synchronise depuis l'image
+  // (normalizeTrackerConfigs ne touche que login/fetch), donc il persiste.
+  app.post('/api/trackers/:trackerId/name', (req, res) => {
+    importLegacyTrackersIfNeeded();
+    const trackerId = req.params.trackerId;
+    const name = String(req.body?.name ?? '').trim();
+    if (!name) return res.status(400).json({ ok: false, error: 'Nom requis.' });
+    if (name.length > 80) return res.status(400).json({ ok: false, error: 'Nom trop long (80 caracteres max).' });
+    const tracker = loadTrackerConfigsFromDb().find(t => t.id === trackerId)
+      ?? loadTrackerDefinitionFile(trackerId);
+    if (!tracker) return res.status(404).json({ ok: false, error: 'Tracker introuvable' });
+    saveTrackerConfig({ ...tracker, name });
+    trackers = normalizeTrackerConfigs();
+    res.json({ ok: true, tracker: { ...tracker, name } });
+  });
+
   // Duplique un tracker pour gerer plusieurs comptes sur un meme site. Le duplicata
   // reprend la definition technique de la source (via baseId, donc il herite des
   // corrections de login amont) mais possede son propre id : identifiants, cookie,
@@ -2745,7 +2842,7 @@ export async function start(): Promise<void> {
     const duplicate: TrackerConfig = {
       ...source,
       id: newId,
-      name: `${baseName} (compte ${n})`,
+      name: `${baseName} (${n})`,
       baseId,
       enabled: true,
     };


### PR DESCRIPTION
## Objectif

Suite de la duplication de tracker (#96). Quatre demandes :

1. Nommage par défaut des comptes en « (2) » (au lieu de « (compte 2) »).
2. Noms d'affichage modifiables.
3. Correction du débordement du bouton « Supprimer ».
4. Attribution des torrents qBittorrent/ruTorrent à un compte selon la **passkey** de l'URL d'annonce.

## Modifications

### Nommage et renommage
- Duplicata nommé « (2) », « (3) »…
- Endpoint `POST /api/trackers/:id/name` ; champ **Nom d'affichage** + bouton **Renommer** sur la fiche de configuration. Le nom n'est pas synchronisé depuis l'image, il persiste (ex. « C411 », « C411 Alex »).

### Bouton Supprimer
- La carte de config est une grille à colonnes fixes ; les actions ajoutées (Dupliquer / Éditer / Supprimer) débordaient des cellules étroites. Elles passent dans une **barre pleine largeur** (`grid-column:1/-1`), boutons en largeur auto (`white-space:nowrap`).

### Attribution par passkey
- Les agrégats de torrents (`fetchQbitClient` / `fetchRutorrentClient`) sont désormais groupés par **hôte + passkey** (`announceAccountKey` : hash stable SHA-1 tronqué, libellé masqué). La passkey n'est **jamais exposée en clair** côté client (seuls le hash et un libellé tronqué transitent).
- Nouveau mapping `accountAnnounceMappings` (passkey → compte), persisté dans `betaSettings`, configurable sur la **fiche** d'un tracker à comptes multiples (section « Attribution des annonces »).
- Résolution (`resolveTorrentTrackerId`) : attribution manuelle d'abord, sinon heuristique hôte → tracker existante.
- **Rétrocompatibilité** : avec un seul compte, un seul groupe par hôte → comportement strictement identique à aujourd'hui.

## Validation

- `npm run build`
- `npm run check:integration` (56 appels)
- `git diff --check`, contrôle d'encodage, syntaxe inline (0 erreur)
