### PR TITLE
fix(fetcher): envoyer le cookie des trackers cookie-only en mode http

### DIFF
--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -501,6 +501,20 @@ function requestUrl(config: InternalAxiosRequestConfig): string | null {
   }
 }
 
+// Injecte le cookie de session colle (mode cookie-only) dans le jar axios. Sans
+// ca, le login etant saute et le jar cree vide, le GET des stats en mode http part
+// SANS cookie -> page deconnectee. Le mode browser, lui, envoie deja ce cookie via
+// le fast-path curl-impersonate.
+async function injectStoredCookieIntoJar(tracker: TrackerConfig, jar: CookieJar): Promise<void> {
+  const header = buildCookieHeader(tracker.id);
+  if (!header) return;
+  for (const pair of header.split(';')) {
+    const trimmed = pair.trim();
+    if (!trimmed.includes('=')) continue;
+    await jar.setCookie(`${trimmed}; Path=/`, tracker.baseUrl).catch(() => {});
+  }
+}
+
 async function storeResponseCookies(
   jar: CookieJar,
   response: AxiosResponse,
@@ -1263,6 +1277,12 @@ export async function fetchTracker(
 
     if (sessionExpired) {
       await doLogin(tracker, creds, session);
+    }
+
+    // Cookie-only : le login est saute, la session vient uniquement du cookie colle.
+    // On l'injecte dans le jar avant le GET (sinon requete non authentifiee).
+    if (tracker.login.cookieOnly) {
+      await injectStoredCookieIntoJar(tracker, session.jar);
     }
 
     // Fetch des stats


### PR DESCRIPTION
## Problème
Un tracker **cookie-only en mode http** partait toujours **déconnecté** : aucune donnée extraite, page de login reçue.

## Cause
- Le jar axios de la session est créé **vide** ; le login étant sauté en cookie-only, rien ne le remplit.
- Le GET-cookie impersoné (`tryCurlFastPath`) n'est appelé **que** dans la branche `mode: browser`.
- `attemptHttpViaCurl` **baille** pour cookie-only.
→ en mode http, le cookie collé n'était **jamais** envoyé.

## Correctif
Avant le GET des stats, pour tout tracker cookie-only, on **injecte le cookie stocké dans le jar axios** (`injectStoredCookieIntoJar`). La requête http est alors authentifiée. Le mode browser n'est pas modifié.

## Validation
`npm run build`, `npm run check:integration` (57), `git diff --check`. Diagnostiqué et reproduit en réel (un tracker cookie-only http revenait déconnecté ; en mode browser le même cookie passait).