### PR TITLE
Corrige les statistiques affichées pour TR4KER

### DIFF
--- a/config/trackers/tr4ker.json
+++ b/config/trackers/tr4ker.json
@@ -18,28 +18,33 @@
     "cookieOnly": true
   },
   "fetch": {
-    "url": "api/me/stats",
+    "url": "api/me",
     "mode": "http",
     "responseType": "json",
     "fields": {
       "uploadedBytes": {
-        "path": "summary.uploaded",
+        "path": "bonus_upload",
         "transform": "bytes"
       },
       "downloadedBytes": {
-        "path": "summary.downloaded",
+        "path": "bonus_download",
         "transform": "bytes"
       },
-      "seeding": {
-        "path": "statistics.torrents_seeding",
-        "transform": "integer"
+      "ratio": {
+        "path": "ratio",
+        "transform": "number"
+      },
+      "memberClass": {
+        "path": "role",
+        "transform": "string"
       }
     },
     "extraFetch": {
-      "url": "api/me",
-      "field": "memberClass",
-      "regex": "\"role\":\"(?<value>[^\"]+)\"",
-      "transform": "string"
+      "url": "api/me/stats",
+      "responseType": "json",
+      "field": "seeding",
+      "path": "statistics.torrents_seeding",
+      "transform": "integer"
     }
   },
   "dashboard": {

--- a/scripts/check-integration.mjs
+++ b/scripts/check-integration.mjs
@@ -5,9 +5,11 @@ const root = process.cwd();
 const htmlPath = path.join(root, 'public', 'index.html');
 const serverPath = path.join(root, 'src', 'server.ts');
 const redactedPath = path.join(root, 'config', 'trackers', 'redacted.json');
+const tr4kerPath = path.join(root, 'config', 'trackers', 'tr4ker.json');
 const html = fs.readFileSync(htmlPath, 'utf8');
 const server = fs.readFileSync(serverPath, 'utf8');
 const redacted = JSON.parse(fs.readFileSync(redactedPath, 'utf8'));
+const tr4ker = JSON.parse(fs.readFileSync(tr4kerPath, 'utf8'));
 const errors = [];
 
 function normalizeRoute(route) {
@@ -80,6 +82,17 @@ const synchronizesAllBundledTrackers = (
 );
 if (redacted.fetch?.fields?.requiredRatio && !synchronizesAllBundledTrackers) {
   errors.push('Redacted bundled fields are not synchronized to existing installations');
+}
+
+const tr4kerUsesDisplayedTotals = (
+  tr4ker.fetch?.url === 'api/me'
+  && tr4ker.fetch?.fields?.uploadedBytes?.path === 'bonus_upload'
+  && tr4ker.fetch?.fields?.downloadedBytes?.path === 'bonus_download'
+  && tr4ker.fetch?.extraFetch?.url === 'api/me/stats'
+  && tr4ker.fetch?.extraFetch?.path === 'statistics.torrents_seeding'
+);
+if (!tr4kerUsesDisplayedTotals) {
+  errors.push('TR4KER must use the totals displayed by the site and keep seeding from api/me/stats');
 }
 
 if (errors.length > 0) {


### PR DESCRIPTION
## Problème

TR4KER utilisait les valeurs effectives de `api/me/stats`, qui excluent les bonus. Le tableau de bord affichait donc des cumuls différents de ceux visibles sur le site.

## Correction

- lecture des totaux affichés par TR4KER depuis `api/me` via `bonus_upload` et `bonus_download` ;
- récupération directe du ratio et de la classe de membre depuis la même réponse ;
- conservation du nombre de torrents en seed via `api/me/stats` ;
- ajout d'un contrôle d'intégration pour protéger cette configuration.

## Validation

- `npm run build`
- `npm run check:integration`
- `git diff --check`
