### PR TITLE
feat(trackers): seeding annonce par le site pour Gazelle et YGGReborn

### DIFF
--- a/config/trackers/yggreborn.json
+++ b/config/trackers/yggreborn.json
@@ -37,6 +37,12 @@
         "regex": ">R[oô]le</span>[\\s\\S]*?uppercase\"[\\s\\S]*?>(?<value>[^<]+)</span>",
         "transform": "string"
       }
+    },
+    "extraFetch": {
+      "url": "account/active-torrents",
+      "field": "seeding",
+      "regex": ">\\s*(?<value>\\d+)\\s+en partage<",
+      "transform": "integer"
     }
   },
   "dashboard": {

--- a/src/trackerTemplates.ts
+++ b/src/trackerTemplates.ts
@@ -105,6 +105,10 @@ export const ENGINE_TEMPLATES: Record<EngineId, EngineTemplate> = {
           uploadedBytes:   { regex: 'id="stats_seeding"[^>]*title="Uploaded: (?<value>[^"]+)"', transform: 'bytes' },
           downloadedBytes: { regex: 'id="stats_leeching"[^>]*title="Downloaded: (?<value>[^"]+)"', transform: 'bytes' },
           ratio:           { regex: 'id="stats_ratio"[^>]*title="Ratio: (?<value>[^"]+)"', transform: 'number' },
+          // Nombre de torrents en seed annonce par le site : compteur "seed: N" du header
+          // utilisateur, rendu dans <span id="nav_seeding_r">N</span> sur les skins Gazelle
+          // recents (HappyFappy, KuFirc...). Best-effort, surchargeable par site.
+          seeding:         { regex: 'id="nav_seeding_r"[^>]*>\\s*(?<value>\\d+)', transform: 'integer' },
           // Classe de membre courante, affichee dans le header utilisateur sur la plupart
           // des skins Gazelle (Redacted, Orpheus, Phoenix Project...). Surchargee par site
           // quand le skin diverge (ex: HD-Forever, classe entre parentheses).


### PR DESCRIPTION
## Objectif

Afficher le **seeding annoncé par le site** en complément du seeding remonté par
les clients BitTorrent liés, pour les trackers qui exposent l'information.

Cette PR ajoute la source « site » pour deux familles qui ne l'avaient pas, en
réutilisant l'affichage double déjà en place (#109).

## Changements

- **Preset Gazelle** : nouveau champ `seeding` lu sur le compteur « seed: N » du
  header utilisateur (`<span id="nav_seeding_r">N</span>`), présent sur les skins
  Gazelle récents. Comme les `fields` fusionnent champ par
  champ (preset puis JSON), les trackers Gazelle en héritent sans toucher à leurs
  surcharges, et un site peut toujours le redéfinir.
- **YGGReborn** : `extraFetch` sur `account/active-torrents` pour récupérer le
  compteur « N en partage », absent de la page de compte principale.

Les trackers UNIT3D exposaient déjà ce champ ; ils ne sont pas
modifiés.
