### PR TITLE
Corrige les sessions anti-bot de YGGReborn et Les Rescapés

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ La navigation se fait depuis la barre latérale gauche :
 
 ## Cookies de session (sites à CAPTCHA / Cloudflare)
 
-Certains trackers protègent leur login par un CAPTCHA ou un challenge anti-bot (Cloudflare Turnstile…). Le navigateur headless ne peut pas les résoudre. Pour ces sites, fournissez directement un **cookie de session** : connectez-vous dans votre navigateur, exportez le cookie, puis collez-le dans **Configuration → Configurer les actifs → (le tracker) → Options avancées → Cookie de session**. Le dashboard l'injecte avant chaque lecture et saute la page de login.
+Certains trackers protègent leur login par un CAPTCHA ou un challenge anti-bot (Cloudflare Turnstile…). Le navigateur headless ne peut pas les résoudre. Pour ces sites, fournissez directement un **cookie de session** : connectez-vous dans votre navigateur, exportez tous les cookies du site, puis collez-les dans **Configuration → Configurer les actifs → (le tracker) → Options avancées → Cookie de session**. Le dashboard les injecte avant chaque lecture et saute la page de login. **Les cookies doivent être créés avec la même IP de sortie que celle utilisée par ce tracker dans Tracker Dashboard** : activez donc dans votre navigateur le même proxy que celui configuré pour le tracker, ou utilisez la même connexion directe si aucun proxy ne lui est affecté. Vérifiez notamment que `cf_clearance` est présent pour les sites protégés par Cloudflare ; sinon, les sessions liées à l'IP et les cookies anti-bot seront refusés.
 
 Trois formats auto-détectés :
 - fichier **Netscape `cookies.txt`** ;

--- a/config/trackers/lesrescapesdeygg.json
+++ b/config/trackers/lesrescapesdeygg.json
@@ -1,0 +1,47 @@
+{
+  "id": "lesrescapesdeygg",
+  "name": "Les Rescapés de Ygg",
+  "baseUrl": "https://lesrescapesdeygg.org",
+  "enabled": true,
+  "login": {
+    "url": "?action=login",
+    "method": "POST",
+    "contentType": "form",
+    "body": {
+      "id": "{{username}}",
+      "pass": "{{password}}"
+    },
+    "failurePatterns": [
+      "id=\"login-form\"",
+      "name=\"pass\"",
+      "Connexion sur Les Rescapés de Ygg"
+    ],
+    "cookieOnly": true
+  },
+  "fetch": {
+    "url": "?action=my-tracker-activity",
+    "mode": "browser",
+    "responseType": "html",
+    "fields": {
+      "uploadedBytes": {
+        "regex": "(?<value>[\\d.,]+\\s*[KMGTP]?i?[oO])[\\s\\S]{0,80}?Upload total",
+        "transform": "bytes"
+      },
+      "downloadedBytes": {
+        "regex": "my-tracker-activity[\\s\\S]*?color:#ea5656\">(?<value>[\\d.,]+\\s*[A-Za-z]{1,3})",
+        "transform": "bytes"
+      },
+      "ratio": {
+        "regex": "[Rr]atio r[ée]el\\s*:\\s*(?<value>[\\d.,]+)",
+        "transform": "number"
+      },
+      "seeding": {
+        "regex": "Sessions tracker actives[\\s\\S]{0,80}?(?<value>\\d+)",
+        "transform": "integer"
+      }
+    }
+  },
+  "dashboard": {
+    "byteUnit": "decimal"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -2238,7 +2238,7 @@
             <div class="beta-field"><label for="nt-test-totp">Secret 2FA (TOTP) <span class="nt-hint">optionnel</span></label><input class="tracker-input" id="nt-test-totp" type="password" autocomplete="off"></div>
           </div>
           <div class="beta-field" style="margin-top:8px">
-            <label for="nt-test-cookie">Cookie de session <span class="nt-hint">requis si « cookie uniquement »</span></label>
+            <label for="nt-test-cookie">Cookie de session <span class="nt-hint">requis si « cookie uniquement » · à exporter avec la même IP de sortie que celle configurée pour ce tracker</span></label>
             <textarea class="tracker-input" id="nt-test-cookie" rows="2" spellcheck="false" style="font-family:monospace; font-size:11px; white-space:pre" placeholder="nom=valeur; nom2=valeur2  (ou export cookies.txt / Cookie-Editor)"></textarea>
           </div>
         </div>
@@ -2305,7 +2305,7 @@
           <details class="definition-advanced" id="gd-cookie-wrap">
             <summary>J'ai un cookie de session (sites à CAPTCHA / Cloudflare)</summary>
             <div class="definition-advanced-body">
-              <p class="beta-note">Si le login automatique échoue (Cloudflare, captcha), connecte-toi dans ton navigateur, exporte tes cookies et colle-les ici.</p>
+              <p class="beta-note">Si le login automatique échoue (Cloudflare, captcha), connecte-toi dans ton navigateur, exporte tes cookies et colle-les ici. Utilise impérativement la même IP de sortie que celle configurée pour ce tracker dans Tracker Dashboard (même proxy, ou même connexion directe).</p>
               <textarea class="tracker-input" id="gd-cookie" rows="3" spellcheck="false" style="font-family:monospace; font-size:11px; white-space:pre" placeholder="nom=valeur; nom2=valeur2  (ou export cookies.txt / Cookie-Editor)"></textarea>
             </div>
           </details>
@@ -6102,9 +6102,10 @@
                       <div class="advanced-cookie-row">
                         <textarea class="tracker-input" id="credential-cookie-${safeId}" autocomplete="off" rows="3" spellcheck="false" style="flex:1; resize:vertical; font-family:monospace; font-size:11px; white-space:pre"
                           placeholder="${credential.hasCookie ? '•••••••• (enregistré — colle pour remplacer, vide pour effacer)' : 'Colle ici un fichier cookies.txt (Netscape), un export JSON Cookie-Editor, ou nom=valeur; nom2=valeur2'}"
-                          title="Connecte-toi au site dans ton navigateur, exporte les cookies (extension cookies-txt / Cookie-Editor) ou copie-les depuis les DevTools (F12 → Application/Stockage → Cookies). Le dashboard les injecte dans le navigateur headless et saute le login + Turnstile."></textarea>
+                          title="Connecte-toi au site dans ton navigateur avec la même IP de sortie que celle configurée pour ce tracker (même proxy ou même connexion directe), puis exporte les cookies. Le dashboard les injecte dans le navigateur headless et saute le login + Turnstile."></textarea>
                         <button class="btn-save" style="padding:6px 10px" onclick="saveTrackerCookie('${safeId}', this)">Enregistrer cookie</button>
                       </div>
+                      <p class="beta-note" style="margin-top:6px"><b>Important :</b> exporte tous les cookies avec la même IP de sortie que celle utilisée par ce tracker dans Tracker Dashboard (même proxy, ou même connexion directe). Vérifie notamment que <code>cf_clearance</code> est présent pour les sites protégés par Cloudflare ; les sessions liées à l’IP et les cookies anti-bot seront sinon refusés.</p>
                     </div>
                     <div class="advanced-field advanced-cookie-field">
                       <label>Secret 2FA (TOTP) <span style="color:var(--muted)">— authentification à deux facteurs${credential.hasTotp ? ' · <b style="color:var(--green)">défini</b>' : ''}</span></label>

--- a/scripts/check-extra-fetch.mjs
+++ b/scripts/check-extra-fetch.mjs
@@ -1,4 +1,4 @@
-import { extractExtraFieldResponse, fetchExtraField } from '../dist/fetcher.js';
+import { extractExtraFieldResponse, fetchExtraField, isAntiBotPage } from '../dist/fetcher.js';
 
 const gazelleTracker = {
   id: 'gazelle-test',
@@ -66,6 +66,14 @@ if (extractExtraFieldResponse({
   path: 'response.community.seeding',
 }, '<html>not JSON</html>') !== null) {
   throw new Error('extraFetch malformed JSON must remain best-effort');
+}
+
+if (!isAntiBotPage('<script src="/cdn-cgi/challenge-platform/h/b/orchestrate/chl_page/v1"></script>')) {
+  throw new Error('Cloudflare managed challenge must be detected');
+}
+
+if (isAntiBotPage('<script src="/cdn-cgi/challenge-platform/scripts/jsd/main.js"></script>')) {
+  throw new Error('Cloudflare Insights beacon must not be treated as an anti-bot challenge');
 }
 
 console.log('extraFetch response extraction OK.');

--- a/scripts/check-integration.mjs
+++ b/scripts/check-integration.mjs
@@ -3,13 +3,17 @@ import path from 'node:path';
 
 const root = process.cwd();
 const htmlPath = path.join(root, 'public', 'index.html');
+const readmePath = path.join(root, 'README.md');
 const serverPath = path.join(root, 'src', 'server.ts');
 const redactedPath = path.join(root, 'config', 'trackers', 'redacted.json');
 const tr4kerPath = path.join(root, 'config', 'trackers', 'tr4ker.json');
+const lesRescapesPath = path.join(root, 'config', 'trackers', 'lesrescapesdeygg.json');
 const html = fs.readFileSync(htmlPath, 'utf8');
+const readme = fs.readFileSync(readmePath, 'utf8');
 const server = fs.readFileSync(serverPath, 'utf8');
 const redacted = JSON.parse(fs.readFileSync(redactedPath, 'utf8'));
 const tr4ker = JSON.parse(fs.readFileSync(tr4kerPath, 'utf8'));
+const lesRescapes = JSON.parse(fs.readFileSync(lesRescapesPath, 'utf8'));
 const errors = [];
 
 function normalizeRoute(route) {
@@ -101,6 +105,25 @@ const tr4kerUsesDisplayedTotals = (
 );
 if (!tr4kerUsesDisplayedTotals) {
   errors.push('TR4KER must use the totals displayed by the site and keep seeding from api/me/stats');
+}
+
+const lesRescapesDetectsExpiredCookies = (
+  lesRescapes.login?.cookieOnly === true
+  && lesRescapes.login?.failurePatterns?.includes('id="login-form"')
+  && lesRescapes.fetch?.url === '?action=my-tracker-activity'
+);
+if (!lesRescapesDetectsExpiredCookies) {
+  errors.push('Les Rescapes de Ygg must detect the login page returned for an expired cookie');
+}
+
+const documentsCookieIpBinding = (
+  html.includes('exporte tous les cookies avec la même IP de sortie')
+  && html.includes('<code>cf_clearance</code>')
+  && readme.includes('Les cookies doivent être créés avec la même IP de sortie')
+  && readme.includes('`cf_clearance` est présent')
+);
+if (!documentsCookieIpBinding) {
+  errors.push('Session cookie guidance must document IP binding and cf_clearance in the WebUI and README');
 }
 
 if (errors.length > 0) {

--- a/src/browserFetcher.ts
+++ b/src/browserFetcher.ts
@@ -319,11 +319,20 @@ async function revealMilkieStats(page: Page): Promise<void> {
 function looksAntiBot(html: string): boolean {
   const h = html.toLowerCase();
   return h.includes('cf-turnstile') ||
-    h.includes('challenge-platform') ||
+    h.includes('/cdn-cgi/challenge-platform/h/') ||
+    h.includes('/cdn-cgi/challenge-platform/orchestrate/') ||
     h.includes('just a moment') ||
-    h.includes('/cdn-cgi/challenge-platform') ||
     h.includes('attention required') ||
+    h.includes('cf-chl-') ||
+    h.includes('please enable javascript and cookies to continue') ||
     h.includes('ddos-guard');
+}
+
+async function waitForAntiBotChallenge(page: Page): Promise<void> {
+  for (let i = 0; i < 20; i += 1) {
+    if (!looksAntiBot(await safeContent(page))) return;
+    await page.waitForTimeout(1000);
+  }
 }
 
 // Dump leger d'une page navigateur pour diagnostic (meme dossier que les autres dumps).
@@ -574,11 +583,13 @@ export async function fetchWithBrowser(
     await page.goto(url, { waitUntil: 'commit', timeout: 45_000 });
     await page.waitForLoadState('domcontentloaded', { timeout: 30_000 }).catch(() => {});
     await waitForAnubis(page);
+    await waitForAntiBotChallenge(page);
     await waitForLiveView(page);
     await ensureLoggedIn(tracker, credentials, page, overrides);
     await page.goto(url, { waitUntil: 'commit', timeout: 45_000 });
     await page.waitForLoadState('domcontentloaded', { timeout: 30_000 }).catch(() => {});
     await waitForAnubis(page);
+    await waitForAntiBotChallenge(page);
     await waitForLiveView(page);
     await page.waitForLoadState('networkidle', { timeout: 10_000 }).catch(() => {});
     if (tracker.id === 'nostradamus') {
@@ -599,6 +610,7 @@ export async function fetchWithBrowser(
     }
     const authConfirmed = await waitForTrackerContent(tracker, page);
     const html = await safeContent(page);
+    const primaryUrl = page.url();
 
     let extraHtml: string | undefined;
     const ef = tracker.fetch.extraFetch;
@@ -629,7 +641,7 @@ export async function fetchWithBrowser(
       }
     }
 
-    return { html, url: page.url(), authConfirmed, extraHtml };
+    return { html, url: primaryUrl, authConfirmed, extraHtml };
   } finally {
     await page.close().catch(() => {});
     // Fermer le contexte (= le process Chromium) apres chaque fetch. Sinon, avec

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -490,14 +490,14 @@ function extractFormAction(html: string): string {
 
 // Page anti-bot / challenge JS (Cloudflare & co) : signaux frequents quand l'IP du
 // client est filtree -> la vraie page (avec le token CSRF) n'est jamais servie.
-function isAntiBotPage(html: string): boolean {
+export function isAntiBotPage(html: string): boolean {
   const h = html.toLowerCase();
   return h.includes('cf-turnstile') ||
-    h.includes('challenge-platform') ||
+    h.includes('/cdn-cgi/challenge-platform/h/') ||
+    h.includes('/cdn-cgi/challenge-platform/orchestrate/') ||
     h.includes('just a moment') ||
     h.includes('attention required') ||
     h.includes('cf-chl-') ||
-    h.includes('/cdn-cgi/challenge-platform') ||
     h.includes('please enable javascript and cookies to continue') ||
     h.includes('ddos-guard');
 }
@@ -964,6 +964,12 @@ export async function fetchTracker(
   };
 
   const buildStatsFromHtml = (url: string, html: string, extraHtml?: string): TrackerStats => {
+    if (isAntiBotPage(html)) {
+      const dumpPath = writeDebugDump(tracker, url, html, {}, 'antibot');
+      const suffix = dumpPath ? ` - dump: ${dumpPath}` : '';
+      throw new Error(`Challenge anti-bot/Cloudflare recu depuis ${url} - renouveler les cookies depuis la meme IP de sortie${suffix}`);
+    }
+
     if (isAnubisChallenge(html)) {
       const dumpPath = writeDebugDump(tracker, url, html, {}, 'anubis');
       const suffix = dumpPath ? ` - dump: ${dumpPath}` : '';


### PR DESCRIPTION
## Résumé

- intègre Les Rescapés de Ygg en mode cookie uniquement et détecte correctement une session expirée ;
- reconnaît les challenges Cloudflare sans les confondre avec le script Cloudflare Insights, attend leur résolution côté navigateur et conserve l’URL principale lors d’une lecture secondaire ;
- explique dans la WebUI et le README que les cookies doivent être exportés avec la même IP de sortie que le tracker, avec `cf_clearance` pour les sites protégés par Cloudflare.

## Validation

- `npm ci`
- `npm run build`
- `npm run check:integration`
- `git diff --check`