### PR TITLE
feat(browser): runtime navigateur externalisable optionnel (étape 1/2)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -67,3 +67,50 @@ jobs:
             APP_IMAGE_REF=${{ github.ref_name }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  build-and-push-browser:
+    name: Runtime navigateur (tracker-dashboard-browser)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.3.1
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/tracker-dashboard/tracker-dashboard-browser
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=sha-
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile.browser
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=browser
+          cache-to: type=gha,mode=max,scope=browser

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -60,6 +60,31 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  docker-browser:
+    name: Docker build runtime navigateur
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.3.1
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build runtime navigateur image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile.browser
+          pull: true
+          load: true
+          tags: tracker-dashboard-browser:pr
+          cache-from: type=gha,scope=browser
+          cache-to: type=gha,mode=max,scope=browser
+
       # Les CVE de l'image de base peuvent casser toutes les PR Dependabot sans
       # rapport avec le changement teste. Sur PR on garde donc le scan visible
       # dans les logs, mais non bloquant. Le scan planifie publie le rapport

--- a/Dockerfile.browser
+++ b/Dockerfile.browser
@@ -1,0 +1,49 @@
+# Runtime navigateur externe : tracker-dashboard-browser
+#
+# Service optionnel qui execute les actions navigateur (Playwright/Chromium et
+# CloakBrowser) pour le compte de l'app principale. Il NE touche pas la base : il
+# recoit tout dans le payload HTTP. Les profils persistants sont partages via le
+# volume ./config (config/browser-profile).
+#
+# Demarrage : node --experimental-sqlite dist/browserRuntime.js (port 3001).
+
+FROM node:22-bookworm-slim AS builder
+
+WORKDIR /app
+ARG NPM_VERSION=11.17.0
+RUN npm install -g "npm@${NPM_VERSION}" \
+  && node -e "const v=require('/usr/local/lib/node_modules/npm/node_modules/tar/package.json').version; const [a,b,c]=v.split('.').map(Number); if (a < 7 || (a === 7 && (b < 5 || (b === 5 && c < 16)))) throw new Error('npm embeds vulnerable tar '+v); console.log('npm tar', v);"
+COPY package*.json tsconfig.json ./
+RUN npm ci
+COPY src/ ./src/
+RUN npm run build
+
+# ── Image finale (Playwright + Chromium + CloakBrowser, sans sources TS) ──────
+FROM node:22-bookworm-slim
+
+WORKDIR /app
+ARG NPM_VERSION=11.17.0
+RUN npm install -g "npm@${NPM_VERSION}" \
+  && node -e "const v=require('/usr/local/lib/node_modules/npm/node_modules/tar/package.json').version; const [a,b,c]=v.split('.').map(Number); if (a < 7 || (a === 7 && (b < 5 || (b === 5 && c < 16)))) throw new Error('npm embeds vulnerable tar '+v); console.log('npm tar', v);"
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+COPY package*.json ./
+RUN npm ci --omit=dev
+RUN npx playwright install --with-deps chromium \
+  && chmod -R a+rX /ms-playwright \
+  && node -e "const fs=require('fs'); const { chromium } = require('playwright'); const p=chromium.executablePath(); if (!fs.existsSync(p)) throw new Error('Chromium Playwright introuvable: '+p); console.log('chromium playwright', p);"
+
+# ── CloakBrowser (moteur navigateur furtif, opt-in) ─────────────────────────
+ENV CLOAKBROWSER_CACHE_DIR=/app/.cloakbrowser \
+    CLOAKBROWSER_AUTO_UPDATE=false
+RUN npm install --omit=dev --no-save cloakbrowser playwright-core \
+  && node -e "import('cloakbrowser').then(m => m.ensureBinary && m.ensureBinary()).catch(e => { console.error('CloakBrowser binary skip:', e.message); })" \
+  || echo "::warning:: CloakBrowser indisponible a la construction — Chromium par defaut."
+
+# npm/npx ne sont necessaires qu'a la construction.
+RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx \
+  && node -e "const fs=require('fs'); for (const p of ['/usr/local/lib/node_modules/npm','/usr/local/bin/npm','/usr/local/bin/npx']) if (fs.existsSync(p)) throw new Error('Artefact npm encore present: '+p); console.log('npm retire de l image runtime');"
+
+COPY --from=builder /app/dist ./dist
+
+EXPOSE 3001
+CMD ["node", "--experimental-sqlite", "dist/browserRuntime.js"]

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Au premier accès, l'application demande de créer le compte administrateur de l
 
 ## Changements récents
 
+- **Runtime navigateur externalisable** : service optionnel `tracker-dashboard-browser` (Playwright/Chromium/CloakBrowser) pour alléger l'image principale, avec statut/versions dans la WebUI. L'app reste utilisable sans lui (trackers HTTP).
 - **Plusieurs comptes par tracker** : duplication d'un tracker, noms d'affichage personnalisables, regroupement sous le site, et attribution des torrents par passkey entre comptes.
 - Refonte de la navigation : barre latérale unique, thème clair/sombre/système, nouveau logo.
 - Fiches de trackers enrichies : statut clair, courbes d'évolution UP/DL/ratio (buffer en option), erreurs en cours / récentes / historique.
@@ -147,7 +148,18 @@ Avec le type **SSH**, le dashboard ouvre un tunnel SSH (SOCKS5 local adossé au 
 - Les secrets sont stockés côté serveur, jamais renvoyés en clair (masqués).
 - Le bouton **Tester** établit le tunnel et vérifie l'IP de sortie.
 
-## Moteur navigateur (CloakBrowser)
+## Runtime navigateur (mode simple / mode complet)
+
+Le navigateur (Playwright/Chromium/CloakBrowser) peut être **externalisé** dans un service séparé pour alléger l'image principale. Deux modes :
+
+- **Mode simple (par défaut)** : un seul container `tracker-dashboard`. Les trackers HTTP et le fast-path `curl-impersonate` fonctionnent. Selon la version d'image, le navigateur peut être embarqué.
+- **Mode complet** : ajoutez le service optionnel `tracker-dashboard-browser` et définissez `BROWSER_RUNTIME_URL` (voir `docker-compose.yml`, bloc commenté). Nécessaire pour les trackers en `mode: browser`.
+
+Les deux services partagent le volume `./config` (mêmes SQLite, trackers, cookies, TOTP, proxies, paramètres et `config/browser-profile`). Le service navigateur **ne touche pas la base** : l'app principale reste la source de vérité et lui transmet ce qu'il faut par appel interne. Si le runtime navigateur est absent, l'app reste utilisable : seuls les trackers `mode: browser` échouent avec un message clair. L'état (disponible/indisponible, versions Playwright/Chromium/CloakBrowser) est visible dans **Proxies → Moteur navigateur → Runtime navigateur** (bouton *Vérifier*).
+
+Sécurité : ne publiez pas le port du runtime ; laissez-le joignable uniquement via le réseau Docker interne. Un token partagé optionnel (`BROWSER_RUNTIME_TOKEN` des deux côtés) protège l'API s'il est exposé par erreur.
+
+### Moteur navigateur (CloakBrowser)
 
 Les lectures en mode navigateur utilisent **Chromium** (Playwright) par défaut. Une option (panneau Proxies → Moteur navigateur) bascule sur **[CloakBrowser](https://github.com/CloakHQ/CloakBrowser)**, un Chromium modifié pour présenter une empreinte de vrai navigateur (TLS, fingerprint) et franchir davantage de protections anti-bot. S'il est indisponible, l'app repart automatiquement sur Chromium.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,5 +12,27 @@ services:
       # Pour un test ponctuel sans token : METRICS_PUBLIC=true
       # Ne pas laisser actif si l'instance est exposee hors reseau local.
       # METRICS_PUBLIC: "true"
+      #
+      # ── Mode complet (trackers en mode navigateur) ─────────────────────────
+      # Decommentez la ligne suivante ET le service tracker-dashboard-browser
+      # ci-dessous pour activer les trackers necessitant un navigateur.
+      # BROWSER_RUNTIME_URL: "http://tracker-dashboard-browser:3001"
+      # Optionnel : token partage si le runtime risque d'etre expose.
+      # BROWSER_RUNTIME_TOKEN: "changez-moi"
     volumes:
       - ./config:/app/config
+
+  # ── Service navigateur OPTIONNEL (mode complet) ──────────────────────────────
+  # Necessaire uniquement pour les trackers en mode navigateur (Chromium/CloakBrowser).
+  # Installation simple : laissez ce bloc commente (un seul container).
+  # Installation complete : decommentez ce bloc + BROWSER_RUNTIME_URL ci-dessus.
+  # tracker-dashboard-browser:
+  #   image: ghcr.io/tracker-dashboard/tracker-dashboard-browser:latest
+  #   container_name: tracker-dashboard-browser
+  #   restart: unless-stopped
+  #   # Aucun port publie : joignable seulement par tracker-dashboard via le reseau Docker.
+  #   environment:
+  #     # Doit correspondre a BROWSER_RUNTIME_TOKEN ci-dessus si vous l'activez.
+  #     BROWSER_RUNTIME_TOKEN: "changez-moi"
+  #   volumes:
+  #     - ./config:/app/config

--- a/docs/browser-runtime-externalization.md
+++ b/docs/browser-runtime-externalization.md
@@ -1,0 +1,303 @@
+# Externaliser le runtime navigateur
+
+## Objectifs
+
+- Réduire autant que possible le poids de l'image principale `tracker-dashboard`.
+- Garder les mises à jour aussi simples qu'aujourd'hui pour l'utilisateur final.
+- Ne jamais demander aux utilisateurs existants de repartir de zéro.
+- Préserver le volume `./config`, la base SQLite, les trackers, cookies, TOTP, proxies, paramètres et profils navigateur existants.
+- Ne pas casser les trackers en mode navigateur.
+- Ne pas imposer Playwright, Chromium ou CloakBrowser aux utilisateurs qui n'en ont pas besoin.
+- Rendre l'état du runtime navigateur clair dans la WebUI : absent, installé, version, à jour, erreur.
+
+## Problème actuel
+
+L'image principale embarque actuellement :
+
+- l'application Node ;
+- les dépendances runtime ;
+- Playwright ;
+- Chromium / Chrome Headless Shell / FFmpeg ;
+- les dépendances système installées par `playwright install --with-deps chromium` ;
+- `curl-impersonate` ;
+- CloakBrowser et son binaire.
+
+Résultat : l'image approche 3 Go. C'est trop lourd pour une fonctionnalité qui n'est nécessaire que pour certains trackers.
+
+## Principe cible
+
+Découper le runtime navigateur de l'application principale.
+
+Image principale :
+
+- contient seulement l'app Node, les dépendances HTTP, la logique métier et éventuellement `curl-impersonate` si le poids reste acceptable ;
+- ne contient pas Chromium ;
+- ne contient pas CloakBrowser ;
+- continue à se mettre à jour comme aujourd'hui via `ghcr.io/tracker-dashboard/tracker-dashboard:latest`.
+
+Runtime navigateur externe :
+
+- image dédiée ou service optionnel ;
+- contient Playwright/Chromium ;
+- contient éventuellement CloakBrowser ;
+- expose une API interne appelée par `tracker-dashboard` uniquement quand un tracker nécessite `mode: browser`.
+
+## Modèle retenu
+
+- fournir le runtime navigateur dans une image/service séparé ;
+- le lancer seulement si nécessaire ;
+- le mettre à jour séparément via Dockge/Watchtower/Unraid comme n'importe quel container ;
+- permettre à `tracker-dashboard` de vérifier sa présence et ses versions.
+
+## Compatibilité et migration
+
+La migration doit être transparente pour les installations existantes.
+
+Contraintes fortes :
+
+- aucun reset utilisateur ;
+- aucun changement obligatoire du volume existant `./config:/app/config` ;
+- aucune perte de base SQLite ;
+- aucune perte de trackers configurés ;
+- aucune perte de cookies, TOTP, proxies ou paramètres ;
+- aucune perte des profils navigateur persistants déjà présents dans `config/browser-profile`;
+- même URL WebUI et même port principal `3000`;
+- même image principale `ghcr.io/tracker-dashboard/tracker-dashboard:latest` pour les usages sans navigateur externe.
+
+Le service navigateur externe ne doit pas devenir propriétaire du SQL. La source de vérité reste l'application principale.
+
+Règle d'architecture :
+
+- `tracker-dashboard` lit et écrit SQLite comme aujourd'hui ;
+- `tracker-dashboard` prépare le payload nécessaire à l'exécution navigateur ;
+- `tracker-dashboard-browser` exécute l'action navigateur et renvoie le résultat ;
+- `tracker-dashboard-browser` ne modifie pas les réglages, les trackers, les credentials ou les proxies en base ;
+- si un accès aux profils persistants est nécessaire, les deux services partagent le même volume `./config:/app/config`.
+
+Les utilisateurs existants doivent pouvoir migrer ainsi :
+
+1. mettre à jour `tracker-dashboard` comme d'habitude ;
+2. constater que les trackers HTTP continuent de fonctionner ;
+3. voir dans la WebUI si un runtime navigateur externe est requis pour certains trackers ;
+4. ajouter le service `tracker-dashboard-browser` au compose seulement s'ils utilisent des trackers `mode: browser` ;
+5. conserver automatiquement les sessions et profils existants via `config/browser-profile`.
+
+Si le runtime navigateur externe est absent, l'application principale doit rester utilisable. Seules les actions nécessitant un navigateur doivent échouer avec un message clair.
+
+## Architecture recommandée
+
+### 1. Service principal léger
+
+`tracker-dashboard`
+
+- garde le port `3000`;
+- garde le volume `./config:/app/config`;
+- garde la compatibilité avec les installations actuelles ;
+- fonctionne entièrement pour les trackers HTTP et le fast-path `curl-impersonate` si conservé.
+
+### 2. Service navigateur optionnel
+
+`tracker-dashboard-browser`
+
+- image dédiée, par exemple `ghcr.io/tracker-dashboard/tracker-dashboard-browser:latest`;
+- expose uniquement une API interne, par exemple `3001`;
+- aucun port public obligatoire ;
+- partage le volume de configuration si nécessaire pour les profils persistants :
+
+```yaml
+services:
+  tracker-dashboard:
+    image: ghcr.io/tracker-dashboard/tracker-dashboard:latest
+    container_name: tracker-dashboard
+    restart: always
+    ports:
+      - "3000:3000"
+    environment:
+      BROWSER_RUNTIME_URL: "http://tracker-dashboard-browser:3001"
+    volumes:
+      - ./config:/app/config
+
+  tracker-dashboard-browser:
+    image: ghcr.io/tracker-dashboard/tracker-dashboard-browser:latest
+    container_name: tracker-dashboard-browser
+    restart: unless-stopped
+    volumes:
+      - ./config:/app/config
+```
+
+Pour rester simple, documenter deux modes :
+
+- installation simple : un seul container, sans navigateur externe ;
+- installation complète : deux containers, nécessaire pour les trackers `mode: browser`.
+
+## API du runtime navigateur
+
+Prévoir une petite API HTTP interne.
+
+Endpoints minimum :
+
+- `GET /health`
+- `GET /version`
+- `POST /fetch`
+- `POST /reset-profile`
+- `POST /close-session`
+- `POST /close-all`
+
+`GET /version` doit retourner par exemple :
+
+```json
+{
+  "ok": true,
+  "runtime": "tracker-dashboard-browser",
+  "playwright": "1.61.0",
+  "chromiumExecutable": "/ms-playwright/...",
+  "chromiumVersion": "149.0.7827.55",
+  "cloakbrowser": {
+    "available": true,
+    "version": "..."
+  }
+}
+```
+
+`POST /fetch` doit recevoir les éléments nécessaires à l'équivalent actuel de `fetchWithBrowser` :
+
+- tracker config utile ;
+- credentials ;
+- cookies ;
+- proxy résolu ou config proxy ;
+- moteur demandé : `chromium` ou `cloak` ;
+- timeout ;
+- identifiant tracker.
+
+Réponse attendue :
+
+```json
+{
+  "ok": true,
+  "url": "https://...",
+  "html": "...",
+  "extraHtml": "...",
+  "authConfirmed": true,
+  "engine": "chromium"
+}
+```
+
+## Points de code à modifier
+
+### `src/browserFetcher.ts`
+
+Aujourd'hui, ce fichier importe directement Playwright :
+
+```ts
+import { chromium, type BrowserContext, type Page } from 'playwright';
+```
+
+Il lance ensuite :
+
+- `chromium.launchPersistentContext(...)`
+- `chromium.launch(...)`
+- éventuellement `cloak.launchPersistentContext(...)`
+
+À faire :
+
+- introduire une abstraction `BrowserRuntime`;
+- garder un backend local temporaire si Playwright est encore présent ;
+- ajouter un backend distant qui appelle `BROWSER_RUNTIME_URL`;
+- faire de `fetchWithBrowser(...)` un appel au runtime distant quand `BROWSER_RUNTIME_URL` est défini ;
+- retourner une erreur claire si un tracker navigateur est demandé mais que le runtime externe est absent.
+
+Message utilisateur attendu :
+
+> Runtime navigateur non disponible. Ajoutez le service tracker-dashboard-browser ou désactivez les trackers en mode navigateur.
+
+### `src/server.ts`
+
+Il existe déjà un réglage :
+
+- `GET /api/settings/browser-engine`
+- `POST /api/settings/browser-engine`
+
+À compléter :
+
+- `GET /api/browser-runtime/status`
+- affichage dans la WebUI : disponible, indisponible, versions, moteur actif ;
+- bouton "Vérifier le runtime navigateur" ;
+- lien vers la documentation d'installation.
+
+### `Dockerfile`
+
+Objectif image principale :
+
+- retirer `npx playwright install --with-deps chromium`;
+- retirer l'installation CloakBrowser ;
+- retirer `PLAYWRIGHT_BROWSERS_PATH` si inutilisé ;
+- idéalement remplacer la dépendance `playwright` par `playwright-core` seulement si nécessaire côté types/API, ou retirer complètement Playwright de l'image principale si le backend distant couvre tout.
+
+À garder provisoirement :
+
+- `curl-impersonate`, sauf si son poids devient lui aussi problématique.
+
+### Nouveau Dockerfile navigateur
+
+Créer par exemple :
+
+- `Dockerfile.browser`
+
+Contenu :
+
+- base Node compatible ;
+- `playwright`;
+- `playwright install --with-deps chromium`;
+- `cloakbrowser` optionnel ou inclus dans cette image ;
+- petit serveur HTTP interne ;
+- partage de `/app/config` pour profils et dumps.
+
+## Versions et mises à jour
+
+Le service principal doit pouvoir dire :
+
+- runtime absent ;
+- runtime présent ;
+- version Playwright attendue ;
+- version Playwright installée ;
+- Chromium trouvé ;
+- CloakBrowser disponible ou non.
+
+Important : ne pas bloquer toute l'application si le runtime navigateur est absent. Seuls les trackers `mode: browser` doivent échouer avec un message clair.
+
+Politique de mise à jour :
+
+- l'image principale suit `tracker-dashboard:latest`;
+- l'image navigateur suit `tracker-dashboard-browser:latest`;
+- Dockge/Watchtower/Unraid peuvent mettre à jour les deux images séparément ;
+- la WebUI peut signaler une différence de version, mais ne doit pas auto-puller une image Docker sans consentement explicite.
+
+## Sécurité
+
+- Ne pas exposer le runtime navigateur sur Internet.
+- Idéalement ne pas publier son port côté host.
+- L'app principale doit l'appeler via le réseau Docker interne.
+- Ajouter un token partagé optionnel si le runtime peut être exposé par erreur :
+  - `BROWSER_RUNTIME_TOKEN`
+  - header `X-Browser-Runtime-Token`
+- Ne jamais envoyer les secrets tracker dans les logs.
+
+## Plan de migration conseillé
+
+1. Ajouter le runtime distant sans retirer immédiatement le runtime local.
+2. Ajouter la WebUI de statut.
+3. Ajouter `Dockerfile.browser` et le compose optionnel.
+4. Basculer les trackers navigateur vers le runtime distant si `BROWSER_RUNTIME_URL` est défini.
+5. Une fois validé, alléger l'image principale en retirant Chromium/CloakBrowser.
+6. Mettre à jour README et exemples Dockge/Unraid.
+
+## Critères d'acceptation
+
+- L'image principale ne contient plus `/ms-playwright`.
+- L'image principale ne préinstalle plus CloakBrowser.
+- Les trackers HTTP fonctionnent sans service navigateur.
+- Les trackers `mode: browser` affichent une erreur claire si le runtime navigateur est absent.
+- Avec `tracker-dashboard-browser`, les trackers navigateur fonctionnent comme avant.
+- La WebUI affiche les versions Playwright/Chromium/CloakBrowser disponibles.
+- Les mises à jour restent simples : pull/recreate de l'image principale et, si utilisé, pull/recreate de l'image navigateur.
+- README mis à jour avec mode simple et mode complet.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
     "check:integration": "node scripts/check-integration.mjs && node scripts/check-unread-messages.mjs",
-    "start": "node --experimental-sqlite dist/index.js"
+    "start": "node --experimental-sqlite dist/index.js",
+    "start:browser": "node --experimental-sqlite dist/browserRuntime.js"
   },
   "dependencies": {
     "axios": "^1.18.0",

--- a/public/index.html
+++ b/public/index.html
@@ -1955,6 +1955,14 @@
     <p style="font-size:12px; color:var(--muted); margin:8px 0 0; max-width:760px">
       Par défaut, les lectures en mode navigateur utilisent <b>Chromium</b> (Playwright). <a href="https://github.com/CloakHQ/CloakBrowser" target="_blank" rel="noreferrer noopener" style="color:var(--blue); text-decoration:none">CloakBrowser</a> est un Chromium modifié au niveau source pour ressembler à un vrai navigateur côté empreinte (TLS, fingerprint), ce qui lui permet de franchir davantage de protections anti-bot — notamment certains challenges Cloudflare Turnstile qui se valident automatiquement — donc moins de sites nécessitant un cookie collé à la main. Mêmes performances qu'un Chromium classique (c'est un navigateur complet). Si le moteur est indisponible, l'app repart automatiquement sur Chromium.
     </p>
+    <div class="proxy-info" style="margin-top:14px; max-width:760px">
+      <div style="display:flex; align-items:center; gap:10px; flex-wrap:wrap">
+        <b>Runtime navigateur</b>
+        <span id="browser-runtime-badge" class="definition-badge definition-badge-muted">…</span>
+        <button class="btn-test" style="padding:4px 10px" onclick="loadBrowserRuntimeStatus()" type="button">Vérifier</button>
+      </div>
+      <div id="browser-runtime-detail" class="beta-note" style="margin-top:8px"></div>
+    </div>
     <div class="proxy-form" style="align-items:flex-start; margin-top:14px">
       <label class="toggle-switch" style="grid-column:span 5" title="Lecture rapide via curl-impersonate">
         <input type="checkbox" id="fast-fetch-enabled" onchange="saveFastFetch()">
@@ -6473,6 +6481,40 @@
     } catch (e) { console.warn('Browser engine unavailable', e); }
   }
 
+  // Etat du runtime navigateur : embarque (local) ou service externe + versions.
+  async function loadBrowserRuntimeStatus() {
+    const badge = document.getElementById('browser-runtime-badge');
+    const detail = document.getElementById('browser-runtime-detail');
+    if (!badge || !detail) return;
+    badge.textContent = 'Vérification…';
+    badge.className = 'definition-badge definition-badge-muted';
+    try {
+      const r = await fetch('/api/browser-runtime/status');
+      const d = await r.json();
+      const s = d.status || {};
+      if (s.mode === 'local') {
+        badge.textContent = 'Embarqué (Chromium local)';
+        badge.className = 'definition-badge';
+        detail.innerHTML = 'Le navigateur est inclus dans l\'image principale. Pour alléger l\'image, ajoutez le service <code>tracker-dashboard-browser</code> et définissez <code>BROWSER_RUNTIME_URL</code>.';
+        return;
+      }
+      if (s.available) {
+        badge.textContent = 'Service externe — disponible';
+        badge.className = 'definition-badge';
+        const cloak = s.cloakbrowser?.available ? `oui${s.cloakbrowser.version ? ' (' + escapeHtml(s.cloakbrowser.version) + ')' : ''}` : 'non';
+        detail.innerHTML = `Playwright <b>${escapeHtml(s.playwright || '?')}</b> · Chromium <b>${escapeHtml(s.chromiumVersion || '?')}</b> · CloakBrowser ${cloak}<br><span style="color:var(--muted)">${escapeHtml(s.url || '')}</span>`;
+      } else {
+        badge.textContent = 'Service externe — indisponible';
+        badge.className = 'definition-badge definition-badge-muted';
+        badge.style.color = 'var(--red)';
+        detail.innerHTML = `Runtime configuré (<code>${escapeHtml(s.url || '')}</code>) mais injoignable${s.error ? ' : ' + escapeHtml(s.error) : ''}. Les trackers en mode navigateur échoueront tant que le service <code>tracker-dashboard-browser</code> n'est pas démarré.`;
+      }
+    } catch (e) {
+      badge.textContent = 'Inconnu';
+      detail.textContent = 'Statut indisponible : ' + e.message;
+    }
+  }
+
   async function saveBrowserEngine() {
     const engine = document.getElementById('browser-engine-cloak').checked ? 'cloak' : 'chromium';
     try {
@@ -6760,6 +6802,7 @@
     await loadPresentationMode();
     await loadProxySettings();
     await loadBrowserEngine();
+    loadBrowserRuntimeStatus();
     await loadFastFetch();
     await loadTrackerDefinitionsPanel();
     getActiveGrid().innerHTML = renderSkeleton(trackerCount);

--- a/src/browserBackend.ts
+++ b/src/browserBackend.ts
@@ -1,0 +1,226 @@
+// Abstraction du runtime navigateur.
+//
+// Objectif : permettre d'externaliser Playwright/Chromium/CloakBrowser dans un
+// service separe `tracker-dashboard-browser` sans casser les installations
+// existantes.
+//
+// - Si `BROWSER_RUNTIME_URL` est defini -> backend DISTANT : l'app principale
+//   resout cookie/TOTP/moteur/proxy depuis la DB, les envoie dans le payload, et
+//   le runtime execute le navigateur (il ne touche jamais la DB).
+// - Sinon -> backend LOCAL : import dynamique de `browserFetcher` (Playwright dans
+//   l'image principale, comportement historique strictement inchange).
+//
+// L'import de `browserFetcher` est dynamique pour que l'app principale puisse, a
+// terme (image allegee sans Playwright), fonctionner pour les trackers HTTP meme
+// sans ce module.
+
+import { resolveProxyForTracker, toSshConfig } from './proxy.js';
+import { getSshLocalEndpoint } from './sshTunnel.js';
+import { getTrackerCookie, getTrackerTotpSecret, getJsonSetting } from './db.js';
+import { type TrackerConfig } from './types.js';
+
+export interface BrowserFetchResult {
+  html: string;
+  url: string;
+  authConfirmed: boolean;
+  extraHtml?: string;
+}
+
+export interface BrowserRuntimeStatus {
+  mode: 'remote' | 'local';
+  configured: boolean;
+  available: boolean;
+  url?: string;
+  error?: string;
+  runtime?: string;
+  playwright?: string;
+  chromiumVersion?: string;
+  chromiumExecutable?: string;
+  cloakbrowser?: { available: boolean; version?: string };
+}
+
+type ProxyPayload = { server: string; username?: string; password?: string } | null;
+
+const RUNTIME_URL = (process.env.BROWSER_RUNTIME_URL || '').replace(/\/+$/, '');
+const RUNTIME_TOKEN = process.env.BROWSER_RUNTIME_TOKEN || '';
+// Hote sous lequel le runtime peut joindre le tunnel SSH local de l'app principale
+// (le runtime tourne dans un autre conteneur, 127.0.0.1 ne conviendrait pas).
+const SELF_HOST_FOR_RUNTIME = process.env.SSH_TUNNEL_ADVERTISE_HOST || '';
+
+export function isRemoteRuntimeConfigured(): boolean {
+  return RUNTIME_URL.length > 0;
+}
+
+export const BROWSER_RUNTIME_UNAVAILABLE =
+  'Runtime navigateur non disponible. Ajoutez le service tracker-dashboard-browser ou désactivez les trackers en mode navigateur.';
+
+function runtimeHeaders(): Record<string, string> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (RUNTIME_TOKEN) headers['X-Browser-Runtime-Token'] = RUNTIME_TOKEN;
+  return headers;
+}
+
+// Resout le proxy au format Playwright pour le payload distant. Pour SSH, on pointe
+// vers le SOCKS local du tunnel etabli par l'app principale ; son hote doit etre
+// joignable par le runtime (SSH_TUNNEL_ADVERTISE_HOST), sinon le proxy est omis.
+function resolveProxyPayload(trackerId: string): ProxyPayload {
+  const proxy = resolveProxyForTracker(trackerId);
+  if (!proxy.enabled || !proxy.host || !proxy.port) return null;
+  if (proxy.type === 'ssh') {
+    const ssh = toSshConfig(proxy);
+    const endpoint = ssh ? getSshLocalEndpoint(ssh) : null;
+    if (!endpoint) return null;
+    const host = SELF_HOST_FOR_RUNTIME || endpoint.host;
+    return { server: `socks5://${host}:${endpoint.port}` };
+  }
+  return {
+    server: `${proxy.type}://${proxy.host}:${proxy.port}`,
+    username: proxy.username || undefined,
+    password: proxy.password || undefined,
+  };
+}
+
+function buildOverrides(tracker: TrackerConfig) {
+  return {
+    cookie: getTrackerCookie(tracker.id) || '',
+    totpSecret: getTrackerTotpSecret(tracker.id) || '',
+    engine: getJsonSetting('browser_engine', 'chromium' as string),
+    proxy: resolveProxyPayload(tracker.id),
+  };
+}
+
+// Charge le backend local (Playwright). Si le module est indisponible (image
+// allegee sans Playwright et aucun runtime distant configure), on renvoie le
+// message clair attendu plutot qu'une erreur d'import opaque.
+async function loadLocalBackend(): Promise<typeof import('./browserFetcher.js')> {
+  try {
+    return await import('./browserFetcher.js');
+  } catch {
+    throw new Error(BROWSER_RUNTIME_UNAVAILABLE);
+  }
+}
+
+async function remotePost<T>(path: string, body: unknown, timeoutMs = 120_000): Promise<T> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(`${RUNTIME_URL}${path}`, {
+      method: 'POST',
+      headers: runtimeHeaders(),
+      body: JSON.stringify(body ?? {}),
+      signal: controller.signal,
+    });
+    const data = await response.json().catch(() => ({}));
+    if (!response.ok || (data && data.ok === false)) {
+      throw new Error((data && data.error) || `runtime HTTP ${response.status}`);
+    }
+    return data as T;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ── API consommee par fetcher.ts / server.ts ────────────────────────────────
+
+export async function fetchWithBrowser(
+  tracker: TrackerConfig,
+  credentials: { username: string; password: string },
+): Promise<BrowserFetchResult> {
+  if (isRemoteRuntimeConfigured()) {
+    try {
+      return await remotePost<BrowserFetchResult>('/fetch', {
+        tracker,
+        credentials,
+        overrides: buildOverrides(tracker),
+      });
+    } catch (err) {
+      // Erreur de connexion au runtime (absent/injoignable) -> message clair ;
+      // une erreur applicative renvoyee par le runtime est propagee telle quelle.
+      const msg = err instanceof Error ? err.message : String(err);
+      if (/fetch failed|aborted|ECONNREFUSED|ENOTFOUND|EAI_AGAIN|network/i.test(msg)) {
+        throw new Error(BROWSER_RUNTIME_UNAVAILABLE);
+      }
+      throw err;
+    }
+  }
+  const local = await loadLocalBackend();
+  return local.fetchWithBrowser(tracker, credentials);
+}
+
+export async function fetchRawHtmlWithBrowser(url: string, trackerId = '__detect__'): Promise<string> {
+  if (isRemoteRuntimeConfigured()) {
+    try {
+      const data = await remotePost<{ html: string }>('/fetch-raw', {
+        url,
+        trackerId,
+        proxy: resolveProxyPayload(trackerId),
+      });
+      return data.html || '';
+    } catch {
+      return '';
+    }
+  }
+  const local = await loadLocalBackend();
+  return local.fetchRawHtmlWithBrowser(url, trackerId);
+}
+
+export async function closeBrowserSession(trackerId: string): Promise<void> {
+  if (isRemoteRuntimeConfigured()) {
+    await remotePost('/close-session', { trackerId }, 15_000).catch(() => {});
+    return;
+  }
+  const local = await loadLocalBackend();
+  await local.closeBrowserSession(trackerId);
+}
+
+export async function closeBrowserSessions(): Promise<void> {
+  if (isRemoteRuntimeConfigured()) {
+    await remotePost('/close-all', {}, 15_000).catch(() => {});
+    return;
+  }
+  const local = await loadLocalBackend();
+  await local.closeBrowserSessions();
+}
+
+export async function resetBrowserProfile(trackerId: string): Promise<void> {
+  if (isRemoteRuntimeConfigured()) {
+    await remotePost('/reset-profile', { trackerId }, 30_000);
+    return;
+  }
+  const local = await loadLocalBackend();
+  await local.resetBrowserProfile(trackerId);
+}
+
+export async function getBrowserRuntimeStatus(): Promise<BrowserRuntimeStatus> {
+  if (!isRemoteRuntimeConfigured()) {
+    // Backend local : Playwright embarque dans l'image principale (cas historique).
+    return { mode: 'local', configured: false, available: true };
+  }
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 8_000);
+    const response = await fetch(`${RUNTIME_URL}/version`, {
+      headers: RUNTIME_TOKEN ? { 'X-Browser-Runtime-Token': RUNTIME_TOKEN } : {},
+      signal: controller.signal,
+    }).finally(() => clearTimeout(timer));
+    const data = await response.json().catch(() => ({} as Record<string, unknown>));
+    if (!response.ok) {
+      return { mode: 'remote', configured: true, available: false, url: RUNTIME_URL, error: `HTTP ${response.status}` };
+    }
+    return {
+      mode: 'remote',
+      configured: true,
+      available: true,
+      url: RUNTIME_URL,
+      runtime: typeof data.runtime === 'string' ? data.runtime : undefined,
+      playwright: typeof data.playwright === 'string' ? data.playwright : undefined,
+      chromiumVersion: typeof data.chromiumVersion === 'string' ? data.chromiumVersion : undefined,
+      chromiumExecutable: typeof data.chromiumExecutable === 'string' ? data.chromiumExecutable : undefined,
+      cloakbrowser: (data.cloakbrowser && typeof data.cloakbrowser === 'object')
+        ? data.cloakbrowser as { available: boolean; version?: string }
+        : undefined,
+    };
+  } catch (err) {
+    return { mode: 'remote', configured: true, available: false, url: RUNTIME_URL, error: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/src/browserFetcher.ts
+++ b/src/browserFetcher.ts
@@ -33,8 +33,19 @@ async function loadCloak(): Promise<CloakModule | null> {
   }
   return cloakModulePromise;
 }
-function cloakEnabled(): boolean {
-  return getJsonSetting('browser_engine', 'chromium' as string) === 'cloak';
+// Overrides optionnels fournis par le runtime navigateur externe : ils remplacent
+// les lectures DB (cookie, TOTP, moteur, proxy). Quand `overrides` est absent (chemin
+// local historique), tout retombe sur la DB et le comportement est strictement identique.
+export interface BrowserFetchOverrides {
+  cookie?: string;
+  totpSecret?: string;
+  engine?: string;
+  proxy?: { server: string; username?: string; password?: string } | null;
+}
+
+function cloakEnabled(overrides?: BrowserFetchOverrides): boolean {
+  const engine = overrides?.engine ?? getJsonSetting('browser_engine', 'chromium' as string);
+  return engine === 'cloak';
 }
 
 // Cookie minimal : on garde juste name+value (+ flags), et on injecte via `url`
@@ -259,8 +270,8 @@ export function buildCookieHeader(trackerId: string): string {
     .join('; ');
 }
 
-async function injectStoredCookies(tracker: TrackerConfig, context: BrowserContext): Promise<void> {
-  const raw = getTrackerCookie(tracker.id);
+async function injectStoredCookies(tracker: TrackerConfig, context: BrowserContext, overrides?: BrowserFetchOverrides): Promise<void> {
+  const raw = overrides ? (overrides.cookie ?? '') : getTrackerCookie(tracker.id);
   if (!raw) return;
   const parsed = parseCookies(raw);
   if (parsed.length === 0) {
@@ -323,7 +334,10 @@ function isAnubisChallenge(html: string): boolean {
     html.includes("Verification que vous n&#39;etes pas un robot");
 }
 
-function playwrightProxy(trackerId: string): { server: string; username?: string; password?: string } | undefined {
+function playwrightProxy(trackerId: string, overrides?: BrowserFetchOverrides): { server: string; username?: string; password?: string } | undefined {
+  // Runtime externe : le proxy est deja resolu cote app principale (y compris le
+  // socks du tunnel SSH), on l'utilise tel quel sans relire la DB ni le tunnel local.
+  if (overrides) return overrides.proxy ?? undefined;
   const proxy = resolveProxyForTracker(trackerId);
   if (!proxy.enabled || !proxy.host || !proxy.port) return undefined;
   // Proxy SSH : on pointe vers le SOCKS5 local du tunnel (etabli par ensureProxyReady
@@ -342,7 +356,7 @@ function playwrightProxy(trackerId: string): { server: string; username?: string
   };
 }
 
-async function getContext(tracker: TrackerConfig): Promise<BrowserContext> {
+async function getContext(tracker: TrackerConfig, overrides?: BrowserFetchOverrides): Promise<BrowserContext> {
   const existing = contexts.get(tracker.id);
   if (existing) return existing;
 
@@ -351,13 +365,13 @@ async function getContext(tracker: TrackerConfig): Promise<BrowserContext> {
   const launchOptions = {
     headless: true,
     userAgent: selectUserAgent(),
-    proxy: playwrightProxy(tracker.id),
+    proxy: playwrightProxy(tracker.id, overrides),
     viewport: { width: 1365, height: 900 },
     locale: 'fr-FR',
   };
 
   let context: BrowserContext | null = null;
-  if (cloakEnabled()) {
+  if (cloakEnabled(overrides)) {
     const cloak = await loadCloak();
     if (cloak) {
       try {
@@ -372,7 +386,7 @@ async function getContext(tracker: TrackerConfig): Promise<BrowserContext> {
   if (!context) {
     context = await chromium.launchPersistentContext(userDataDir, launchOptions);
   }
-  await injectStoredCookies(tracker, context);
+  await injectStoredCookies(tracker, context, overrides);
   contexts.set(tracker.id, context);
   return context;
 }
@@ -569,6 +583,7 @@ async function ensureLoggedIn(
   tracker: TrackerConfig,
   credentials: { username: string; password: string },
   page: Page,
+  overrides?: BrowserFetchOverrides,
 ): Promise<void> {
   const html = await safeContent(page);
   if (!hasFailurePattern(html, tracker.login.failurePatterns)) return;
@@ -643,7 +658,7 @@ async function ensureLoggedIn(
   }
 
   // 2FA : si un secret TOTP est enregistre, on remplit le champ du code avant submit.
-  const totpSecret = getTrackerTotpSecret(tracker.id);
+  const totpSecret = overrides ? (overrides.totpSecret ?? '') : getTrackerTotpSecret(tracker.id);
   if (totpSecret) {
     const code = generateTotp(totpSecret);
     if (code) {
@@ -767,8 +782,9 @@ async function ensureLoggedIn(
 export async function fetchWithBrowser(
   tracker: TrackerConfig,
   credentials: { username: string; password: string },
+  overrides?: BrowserFetchOverrides,
 ): Promise<{ html: string; url: string; authConfirmed: boolean; extraHtml?: string }> {
-  const context = await getContext(tracker);
+  const context = await getContext(tracker, overrides);
   const page = await context.newPage();
   const url = resolveUrl(tracker.baseUrl, interpolate(tracker.fetch.url, {
     username: credentials.username,
@@ -780,7 +796,7 @@ export async function fetchWithBrowser(
     await page.waitForLoadState('domcontentloaded', { timeout: 30_000 }).catch(() => {});
     await waitForAnubis(page);
     await waitForLiveView(page);
-    await ensureLoggedIn(tracker, credentials, page);
+    await ensureLoggedIn(tracker, credentials, page, overrides);
     await page.goto(url, { waitUntil: 'commit', timeout: 45_000 });
     await page.waitForLoadState('domcontentloaded', { timeout: 30_000 }).catch(() => {});
     await waitForAnubis(page);
@@ -845,7 +861,7 @@ export async function fetchWithBrowser(
  * HTTP echoue (Cloudflare/JS). Aucun login, aucune session : usage strictement
  * lecture-seule d'une page publique (ex: page de login). Best-effort : renvoie '' en cas d'echec.
  */
-export async function fetchRawHtmlWithBrowser(url: string, trackerId = '__detect__'): Promise<string> {
+export async function fetchRawHtmlWithBrowser(url: string, trackerId = '__detect__', overrides?: BrowserFetchOverrides): Promise<string> {
   const contextOptions = {
     userAgent: selectUserAgent(),
     viewport: { width: 1365, height: 900 },
@@ -853,7 +869,7 @@ export async function fetchRawHtmlWithBrowser(url: string, trackerId = '__detect
   };
   let browser: Awaited<ReturnType<typeof chromium.launch>> | null = null;
   try {
-    browser = await chromium.launch({ headless: true, proxy: playwrightProxy(trackerId) });
+    browser = await chromium.launch({ headless: true, proxy: playwrightProxy(trackerId, overrides) });
     const context = await browser.newContext(contextOptions);
     const page = await context.newPage();
     await page.goto(url, { waitUntil: 'commit', timeout: 45_000 });

--- a/src/browserRuntime.ts
+++ b/src/browserRuntime.ts
@@ -1,0 +1,132 @@
+// Runtime navigateur externe `tracker-dashboard-browser`.
+//
+// Service HTTP interne, sans acces a la base : il recoit de l'app principale tout
+// ce qu'il faut (tracker, credentials, cookie, TOTP, moteur, proxy resolu) et
+// execute l'action navigateur via Playwright/CloakBrowser, en reutilisant la
+// logique de browserFetcher. Les profils persistants sont partages via le volume
+// ./config (config/browser-profile), comme l'app principale.
+//
+// Demarrage : node --experimental-sqlite dist/browserRuntime.js
+// (le flag est requis uniquement parce que browserFetcher importe db.js ; aucune
+// fonction DB n'est jamais appelee ici — tout passe par les overrides du payload.)
+
+import express from 'express';
+import { createRequire } from 'module';
+import { execFile } from 'child_process';
+import { chromium } from 'playwright';
+import {
+  fetchWithBrowser,
+  fetchRawHtmlWithBrowser,
+  resetBrowserProfile,
+  closeBrowserSession,
+  closeBrowserSessions,
+  type BrowserFetchOverrides,
+} from './browserFetcher.js';
+
+const require = createRequire(import.meta.url);
+const PORT = Number(process.env.BROWSER_RUNTIME_PORT || 3001);
+const TOKEN = process.env.BROWSER_RUNTIME_TOKEN || '';
+
+function playwrightVersion(): string | undefined {
+  try {
+    return require('playwright/package.json').version;
+  } catch {
+    return undefined;
+  }
+}
+
+async function chromiumVersion(executable: string): Promise<string | undefined> {
+  if (!executable) return undefined;
+  return new Promise(resolve => {
+    execFile(executable, ['--version'], { timeout: 5000 }, (err, stdout) => {
+      if (err) return resolve(undefined);
+      const match = /[\d.]+/.exec(String(stdout));
+      resolve(match ? match[0] : undefined);
+    });
+  });
+}
+
+async function cloakbrowserInfo(): Promise<{ available: boolean; version?: string }> {
+  try {
+    const spec = 'cloakbrowser'; // specifier non litteral -> non resolu a la compilation
+    await import(spec);
+    let version: string | undefined;
+    try { version = require('cloakbrowser/package.json').version; } catch { /* version best-effort */ }
+    return { available: true, version };
+  } catch {
+    return { available: false };
+  }
+}
+
+const app = express();
+app.use(express.json({ limit: '2mb' }));
+
+// Auth optionnelle par token partage (si le service est expose par erreur).
+app.use((req, res, next) => {
+  if (req.path === '/health') return next();
+  if (TOKEN && req.get('X-Browser-Runtime-Token') !== TOKEN) {
+    return res.status(401).json({ ok: false, error: 'token invalide' });
+  }
+  next();
+});
+
+app.get('/health', (_req, res) => {
+  res.json({ ok: true });
+});
+
+app.get('/version', async (_req, res) => {
+  const executable = (() => { try { return chromium.executablePath(); } catch { return ''; } })();
+  res.json({
+    ok: true,
+    runtime: 'tracker-dashboard-browser',
+    playwright: playwrightVersion(),
+    chromiumExecutable: executable || undefined,
+    chromiumVersion: await chromiumVersion(executable),
+    cloakbrowser: await cloakbrowserInfo(),
+  });
+});
+
+app.post('/fetch', async (req, res) => {
+  try {
+    const { tracker, credentials, overrides } = req.body ?? {};
+    if (!tracker || !credentials) return res.status(400).json({ ok: false, error: 'payload incomplet (tracker/credentials requis)' });
+    const result = await fetchWithBrowser(tracker, credentials, (overrides ?? {}) as BrowserFetchOverrides);
+    res.json({ ok: true, ...result });
+  } catch (err) {
+    res.status(200).json({ ok: false, error: err instanceof Error ? err.message : String(err) });
+  }
+});
+
+app.post('/fetch-raw', async (req, res) => {
+  try {
+    const { url, trackerId, proxy } = req.body ?? {};
+    if (!url) return res.status(400).json({ ok: false, error: 'url requise' });
+    const html = await fetchRawHtmlWithBrowser(String(url), String(trackerId || '__detect__'), { proxy: proxy ?? null });
+    res.json({ ok: true, html });
+  } catch (err) {
+    res.status(200).json({ ok: false, error: err instanceof Error ? err.message : String(err) });
+  }
+});
+
+app.post('/reset-profile', async (req, res) => {
+  try {
+    await resetBrowserProfile(String(req.body?.trackerId || ''));
+    res.json({ ok: true });
+  } catch (err) {
+    res.status(200).json({ ok: false, error: err instanceof Error ? err.message : String(err) });
+  }
+});
+
+app.post('/close-session', async (req, res) => {
+  await closeBrowserSession(String(req.body?.trackerId || '')).catch(() => {});
+  res.json({ ok: true });
+});
+
+app.post('/close-all', async (_req, res) => {
+  await closeBrowserSessions().catch(() => {});
+  res.json({ ok: true });
+});
+
+app.listen(PORT, () => {
+  console.log(`[tracker-dashboard-browser] runtime navigateur en ecoute sur le port ${PORT}${TOKEN ? ' (token actif)' : ''}`);
+});

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -20,7 +20,7 @@ import { buildCookieHeader } from './browserFetcher.js';
 import { getTrackerTotpSecret, loadTrackerConfigsFromDb, saveTrackerConfig } from './db.js';
 import { generateTotp } from './totp.js';
 import { selectUserAgent } from './userAgent.js';
-import { closeBrowserSession, closeBrowserSessions, fetchWithBrowser } from './browserFetcher.js';
+import { closeBrowserSession, closeBrowserSessions, fetchWithBrowser } from './browserBackend.js';
 
 // ─── Transforms ──────────────────────────────────────────────────────────────
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,7 +4,7 @@ import fs from 'fs';
 import { fileURLToPath } from 'url';
 import axios from 'axios';
 import { fetchTracker, invalidateAllSessions, invalidateSession } from './fetcher.js';
-import { resetBrowserProfile, closeBrowserSession, fetchRawHtmlWithBrowser } from './browserFetcher.js';
+import { resetBrowserProfile, closeBrowserSession, fetchRawHtmlWithBrowser, getBrowserRuntimeStatus } from './browserBackend.js';
 import { type FieldExtractor, type TrackerConfig, type TrackerStats } from './types.js';
 import {
   listEngines,
@@ -3189,6 +3189,11 @@ export async function start(): Promise<void> {
   // ── Moteur navigateur : chromium (defaut) ou cloak (CloakBrowser furtif) ──
   app.get('/api/settings/browser-engine', (_req, res) => {
     res.json({ engine: getJsonSetting('browser_engine', 'chromium') });
+  });
+
+  // Etat du runtime navigateur (local embarque ou service externe) + versions.
+  app.get('/api/browser-runtime/status', async (_req, res) => {
+    res.json({ ok: true, status: await getBrowserRuntimeStatus() });
   });
 
   app.post('/api/settings/browser-engine', (req, res) => {


### PR DESCRIPTION
## Objectif (étape 1/2)

Externaliser le runtime navigateur (Playwright/Chromium/CloakBrowser) dans un service optionnel `tracker-dashboard-browser` afin d'alléger l'image principale, **sans reset utilisateur** et **sans casser les installations existantes**. Cette PR met en place toute la mécanique en **conservant le fallback local** : l'image principale est inchangée à cette étape.

## Contraintes respectées

- Aucun reset utilisateur ; volume `./config:/app/config` conservé ; SQLite, trackers, cookies, TOTP, proxies, paramètres et `config/browser-profile` intacts.
- `tracker-dashboard` reste la **source de vérité SQL** ; le runtime ne lit/écrit jamais la base (tout passe par le payload `/fetch`).
- L'app principale fonctionne **sans** runtime pour les trackers HTTP ; les trackers `mode: browser` affichent un message clair si le runtime est absent.
- Mise à jour simple : image principale comme aujourd'hui ; 2ᵉ service optionnel seulement si nécessaire (bloc commenté dans `docker-compose.yml`).
- Pas d'install/désinstall de Playwright à l'usage : le runtime est une image/service séparé, mis à jour comme un container normal.

## Contenu

- `browserFetcher` rendu paramétrable par overrides optionnels (sans override = comportement actuel **strictement identique**).
- `browserBackend` : abstraction distant/local (import dynamique de Playwright côté local).
- `browserRuntime` : service HTTP `/health` `/version` `/fetch` `/fetch-raw` `/reset-profile` `/close-session` `/close-all`, token optionnel `BROWSER_RUNTIME_TOKEN`.
- `GET /api/browser-runtime/status` + encart WebUI (Proxies → Moteur navigateur → Runtime navigateur).
- `Dockerfile.browser`, service compose optionnel, workflows (build/push + build CI de l'image navigateur), README (mode simple / complet), `npm run start:browser`.

## Non-régression

Sans `BROWSER_RUNTIME_URL` (cas de toutes les installations actuelles), le backend local est utilisé via import dynamique : **aucun changement de comportement**, image principale inchangée.

## Validation

- Local : `npm run build`, `npm run check:integration` (57 appels), `git diff --check`, syntaxe du script inline.
- CI (gate de merge) : build image principale + **build `Dockerfile.browser`** (nouveau job) + scan CVE.

## Étape 2 (PR séparée, après validation)

Retrait de Chromium/CloakBrowser de l'image principale + mesure de taille avant/après.

