### PR TITLE
fix(fetcher): pas de login form pour un tracker cookie-only (mode http)

### DIFF
--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -1271,11 +1271,14 @@ export async function fetchTracker(
       if (viaCurl) return viaCurl;
     }
 
-    // Login si nécessaire
+    // Login si nécessaire. Les trackers cookie-only n'ont pas de login par
+    // formulaire (leur "session" est le cookie collé) : on saute doLogin, sinon
+    // un POST vers la page de login renvoie souvent une erreur (ex. nginx 405
+    // sur TR4KER), faisant échouer le tracker alors que le cookie est valide.
     const sessionExpired =
       !session.loggedInAt || Date.now() - session.loggedInAt > SESSION_TTL_MS;
 
-    if (sessionExpired) {
+    if (sessionExpired && !tracker.login.cookieOnly) {
       await doLogin(tracker, creds, session);
     }
 


### PR DESCRIPTION
## Symptome

TR4KER tombe en erreur au refresh :

```
[TR4KER] Stats ERREUR - Login échoué — HTTP 405 - dump: /app/config/debug/tr4ker-login-last.html
```

Le dump est une page nginx "405 Not Allowed" : un POST a ete envoye vers la
page de login de TR4KER, qui n'accepte pas cette methode.

## Cause

TR4KER est configure en `cookieOnly` (sa session vient du cookie colle, pas
d'un login par formulaire) et en mode `http`. Sur la voie axios, `doLogin`
etait appele des que la session memoire etait consideree expiree — ce qui est
le cas en permanence pour un tracker cookie-only, dont `loggedInAt` n'est
jamais positionne (il ne l'est qu'apres un login reussi). Resultat : un POST de
login systematique, et l'erreur 405.

Le commentaire juste en dessous indiquait deja l'intention ("le login est
saute"), mais le garde-fou manquait. Les autres trackers cookie-only
(lesrescapesdeygg, YGGReborn) sont en mode navigateur et ne passent pas par ce
chemin, d'ou l'impact limite a TR4KER.

## Correctif

Sauter `doLogin` quand `login.cookieOnly` est vrai. Le cookie stocke est
injecte juste apres, puis le fetch des stats suit normalement.

## Validation

- `npm run build`, `npm run check:integration`, `git diff --check` : OK.