### PR TITLE
feat(speedapp): seeding annonce par le site

### DIFF
--- a/config/trackers/speedapp.json
+++ b/config/trackers/speedapp.json
@@ -40,6 +40,12 @@
         "regex": "Seed time[\\s\\S]{0,120}?<dd[^>]*>\\s*(?<value>\\d[\\d\\s.,]*)\\s*days",
         "transform": "number"
       }
+    },
+    "extraFetch": {
+      "url": "profile/menu-stats",
+      "field": "seeding",
+      "regex": "title=\"Currently seeding torrents\"[\\s\\S]*?</i>\\s*(?<value>\\d+)",
+      "transform": "integer"
     }
   },
   "dashboard": {


### PR DESCRIPTION
## Objectif

Afficher le nombre de torrents en seed declare par SpeedApp, comme pour les
autres trackers (en complement du seeding des clients BitTorrent lies).

## Changement

SpeedApp charge ses stats utilisateur via un fragment AJAX (`/profile/menu-stats`),
ouvert par le menu "User Profile". La page `profile` principale ne contient pas
le compteur. Ajout d'un `extraFetch` sur ce fragment pour lire
"Currently seeding torrents".

## Validation

- Regex verifie sur le fragment reel : seeding = 3.
- L'endpoint repond sans en-tete XHR (cookie de session suffisant).
- `npm run build`, `npm run check:integration`, `git diff --check` : OK.