### PR TITLE
fix(trackers): ne plus rejeter un tracker cookie-only sans mot de passe

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -907,6 +907,15 @@ function hydrateFromSnapshots(trackers: TrackerConfig[]): TrackerConfig[] {
   return stale;
 }
 
+// Un tracker en cookie-only n'a pas forcement de mot de passe enregistre : sa
+// "credential" est le cookie de session. Sans ce cas, un tracker purement cookie
+// (cookie present, aucun mot de passe) serait rejete a tort en "Credentials manquants".
+function cookieOnlyReady(tracker: TrackerConfig): boolean {
+  return Boolean(tracker.login?.cookieOnly) && hasTrackerCookie(tracker.id);
+}
+
+const EMPTY_CREDENTIALS = { username: '', password: '' };
+
 async function refresh(trackers: TrackerConfig[]): Promise<TrackerStats[]> {
   if (isRefreshing) return [];
   isRefreshing = true;
@@ -930,7 +939,7 @@ async function refresh(trackers: TrackerConfig[]): Promise<TrackerStats[]> {
     const enabledTrackers = trackers.filter(t => t.enabled !== false);
     const results = await mapWithConcurrency(enabledTrackers, REFRESH_CONCURRENCY, async tracker => {
       const creds = credentials[tracker.id];
-      if (!creds) {
+      if (!creds && !cookieOnlyReady(tracker)) {
         const stat: TrackerStats = {
           id:          tracker.id,
           name:        tracker.name,
@@ -946,7 +955,7 @@ async function refresh(trackers: TrackerConfig[]): Promise<TrackerStats[]> {
         return stat;
       }
 
-      const fetched = await fetchTrackerBounded(tracker, creds);
+      const fetched = await fetchTrackerBounded(tracker, creds ?? EMPTY_CREDENTIALS);
       processIncidentStreak(fetched); // une fois par tracker par cycle
       const stat = preserveLastKnownOnTimeout(tracker, fetched);
       updateRetryState(tracker, fetched, stat);
@@ -993,7 +1002,7 @@ async function refreshOneTracker(
   }
 
   const creds = loadCredentialsFromDb()[tracker.id];
-  if (!creds) {
+  if (!creds && !cookieOnlyReady(tracker)) {
     const stat: TrackerStats = {
       id:          tracker.id,
       name:        tracker.name,
@@ -1009,7 +1018,7 @@ async function refreshOneTracker(
     return stat;
   }
 
-  const fetched = await fetchTrackerBounded(tracker, creds);
+  const fetched = await fetchTrackerBounded(tracker, creds ?? EMPTY_CREDENTIALS);
   processIncidentStreak(fetched); // une fois par tracker par cycle
   const stat = preserveLastKnownOnTimeout(tracker, fetched);
   updateRetryState(tracker, fetched, stat);


### PR DESCRIPTION
## Problème
Un tracker en **cookie-only** dont la seule "credential" est le cookie de session (aucun mot de passe enregistré) était rejeté à tort en **« Credentials manquants »** au refresh, donc invisible dans « Trackers activés » et le dashboard (filtre `isUnconfigured`). Un tracker cookie-only qui a *aussi* un mot de passe (ex. BitPorn) passait, ce qui masquait le bug.

## Cause
Le verrou (`server.ts`) ne testait que la map user/mot de passe (`loadCredentialsFromDb()[id]`), sans tenir compte du cas cookie-only + cookie présent. Présent aux deux points de vérif (refresh global ligne ~932, refresh unitaire ligne ~995).

## Correctif
- Helper `cookieOnlyReady(tracker)` = `login.cookieOnly` **et** cookie enregistré.
- Le verrou n'émet « Credentials manquants » que si `!creds && !cookieOnlyReady(tracker)`.
- On passe des credentials vides au fetch (le login est de toute façon sauté en cookie-only).

## Validation
- `npm run build`, `npm run check:integration` (57), `git diff --check`
- Vérifié en réel : un tracker cookie-only sans mot de passe passe désormais le verrou et exécute le fetch.