### PR TITLE
fix(browser): utiliser le runtime parallèle sans modifier le compose

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -112,5 +112,10 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            APP_IMAGE_SOURCE=${{ env.REGISTRY }}/tracker-dashboard/tracker-dashboard-browser
+            APP_IMAGE_VERSION=${{ steps.meta.outputs.version }}
+            APP_IMAGE_REVISION=${{ github.sha }}
+            APP_IMAGE_REF=${{ github.ref_name }}
           cache-from: type=gha,scope=browser
           cache-to: type=gha,mode=max,scope=browser

--- a/Dockerfile.browser
+++ b/Dockerfile.browser
@@ -25,7 +25,15 @@ WORKDIR /app
 ARG NPM_VERSION=11.17.0
 RUN npm install -g "npm@${NPM_VERSION}" \
   && node -e "const v=require('/usr/local/lib/node_modules/npm/node_modules/tar/package.json').version; const [a,b,c]=v.split('.').map(Number); if (a < 7 || (a === 7 && (b < 5 || (b === 5 && c < 16)))) throw new Error('npm embeds vulnerable tar '+v); console.log('npm tar', v);"
-ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+ARG APP_IMAGE_SOURCE=local
+ARG APP_IMAGE_VERSION=dev
+ARG APP_IMAGE_REVISION=unknown
+ARG APP_IMAGE_REF=local
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright \
+    APP_IMAGE_SOURCE=$APP_IMAGE_SOURCE \
+    APP_IMAGE_VERSION=$APP_IMAGE_VERSION \
+    APP_IMAGE_REVISION=$APP_IMAGE_REVISION \
+    APP_IMAGE_REF=$APP_IMAGE_REF
 COPY package*.json ./
 RUN npm ci --omit=dev
 RUN npx playwright install --with-deps chromium \

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Au premier accès, l'application demande de créer le compte administrateur de l
 
 ## Changements récents
 
-- **Image principale allégée** : Playwright/Chromium/CloakBrowser sont sortis dans un service optionnel `tracker-dashboard-browser` (l'image principale ne les embarque plus). Statut/versions dans la WebUI. L'app reste pleinement utilisable sans lui pour les trackers HTTP ; les trackers `mode: browser` nécessitent ce service.
+- **Image principale allégée** : Playwright/Chromium/CloakBrowser sont sortis dans l'image parallèle `tracker-dashboard-browser`. Le compose principal ne change pas ; la WebUI affiche l'état, les versions, la commande de lancement et les alertes de mise à jour.
 - **Plusieurs comptes par tracker** : duplication d'un tracker, noms d'affichage personnalisables, regroupement sous le site, et attribution des torrents par passkey entre comptes.
 - Refonte de la navigation : barre latérale unique, thème clair/sombre/système, nouveau logo.
 - Fiches de trackers enrichies : statut clair, courbes d'évolution UP/DL/ratio (buffer en option), erreurs en cours / récentes / historique.
@@ -148,16 +148,24 @@ Avec le type **SSH**, le dashboard ouvre un tunnel SSH (SOCKS5 local adossé au 
 - Les secrets sont stockés côté serveur, jamais renvoyés en clair (masqués).
 - Le bouton **Tester** établit le tunnel et vérifie l'IP de sortie.
 
-## Runtime navigateur (mode simple / mode complet)
+## Runtime navigateur
 
-Le navigateur (Playwright/Chromium/CloakBrowser) est **externalisé** dans un service séparé : l'image principale ne l'embarque plus (image fortement allégée). Deux modes :
+Le navigateur (Playwright/Chromium/CloakBrowser) est externalisé dans l'image `ghcr.io/tracker-dashboard/tracker-dashboard-browser:latest`. L'image principale reste allégée, sans modifier le `docker-compose.yml` existant.
 
-- **Mode simple (par défaut)** : un seul container `tracker-dashboard`. Les trackers HTTP et le fast-path `curl-impersonate` fonctionnent. L'image n'embarque pas de navigateur.
-- **Mode complet** : ajoutez le service optionnel `tracker-dashboard-browser` et définissez `BROWSER_RUNTIME_URL` (voir `docker-compose.yml`, bloc commenté). **Nécessaire pour les trackers en `mode: browser`** (sinon ils affichent un message clair invitant à ajouter le service).
+Lancez le runtime navigateur en parallèle du conteneur principal :
 
-Les deux services partagent le volume `./config` (mêmes SQLite, trackers, cookies, TOTP, proxies, paramètres et `config/browser-profile`). Le service navigateur **ne touche pas la base** : l'app principale reste la source de vérité et lui transmet ce qu'il faut par appel interne. Si le runtime navigateur est absent, l'app reste utilisable : seuls les trackers `mode: browser` échouent avec un message clair. L'état (disponible/indisponible, versions Playwright/Chromium/CloakBrowser) est visible dans **Proxies → Moteur navigateur → Runtime navigateur** (bouton *Vérifier*).
+```bash
+docker run -d \
+  --name tracker-dashboard-browser \
+  --restart unless-stopped \
+  --network container:tracker-dashboard \
+  --volumes-from tracker-dashboard \
+  ghcr.io/tracker-dashboard/tracker-dashboard-browser:latest
+```
 
-Sécurité : ne publiez pas le port du runtime ; laissez-le joignable uniquement via le réseau Docker interne. Un token partagé optionnel (`BROWSER_RUNTIME_TOKEN` des deux côtés) protège l'API s'il est exposé par erreur.
+Avec `--network container:tracker-dashboard`, Tracker Dashboard joint automatiquement le runtime sur `http://127.0.0.1:3001`. Avec `--volumes-from tracker-dashboard`, les profils navigateur et cookies restent sur le même volume `./config`. Le service navigateur ne touche pas la base : l'app principale reste la source de vérité et lui transmet ce qu'il faut par appel interne.
+
+Si le runtime navigateur est absent, les trackers en `mode: browser` affichent une erreur claire et la WebUI donne la commande d'installation. L'état et les versions (Playwright/Chromium/CloakBrowser) sont visibles dans **Proxies → Moteur navigateur → Runtime navigateur**. La WebUI signale aussi si le runtime navigateur ne correspond pas à la révision de l'application.
 
 ### Moteur navigateur (CloakBrowser)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,27 +12,5 @@ services:
       # Pour un test ponctuel sans token : METRICS_PUBLIC=true
       # Ne pas laisser actif si l'instance est exposee hors reseau local.
       # METRICS_PUBLIC: "true"
-      #
-      # ── Mode complet (trackers en mode navigateur) ─────────────────────────
-      # Decommentez la ligne suivante ET le service tracker-dashboard-browser
-      # ci-dessous pour activer les trackers necessitant un navigateur.
-      # BROWSER_RUNTIME_URL: "http://tracker-dashboard-browser:3001"
-      # Optionnel : token partage si le runtime risque d'etre expose.
-      # BROWSER_RUNTIME_TOKEN: "changez-moi"
     volumes:
       - ./config:/app/config
-
-  # ── Service navigateur OPTIONNEL (mode complet) ──────────────────────────────
-  # Necessaire uniquement pour les trackers en mode navigateur (Chromium/CloakBrowser).
-  # Installation simple : laissez ce bloc commente (un seul container).
-  # Installation complete : decommentez ce bloc + BROWSER_RUNTIME_URL ci-dessus.
-  # tracker-dashboard-browser:
-  #   image: ghcr.io/tracker-dashboard/tracker-dashboard-browser:latest
-  #   container_name: tracker-dashboard-browser
-  #   restart: unless-stopped
-  #   # Aucun port publie : joignable seulement par tracker-dashboard via le reseau Docker.
-  #   environment:
-  #     # Doit correspondre a BROWSER_RUNTIME_TOKEN ci-dessus si vous l'activez.
-  #     BROWSER_RUNTIME_TOKEN: "changez-moi"
-  #   volumes:
-  #     - ./config:/app/config

--- a/public/index.html
+++ b/public/index.html
@@ -6481,7 +6481,14 @@
     } catch (e) { console.warn('Browser engine unavailable', e); }
   }
 
-  // Etat du runtime navigateur : embarque (local) ou service externe + versions.
+  const BROWSER_RUNTIME_INSTALL_COMMAND = `docker run -d \\
+  --name tracker-dashboard-browser \\
+  --restart unless-stopped \\
+  --network container:tracker-dashboard \\
+  --volumes-from tracker-dashboard \\
+  ghcr.io/tracker-dashboard/tracker-dashboard-browser:latest`;
+
+  // Etat du runtime navigateur externe + versions.
   async function loadBrowserRuntimeStatus() {
     const badge = document.getElementById('browser-runtime-badge');
     const detail = document.getElementById('browser-runtime-detail');
@@ -6492,22 +6499,21 @@
       const r = await fetch('/api/browser-runtime/status');
       const d = await r.json();
       const s = d.status || {};
-      if (s.mode === 'local') {
-        badge.textContent = 'Embarqué (Chromium local)';
-        badge.className = 'definition-badge';
-        detail.innerHTML = 'Le navigateur est inclus dans l\'image principale. Pour alléger l\'image, ajoutez le service <code>tracker-dashboard-browser</code> et définissez <code>BROWSER_RUNTIME_URL</code>.';
-        return;
-      }
       if (s.available) {
-        badge.textContent = 'Service externe — disponible';
-        badge.className = 'definition-badge';
+        const stale = s.upToDate === false;
+        badge.textContent = stale ? 'Runtime navigateur — mise à jour requise' : 'Runtime navigateur — disponible';
+        badge.className = stale ? 'definition-badge definition-badge-muted' : 'definition-badge';
+        if (stale) badge.style.color = 'var(--yellow)';
         const cloak = s.cloakbrowser?.available ? `oui${s.cloakbrowser.version ? ' (' + escapeHtml(s.cloakbrowser.version) + ')' : ''}` : 'non';
-        detail.innerHTML = `Playwright <b>${escapeHtml(s.playwright || '?')}</b> · Chromium <b>${escapeHtml(s.chromiumVersion || '?')}</b> · CloakBrowser ${cloak}<br><span style="color:var(--muted)">${escapeHtml(s.url || '')}</span>`;
+        const updateHint = stale
+          ? `<br><span style="color:var(--yellow)">Le runtime navigateur ne correspond pas à la révision de l'application. Mettez à jour <code>tracker-dashboard-browser</code>.</span>`
+          : '';
+        detail.innerHTML = `Playwright <b>${escapeHtml(s.playwright || '?')}</b> · Chromium <b>${escapeHtml(s.chromiumVersion || '?')}</b> · CloakBrowser ${cloak}<br><span style="color:var(--muted)">${escapeHtml(s.url || '')}</span>${updateHint}`;
       } else {
-        badge.textContent = 'Service externe — indisponible';
+        badge.textContent = 'Runtime navigateur — absent';
         badge.className = 'definition-badge definition-badge-muted';
         badge.style.color = 'var(--red)';
-        detail.innerHTML = `Runtime configuré (<code>${escapeHtml(s.url || '')}</code>) mais injoignable${s.error ? ' : ' + escapeHtml(s.error) : ''}. Les trackers en mode navigateur échoueront tant que le service <code>tracker-dashboard-browser</code> n'est pas démarré.`;
+        detail.innerHTML = `Le runtime navigateur est absent ou injoignable${s.error ? ' : ' + escapeHtml(s.error) : ''}. Lancez-le en parallèle, sans modifier le compose existant :<pre style="white-space:pre-wrap;margin-top:8px"><code>${escapeHtml(BROWSER_RUNTIME_INSTALL_COMMAND)}</code></pre>`;
       }
     } catch (e) {
       badge.textContent = 'Inconnu';

--- a/src/browserBackend.ts
+++ b/src/browserBackend.ts
@@ -4,15 +4,14 @@
 // service separe `tracker-dashboard-browser` sans casser les installations
 // existantes.
 //
-// - Si `BROWSER_RUNTIME_URL` est defini -> backend DISTANT : l'app principale
+// - Par defaut -> backend DISTANT sur http://127.0.0.1:3001, lance en conteneur
+//   parallele avec `--network container:tracker-dashboard`.
+// - Si `BROWSER_RUNTIME_URL` est defini, il remplace cette URL.
+//   L'app principale
 //   resout cookie/TOTP/moteur/proxy depuis la DB, les envoie dans le payload, et
 //   le runtime execute le navigateur (il ne touche jamais la DB).
-// - Sinon -> backend LOCAL : import dynamique de `browserFetcher` (Playwright dans
-//   l'image principale, comportement historique strictement inchange).
-//
-// L'import de `browserFetcher` est dynamique pour que l'app principale puisse, a
-// terme (image allegee sans Playwright), fonctionner pour les trackers HTTP meme
-// sans ce module.
+// - L'image principale reste allegee : Playwright/Chromium/CloakBrowser vivent
+//   dans l'image tracker-dashboard-browser.
 
 import { resolveProxyForTracker, toSshConfig } from './proxy.js';
 import { getSshLocalEndpoint } from './sshTunnel.js';
@@ -36,23 +35,28 @@ export interface BrowserRuntimeStatus {
   playwright?: string;
   chromiumVersion?: string;
   chromiumExecutable?: string;
+  revision?: string;
+  expectedRevision?: string;
+  upToDate?: boolean;
   cloakbrowser?: { available: boolean; version?: string };
 }
 
 type ProxyPayload = { server: string; username?: string; password?: string } | null;
 
-const RUNTIME_URL = (process.env.BROWSER_RUNTIME_URL || '').replace(/\/+$/, '');
+const DEFAULT_RUNTIME_URL = 'http://127.0.0.1:3001';
+const RUNTIME_URL = (process.env.BROWSER_RUNTIME_URL || DEFAULT_RUNTIME_URL).replace(/\/+$/, '');
 const RUNTIME_TOKEN = process.env.BROWSER_RUNTIME_TOKEN || '';
+const EXPECTED_REVISION = process.env.APP_IMAGE_REVISION?.trim() || '';
 // Hote sous lequel le runtime peut joindre le tunnel SSH local de l'app principale
 // (le runtime tourne dans un autre conteneur, 127.0.0.1 ne conviendrait pas).
 const SELF_HOST_FOR_RUNTIME = process.env.SSH_TUNNEL_ADVERTISE_HOST || '';
 
 export function isRemoteRuntimeConfigured(): boolean {
-  return RUNTIME_URL.length > 0;
+  return true;
 }
 
 export const BROWSER_RUNTIME_UNAVAILABLE =
-  'Runtime navigateur non disponible. Ajoutez le service tracker-dashboard-browser ou désactivez les trackers en mode navigateur.';
+  'Runtime navigateur indisponible. Lancez le conteneur tracker-dashboard-browser en parallele de tracker-dashboard.';
 
 function runtimeHeaders(): Record<string, string> {
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
@@ -89,9 +93,8 @@ function buildOverrides(tracker: TrackerConfig) {
   };
 }
 
-// Charge le backend local (Playwright). Si le module est indisponible (image
-// allegee sans Playwright et aucun runtime distant configure), on renvoie le
-// message clair attendu plutot qu'une erreur d'import opaque.
+// Fallback de developpement local : utile uniquement si Playwright est present
+// dans node_modules. L'image publiee utilise le runtime navigateur separe.
 async function loadLocalBackend(): Promise<typeof import('./browserFetcher.js')> {
   try {
     return await import('./browserFetcher.js');
@@ -192,10 +195,6 @@ export async function resetBrowserProfile(trackerId: string): Promise<void> {
 }
 
 export async function getBrowserRuntimeStatus(): Promise<BrowserRuntimeStatus> {
-  if (!isRemoteRuntimeConfigured()) {
-    // Backend local : Playwright embarque dans l'image principale (cas historique).
-    return { mode: 'local', configured: false, available: true };
-  }
   try {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), 8_000);
@@ -205,22 +204,26 @@ export async function getBrowserRuntimeStatus(): Promise<BrowserRuntimeStatus> {
     }).finally(() => clearTimeout(timer));
     const data = await response.json().catch(() => ({} as Record<string, unknown>));
     if (!response.ok) {
-      return { mode: 'remote', configured: true, available: false, url: RUNTIME_URL, error: `HTTP ${response.status}` };
+      return { mode: 'remote', configured: Boolean(process.env.BROWSER_RUNTIME_URL), available: false, url: RUNTIME_URL, expectedRevision: EXPECTED_REVISION || undefined, error: `HTTP ${response.status}` };
     }
+    const revision = typeof data.revision === 'string' ? data.revision : undefined;
     return {
       mode: 'remote',
-      configured: true,
+      configured: Boolean(process.env.BROWSER_RUNTIME_URL),
       available: true,
       url: RUNTIME_URL,
       runtime: typeof data.runtime === 'string' ? data.runtime : undefined,
       playwright: typeof data.playwright === 'string' ? data.playwright : undefined,
       chromiumVersion: typeof data.chromiumVersion === 'string' ? data.chromiumVersion : undefined,
       chromiumExecutable: typeof data.chromiumExecutable === 'string' ? data.chromiumExecutable : undefined,
+      revision,
+      expectedRevision: EXPECTED_REVISION || undefined,
+      upToDate: EXPECTED_REVISION && revision ? revision === EXPECTED_REVISION : undefined,
       cloakbrowser: (data.cloakbrowser && typeof data.cloakbrowser === 'object')
         ? data.cloakbrowser as { available: boolean; version?: string }
         : undefined,
     };
   } catch (err) {
-    return { mode: 'remote', configured: true, available: false, url: RUNTIME_URL, error: err instanceof Error ? err.message : String(err) };
+    return { mode: 'remote', configured: Boolean(process.env.BROWSER_RUNTIME_URL), available: false, url: RUNTIME_URL, expectedRevision: EXPECTED_REVISION || undefined, error: err instanceof Error ? err.message : String(err) };
   }
 }

--- a/src/browserRuntime.ts
+++ b/src/browserRuntime.ts
@@ -79,6 +79,9 @@ app.get('/version', async (_req, res) => {
   res.json({
     ok: true,
     runtime: 'tracker-dashboard-browser',
+    revision: process.env.APP_IMAGE_REVISION || 'unknown',
+    version: process.env.APP_IMAGE_VERSION || 'dev',
+    ref: process.env.APP_IMAGE_REF || 'local',
     playwright: playwrightVersion(),
     chromiumExecutable: executable || undefined,
     chromiumVersion: await chromiumVersion(executable),


### PR DESCRIPTION
## Résumé
- utilise automatiquement le runtime navigateur sur http://127.0.0.1:3001
- conserve le docker-compose.yml principal inchangé et retire les blocs à décommenter
- affiche dans la WebUI la commande docker run parallèle si le runtime manque
- ajoute les métadonnées de révision au runtime navigateur pour alerter s'il n'est pas à jour

## Installation du runtime navigateur
\\\bash
docker run -d \\
  --name tracker-dashboard-browser \\
  --restart unless-stopped \\
  --network container:tracker-dashboard \\
  --volumes-from tracker-dashboard \\
  ghcr.io/tracker-dashboard/tracker-dashboard-browser:latest
\\\

## Validations locales
- npm.cmd run build
- npm.cmd run check:integration
- git diff --check