### PR TITLE
feat(trackers): seeding annonce par le site (C411, Nexum, Torr9)

### DIFF
--- a/config/trackers/c411.json
+++ b/config/trackers/c411.json
@@ -42,7 +42,8 @@
       "ratio":           { "path": "user.ratio",       "transform": "number" },
       "memberClass":     { "path": "user.badge.label", "transform": "string" }
     },
-    "unreadFetch": { "url": "api/messages/unread-count", "responseType": "json", "path": "total", "transform": "integer" }
+    "unreadFetch": { "url": "api/messages/unread-count", "responseType": "json", "path": "total", "transform": "integer" },
+    "extraFetch": { "url": "api/profile/active-seeds", "field": "seeding", "path": "meta.total", "transform": "integer" }
   },
   "dashboard": {
     "byteUnit": "decimal"

--- a/config/trackers/nexum.json
+++ b/config/trackers/nexum.json
@@ -39,7 +39,8 @@
       "dlQuota":       { "regex": "user-stat-dlday[\\s\\S]{0,160}?</i>\\s*(?<value>[^<]+?)\\s*</span>", "transform": "string" },
       "level":         { "regex": "Niveau\\s*(?<value>\\d+)", "transform": "integer" },
       "xp":            { "regex": "Niveau\\s*\\d+\\s*·\\s*(?<value>[\\d\\s]+?)\\s*XP", "transform": "string" },
-      "unreadMessages": { "regex": "id=['\"]pm-badge['\"][^>]*>(?<value>\\d+)", "transform": "integer" }
+      "unreadMessages": { "regex": "id=['\"]pm-badge['\"][^>]*>(?<value>\\d+)", "transform": "integer" },
+      "seeding": { "regex": "Actuellement en partage[\\s\\S]{0,200}?sur\\s*<strong[^>]*>\\s*(?<value>\\d+)\\s*</strong>\\s*torrents", "transform": "integer" }
     },
     "extraFetch": {
       "url": "user/{{username}}",

--- a/config/trackers/torr9.json
+++ b/config/trackers/torr9.json
@@ -29,7 +29,14 @@
       "seedBonus":       { "path": "jeton_balance",          "transform": "integer" },
       "memberClass":     { "path": "role",                   "transform": "string" }
     },
-    "unreadFetch": { "url": "https://api.torr9.net/api/v1/chat/unread-counts", "responseType": "json", "path": "total_dms", "transform": "integer" }
+    "unreadFetch": { "url": "https://api.torr9.net/api/v1/chat/unread-counts", "responseType": "json", "path": "total_dms", "transform": "integer" },
+    "extraFetch": {
+      "url": "https://api.torr9.net/api/v1/users/{{id}}/stats?page=1&limit=20",
+      "idExtract": { "regex": "\"id\"\\s*:\\s*(?<value>\\d+)" },
+      "field": "seeding",
+      "path": "statistics.torrents_seeding",
+      "transform": "integer"
+    }
   },
   "dashboard": { "byteUnit": "decimal" }
 }


### PR DESCRIPTION
## Objectif

Completer la source "site" du seeding (en complement des clients BitTorrent
lies) pour trois trackers dont le compteur vit sur une API ou une page dediee.

## Changements

- **C411** : `extraFetch` sur `api/profile/active-seeds` (`meta.total`), qui
  alimente l'onglet "Mes seeds (actifs)" du profil. Les autres endpoints
  `api/...` ne portent pas ce compteur.
- **Nexum** : champ `seeding` lu sur la page `activity`, via le compteur
  "sur N torrents" de la ligne "Actuellement en partage".
- **Torr9** : `extraFetch` sur `api/v1/users/{id}/stats`
  (`statistics.torrents_seeding`). L'identifiant est extrait de la reponse
  principale `users/me` via `idExtract`.

## Validation

- Valeurs verifiees sur les reponses reelles : C411 = 11, Nexum = 9, Torr9 = 12.
- `npm run build`, `npm run check:integration`, `git diff --check` : OK.