### PR TITLE
Gusdezup/seeding site gazelle fix

### DIFF
--- a/config/trackers/orpheus.json
+++ b/config/trackers/orpheus.json
@@ -32,6 +32,15 @@
         "regex": "data-noty-type=['\"]Inbox['\"][^>]*>[^<]*?(?<value>\\d+|\\ba) new message",
         "transform": "string"
       }
+    },
+    "extraFetch": {
+      "url": "torrents.php?type=seeding&userid={{id}}",
+      "field": "seeding",
+      "idExtract": {
+        "regex": "href=\"user\\.php\\?id=(?<value>\\d+)\" class=\"username\""
+      },
+      "regex": "(?<value>\\d+)\\s+torrents? found",
+      "transform": "integer"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
-    "check:integration": "node scripts/check-integration.mjs && node scripts/check-unread-messages.mjs",
+    "check:integration": "node scripts/check-integration.mjs && node scripts/check-unread-messages.mjs && node scripts/check-extra-fetch.mjs",
     "start": "node --experimental-sqlite dist/index.js",
     "start:browser": "node --experimental-sqlite dist/browserRuntime.js"
   },

--- a/public/index.html
+++ b/public/index.html
@@ -1221,6 +1221,8 @@
       border-radius: 4px; background: var(--border); color: var(--muted);
       vertical-align: middle; cursor: help; text-transform: none;
     }
+    .seeding-sources { display: flex; flex-direction: column; gap: 2px; }
+    .seeding-sources > span { display: flex; align-items: center; }
 
     .col-good   { color: var(--green);  }
     .col-warn   { color: var(--yellow); }
@@ -2648,7 +2650,9 @@
       const badge = qbitSourceLabel(stat.qbitSeedingTypes) || 'client';
       parts.push(`<span title="Torrents en seed dans vos clients BitTorrent liés">${formatCount(stat.qbitSeeding)} <span class="stat-source">${escapeHtml(badge)}</span></span>`);
     }
-    return parts.length ? parts.join(' <span class="cell-muted">·</span> ') : null;
+    if (!parts.length) return null;
+    // Empilage vertical (site au-dessus, qBit en dessous) plutot qu'inline avec separateur.
+    return `<span class="seeding-sources">${parts.join('')}</span>`;
   }
 
   // Cellule "Seeding" pour la grille des cartes (inline, 1 colonne).

--- a/scripts/check-extra-fetch.mjs
+++ b/scripts/check-extra-fetch.mjs
@@ -1,0 +1,71 @@
+import { extractExtraFieldResponse, fetchExtraField } from '../dist/fetcher.js';
+
+const gazelleTracker = {
+  id: 'gazelle-test',
+  name: 'Gazelle Test',
+  baseUrl: 'https://tracker.example/',
+  login: { url: 'login.php', method: 'POST', contentType: 'form', failurePatterns: [] },
+  fetch: {
+    url: 'index.php',
+    responseType: 'html',
+    fields: {},
+    extraFetch: {
+      url: 'ajax.php?action=user&id={{id}}',
+      field: 'seeding',
+      responseType: 'json',
+      idExtract: { regex: 'href="user\\.php\\?id=(?<value>\\d+)" class="username"' },
+      path: 'response.community.seeding',
+      transform: 'integer',
+    },
+  },
+};
+
+let requestedUrl = '';
+const fetchedGazelleResult = await fetchExtraField(
+  gazelleTracker,
+  '<a href="user.php?id=42" class="username">user</a>',
+  async (url) => {
+    requestedUrl = url;
+    return { status: 200, body: JSON.stringify({ response: { community: { seeding: 23 } } }) };
+  },
+  {},
+  { username: 'user', password: 'unused' },
+);
+
+if (requestedUrl !== 'https://tracker.example/ajax.php?action=user&id=42'
+  || fetchedGazelleResult?.value !== 23) {
+  throw new Error('Gazelle extraFetch id interpolation or JSON extraction failed');
+}
+
+const jsonResult = extractExtraFieldResponse({
+  url: 'ajax.php?action=user&id={{id}}',
+  field: 'seeding',
+  responseType: 'json',
+  path: 'response.community.seeding',
+  transform: 'integer',
+}, JSON.stringify({ response: { community: { seeding: 23 } } }));
+
+if (jsonResult?.field !== 'seeding' || jsonResult.value !== 23) {
+  throw new Error('extraFetch JSON path extraction failed');
+}
+
+const htmlResult = extractExtraFieldResponse({
+  url: 'torrents.php?type=seeding&userid={{id}}',
+  field: 'seeding',
+  regex: '(?<value>\\d+)\\s+torrents? found',
+  transform: 'integer',
+}, '<h2>122 torrents found</h2>');
+
+if (htmlResult?.field !== 'seeding' || htmlResult.value !== 122) {
+  throw new Error('extraFetch HTML regex extraction failed');
+}
+
+if (extractExtraFieldResponse({
+  url: 'ajax.php',
+  field: 'seeding',
+  path: 'response.community.seeding',
+}, '<html>not JSON</html>') !== null) {
+  throw new Error('extraFetch malformed JSON must remain best-effort');
+}
+
+console.log('extraFetch response extraction OK.');

--- a/scripts/check-integration.mjs
+++ b/scripts/check-integration.mjs
@@ -76,6 +76,14 @@ if (!html.includes('<h2>🔀 Proxy</h2>')) {
   errors.push('Proxy panel heading is missing or corrupted');
 }
 
+const seedingSourcesAreStacked = (
+  html.includes('.seeding-sources { display: flex; flex-direction: column; gap: 2px; }')
+  && html.includes('return `<span class="seeding-sources">${parts.join(\'\')}</span>`;')
+);
+if (!seedingSourcesAreStacked) {
+  errors.push('Site and BitTorrent seeding sources must remain vertically stacked');
+}
+
 const synchronizesAllBundledTrackers = (
   server.includes('const definition = loadDefaultTrackerDefinition(tracker.baseId ?? tracker.id);')
   && !server.includes('CANONICAL_CONNECTION_TRACKERS')

--- a/src/browserFetcher.ts
+++ b/src/browserFetcher.ts
@@ -615,7 +615,13 @@ export async function fetchWithBrowser(
           await page.goto(extraUrl, { waitUntil: 'commit', timeout: 45_000 });
           await page.waitForLoadState('domcontentloaded', { timeout: 30_000 }).catch(() => {});
           await page.waitForLoadState('networkidle', { timeout: 10_000 }).catch(() => {});
-          extraHtml = await safeContent(page);
+          // Une navigation Playwright vers du JSON enveloppe la réponse dans une page
+          // HTML (<pre>...</pre>). Conserver le texte brut pour permettre l'extraction
+          // par chemin JSON ; garder le DOM rendu pour les extraFetch HTML/SPA.
+          const responseType = ef.responseType ?? (ef.path ? 'json' : 'html');
+          extraHtml = responseType === 'json'
+            ? await page.locator('body').innerText()
+            : await safeContent(page);
         }
       } catch {
         // Best-effort : la page secondaire (ex. classe de membre) ne doit jamais

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -146,6 +146,29 @@ function extractHtml(
   return { values: out, byteUnit };
 }
 
+type ExtraFetchConfig = NonNullable<TrackerConfig['fetch']['extraFetch']>;
+
+/** Extrait la valeur d'une réponse extraFetch, quel que soit son transport. */
+export function extractExtraFieldResponse(
+  ef: ExtraFetchConfig,
+  body: string,
+): { field: string; value: string | number } | null {
+  const single: Record<string, FieldExtractor> = {
+    [ef.field]: { path: ef.path, regex: ef.regex, transform: ef.transform },
+  };
+  const responseType = ef.responseType ?? (ef.path ? 'json' : 'html');
+  let out: { values: Record<string, string | number>; byteUnit: 'decimal' | 'binary' | null };
+  if (responseType === 'json') {
+    let json: unknown;
+    try { json = JSON.parse(body); } catch { return null; }
+    out = extractJson(json, single);
+  } else {
+    out = extractHtml(body, single);
+  }
+  const value = out.values[ef.field];
+  return value !== undefined && value !== '' ? { field: ef.field, value } : null;
+}
+
 function hasExtractedValues(fields: Record<string, string | number>): boolean {
   return Object.values(fields).some(value => (
     value !== '' && value !== undefined && value !== null
@@ -273,20 +296,7 @@ export async function fetchExtraField(
     const url = resolveUrl(tracker.baseUrl, interpolate(ef.url, vars));
     const res = await request(url, headers);
     if (!res || res.status >= 400) return null;
-    const single: Record<string, FieldExtractor> = {
-      [ef.field]: { path: ef.path, regex: ef.regex, transform: ef.transform },
-    };
-    const rt = ef.responseType ?? (ef.path ? 'json' : 'html');
-    let out: { values: Record<string, string | number>; byteUnit: 'decimal' | 'binary' | null };
-    if (rt === 'json') {
-      let json: unknown;
-      try { json = JSON.parse(res.body); } catch { return null; }
-      out = extractJson(json, single);
-    } else {
-      out = extractHtml(res.body, single);
-    }
-    const value = out.values[ef.field];
-    return value !== undefined && value !== '' ? { field: ef.field, value } : null;
+    return extractExtraFieldResponse(ef, res.body);
   } catch {
     return null;
   }
@@ -990,9 +1000,8 @@ export async function fetchTracker(
     // de membre TR4KER, profil hydraté en JS sur une autre route). Best-effort.
     const ef = tracker.fetch.extraFetch;
     if (ef && extraHtml) {
-      const extra = extractHtml(extraHtml, { [ef.field]: { path: ef.path, regex: ef.regex, transform: ef.transform } });
-      const value = extra.values[ef.field];
-      if (value !== undefined && value !== '') fields[ef.field] = value;
+      const extra = extractExtraFieldResponse(ef, extraHtml);
+      if (extra) fields[extra.field] = extra.value;
     }
 
     // L'unité d'affichage suit ce que le site écrit réellement (« GB » -> décimal,

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -317,6 +317,22 @@ async function fetchExtraFieldViaCurl(
   }, headers, creds);
 }
 
+// Variante du fetch secondaire pour le fast-path curl LÉGER (tryCurlFastPath), qui
+// n'a pas de CurlSession mais un simple cookie de session impersoné. La requête
+// secondaire rejoue curlImpersonateGet avec ce même cookie -> même auth + même
+// empreinte TLS que le fetch principal. Best-effort : toute erreur renvoie null.
+async function fetchExtraFieldViaCurlCookie(
+  tracker: TrackerConfig,
+  primaryBody: string,
+  cookie: string,
+  creds: { username: string; password: string },
+): Promise<{ field: string; value: string | number } | null> {
+  return fetchExtraField(tracker, primaryBody, async (url) => {
+    const r = await curlImpersonateGet(tracker.id, url, { cookie, timeoutMs: 30_000 }).catch(() => null);
+    return r ? { status: r.status, body: r.body } : null;
+  }, {}, creds);
+}
+
 function writeDebugDump(
   tracker: TrackerConfig,
   url: string,
@@ -1017,6 +1033,15 @@ export async function fetchTracker(
     if (isAnubisChallenge(result.body)) return null;
     try {
       const stats = buildStatsFromHtml(url, result.body); // throw si aucune valeur extraite
+      // Requête secondaire (extraFetch) : buildStatsFromHtml ne la gère que via un
+      // extraHtml pré-fourni (navigateur). En fast-path curl léger on la récupère ici,
+      // avec le même cookie impersoné, puis on injecte (ex. seeding Gazelle via
+      // ajax.php?action=user, ou page torrents.php?type=seeding pour Orpheus).
+      const ef = tracker.fetch.extraFetch;
+      if (ef?.url) {
+        const extra = await fetchExtraFieldViaCurlCookie(tracker, result.body, cookie, creds);
+        if (extra) stats.fields[extra.field] = extra.value;
+      }
       console.log(`  [${tracker.name}] Fast-path curl-impersonate OK (navigateur evite)`);
       return stats;
     } catch {

--- a/src/trackerTemplates.ts
+++ b/src/trackerTemplates.ts
@@ -105,14 +105,24 @@ export const ENGINE_TEMPLATES: Record<EngineId, EngineTemplate> = {
           uploadedBytes:   { regex: 'id="stats_seeding"[^>]*title="Uploaded: (?<value>[^"]+)"', transform: 'bytes' },
           downloadedBytes: { regex: 'id="stats_leeching"[^>]*title="Downloaded: (?<value>[^"]+)"', transform: 'bytes' },
           ratio:           { regex: 'id="stats_ratio"[^>]*title="Ratio: (?<value>[^"]+)"', transform: 'number' },
-          // Nombre de torrents en seed annonce par le site : compteur "seed: N" du header
-          // utilisateur, rendu dans <span id="nav_seeding_r">N</span> sur les skins Gazelle
-          // recents (HappyFappy, KuFirc...). Best-effort, surchargeable par site.
-          seeding:         { regex: 'id="nav_seeding_r"[^>]*>\\s*(?<value>\\d+)', transform: 'integer' },
           // Classe de membre courante, affichee dans le header utilisateur sur la plupart
           // des skins Gazelle (Redacted, Orpheus, Phoenix Project...). Surchargee par site
           // quand le skin diverge (ex: HD-Forever, classe entre parentheses).
           memberClass:     { regex: 'class="hidden userclass">(?<value>[^<]+)<', transform: 'string' },
+        },
+        // Nombre de torrents en seed annonce par le site : recupere via l'API JSON
+        // Gazelle (ajax.php?action=user&id=N -> response.community.seeding). Fiable sur
+        // la plupart des skins (HD-Forever, Phoenix Project, Redacted...). L'id utilisateur
+        // est extrait de la page principale via le lien `<a href="user.php?id=N"
+        // class="username">` present dans le header. Best-effort, surchargeable par site
+        // (ex: Orpheus, dont l'API renvoie un compteur fantome errone -> override HTML).
+        extraFetch: {
+          url: 'ajax.php?action=user&id={{id}}',
+          field: 'seeding',
+          responseType: 'json',
+          idExtract: { regex: 'href="user\\.php\\?id=(?<value>\\d+)" class="username"' },
+          path: 'response.community.seeding',
+          transform: 'integer',
         },
       },
       dashboard: { byteUnit: 'binary' },


### PR DESCRIPTION
## Contexte

Le seeding annoncé par le site (PR #110) ne remontait pas sur les trackers Gazelle.
Diagnostic : le field `nav_seeding_r` du preset gazelle ne matchait aucun skin réel
(HD-Forever, Orpheus, Phoenix Project, Redacted), et un bug du fast-path curl empêchait
de toute façon l'exécution des requêtes secondaires.

## Changements

### fix(fetcher) — extraFetch dans le fast-path curl léger
Le fast-path curl léger (`tryCurlFastPath`) appelait `buildStatsFromHtml` sans `extraHtml`,
donc l'`extraFetch` n'était jamais déclenché — seuls les chemins navigateur et axios le
géraient. Les trackers passant par ce fast-path (ex. Orpheus) n'extrayaient aucun champ
secondaire, en silence.

Ajout de `fetchExtraFieldViaCurlCookie` : rejoue `curlImpersonateGet` avec le même cookie
de session impersoné (même auth, même empreinte TLS que le fetch principal). Best-effort.

### feat(gazelle) — seeding via l'API JSON Gazelle
Remplacement du field mort `nav_seeding_r` par un `extraFetch` sur l'API JSON Gazelle :
`ajax.php?action=user&id={{id}}` → `response.community.seeding`. L'`id` est extrait de la
page principale via le lien `<a href="user.php?id=N" class="username">` (commun aux skins).

Validé : HD-Forever (235), Phoenix Project (23), Redacted (131) — alignés sur qBittorrent.

**Orpheus surcharge cet extraFetch** : son `community.seeding` renvoie un compteur fantôme
erroné (366 au lieu de 122 — torrents non flushés, biais aussi présent sur sa page user).
Override HTML sur `torrents.php?type=seeding` (« N torrents found ») qui donne le vrai total.

### feat(webui) — affichage empilé
Les deux sources de seeding (site / qBit) passent d'un affichage côte à côte avec séparateur
à un empilage vertical, plus lisible.

## Tests
Validé en dev sur l'ensemble de la famille Gazelle (HDF, Phoenix, Redacted, Orpheus, The Old
School) : valeurs `site` alignées sur le compte `qBit`. C411 affiche `0 site` mais c'est
correct — le tracker lui-même voit 0 seed (confirmé dans son interface). ABNormal n'expose
pas la donnée (pas d'API accessible, pas de page seeding) → reste à `qBit` seul.

## À valider en review
- [ ] **HD-Only**, Brokenstones, etc : Gazelle non testable de mon côté (pas de compte). À confirmer