### PR TITLE
feat(tr4ker): lecture via l'API JSON /api/me/stats (plus de navigateur)

### DIFF
--- a/config/trackers/tr4ker.json
+++ b/config/trackers/tr4ker.json
@@ -13,30 +13,26 @@
       "password": "{{password}}"
     },
     "failurePatterns": [
-      "type=\"password\"",
-      "name=\"password\"",
-      "href=\"/login\"",
-      "aria-label=\"Connexion\"",
-      "Inscription"
+      "Page introuvable"
     ],
     "cookieOnly": true
   },
   "fetch": {
-    "url": "/",
-    "mode": "browser",
-    "responseType": "html",
+    "url": "api/me/stats",
+    "mode": "http",
+    "responseType": "json",
     "fields": {
-      "ratio": {
-        "regex": "RATIO\\s*:?\\s*(?<value>[\\d\\s.,]+)",
-        "transform": "number"
-      },
       "uploadedBytes": {
-        "regex": ">UPLOAD<[\\s\\S]{0,180}?_statValue[^>]*>\\s*(?<value>\\d[\\d\\s.,]*\\s*(?:[KMGTPE](?:i?B|io|o)|B|o))\\s*<",
+        "path": "summary.uploaded",
         "transform": "bytes"
       },
       "downloadedBytes": {
-        "regex": ">DOWNLOAD<[\\s\\S]{0,180}?_statValue[^>]*>\\s*(?<value>\\d[\\d\\s.,]*\\s*(?:[KMGTPE](?:i?B|io|o)|B|o))\\s*<",
+        "path": "summary.downloaded",
         "transform": "bytes"
+      },
+      "seeding": {
+        "path": "statistics.torrents_seeding",
+        "transform": "integer"
       }
     },
     "extraFetch": {


### PR DESCRIPTION
## Contexte
TR4KER était le seul tracker à exiger `tracker-dashboard-browser` : c'est un **SPA**, ses stats sont rendues en JS, donc le mode navigateur était nécessaire (lecture de la home).

## Changement
Le site expose une **API JSON authentifiée par cookie**. On lit les stats sur **`api/me/stats`** en **mode http** → plus de navigateur.

- `uploadedBytes` ← `summary.uploaded`
- `downloadedBytes` ← `summary.downloaded` (effectif, 0)
- `seeding` ← `statistics.torrents_seeding`
- ratio calculé par le dashboard (→ ∞, comme le compte le tracker)
- classe de membre conservée via `extraFetch` sur `api/me` (`role`)

Vérifié en réel via le proxy : `api/me/stats` renvoie le JSON avec cookie (200), **401** sinon (erreur claire). Profite à tous (Zup inclus). S'appuie sur le correctif cookie-only+http (#106).

## Note
Les totaux du site incluent le bonus (`uploaded + bonus_upload`) ; le dashboard ne sommant pas deux champs JSON, on retient les valeurs effectives.