### PR TITLE
Ajoute un repli FlareSolverr aux challenges anti-bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,27 @@ Si le runtime navigateur est absent, les trackers en `mode: browser` affichent u
 
 Les lectures en mode navigateur utilisent **Chromium** (Playwright) par défaut. Une option (panneau Proxies → Moteur navigateur) bascule sur **[CloakBrowser](https://github.com/CloakHQ/CloakBrowser)**, un Chromium modifié pour présenter une empreinte de vrai navigateur (TLS, fingerprint) et franchir davantage de protections anti-bot. S'il est indisponible, l'app repart automatiquement sur Chromium.
 
+### Repli Cloudflare (FlareSolverr)
+
+Pour les trackers qui déclarent le repli anti-bot, Tracker Dashboard peut utiliser **[FlareSolverr](https://github.com/FlareSolverr/FlareSolverr)** après l'échec des lectures HTTP légères. Le sidecar reçoit uniquement l'URL, les cookies et le proxy du tracker concerné, résout le challenge dans une session temporaire, renvoie le HTML puis détruit cette session. Les autres trackers continuent d'utiliser leur chemin habituel.
+
+Le fichier `docker-compose.yml` fourni inclut déjà ce sidecar. Pour une stack existante, ajoutez :
+
+```yaml
+services:
+  tracker-dashboard-flaresolverr:
+    image: ghcr.io/flaresolverr/flaresolverr:latest
+    container_name: tracker-dashboard-flaresolverr
+    restart: unless-stopped
+    network_mode: "container:tracker-dashboard"
+    environment:
+      HOST: 127.0.0.1
+      LOG_LEVEL: info
+      TZ: Europe/Paris
+```
+
+Le partage du réseau du conteneur principal est important : FlareSolverr est alors joignable en interne sur `http://127.0.0.1:8191` et réutilise aussi les tunnels SOCKS locaux des proxies SSH. Aucun port FlareSolverr n'est exposé sur l'hôte. Une URL différente peut être fournie avec `FLARESOLVERR_URL`.
+
 ## Lecture rapide (curl-impersonate)
 
 **[curl-impersonate](https://github.com/lexiforest/curl-impersonate)** usurpe l'empreinte TLS/HTTP2 d'un vrai Chrome et franchit le filtrage anti-bot passif sans navigateur. Le dashboard l'utilise automatiquement pour le login HTTP complet et pour les trackers navigateur disposant d'un cookie. Le repli est automatique (aucune lecture cassée). Réglage : panneau Proxies → Moteur navigateur → *Lecture rapide* (activé par défaut).
@@ -257,4 +278,5 @@ Le ratio peut être calculé depuis upload/download s'il n'est pas exposé ; ide
 
 - [Autovisit](https://github.com/Gusdezup/Autovisit) — idée de la prise en charge du 2FA (TOTP).
 - [CloakBrowser](https://github.com/CloakHQ/CloakBrowser) — moteur Chromium furtif proposé en option.
+- [FlareSolverr](https://github.com/FlareSolverr/FlareSolverr) — résolution de challenges Cloudflare via un sidecar interne optionnel.
 - Et tous les contributeurs qui partagent des définitions de trackers.

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Les lectures en mode navigateur utilisent **Chromium** (Playwright) par défaut.
 
 ### Repli Cloudflare (FlareSolverr)
 
-Pour les trackers qui déclarent le repli anti-bot, Tracker Dashboard peut utiliser **[FlareSolverr](https://github.com/FlareSolverr/FlareSolverr)** après l'échec des lectures HTTP légères. Le sidecar reçoit uniquement l'URL, les cookies et le proxy du tracker concerné, résout le challenge dans une session temporaire, renvoie le HTML puis détruit cette session. Les autres trackers continuent d'utiliser leur chemin habituel.
+Tracker Dashboard peut utiliser **[FlareSolverr](https://github.com/FlareSolverr/FlareSolverr)** en dernier recours lorsqu'un tracker renvoie explicitement un challenge Cloudflare ou anti-bot. Le sidecar reçoit uniquement l'URL, les cookies et le proxy du tracker concerné, résout le challenge dans une session temporaire, renvoie le HTML puis détruit cette session. Les erreurs de credentials, de réseau ou d'extraction ne déclenchent pas ce navigateur supplémentaire. Un tracker connu pour nécessiter FlareSolverr, comme YGGReborn, peut déclarer ce repli en priorité après les lectures HTTP légères.
 
 Le fichier `docker-compose.yml` fourni inclut déjà ce sidecar. Pour une stack existante, ajoutez :
 

--- a/config/trackers/yggreborn.json
+++ b/config/trackers/yggreborn.json
@@ -23,6 +23,7 @@
   "fetch": {
     "url": "account/",
     "mode": "browser",
+    "antiBotFallback": "flaresolverr",
     "responseType": "html",
     "fields": {
       "uploadedBytes": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,3 +14,13 @@ services:
       # METRICS_PUBLIC: "true"
     volumes:
       - ./config:/app/config
+
+  tracker-dashboard-flaresolverr:
+    image: ghcr.io/flaresolverr/flaresolverr:latest
+    container_name: tracker-dashboard-flaresolverr
+    restart: unless-stopped
+    network_mode: "service:tracker-dashboard"
+    environment:
+      HOST: 127.0.0.1
+      LOG_LEVEL: info
+      TZ: Europe/Paris

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
-    "check:integration": "node scripts/check-integration.mjs && node scripts/check-unread-messages.mjs && node scripts/check-extra-fetch.mjs",
+    "check:integration": "node scripts/check-integration.mjs && node scripts/check-unread-messages.mjs && node scripts/check-extra-fetch.mjs && node scripts/check-flaresolverr.mjs",
     "start": "node --experimental-sqlite dist/index.js",
     "start:browser": "node --experimental-sqlite dist/browserRuntime.js"
   },

--- a/public/index.html
+++ b/public/index.html
@@ -1978,6 +1978,14 @@
       </div>
       <div id="browser-runtime-detail" class="beta-note" style="margin-top:8px"></div>
     </div>
+    <div class="proxy-info" style="margin-top:14px; max-width:760px">
+      <div style="display:flex; align-items:center; gap:10px; flex-wrap:wrap">
+        <b>Repli Cloudflare (FlareSolverr)</b>
+        <span id="flaresolverr-badge" class="definition-badge definition-badge-muted">…</span>
+        <button class="btn-test" style="padding:4px 10px" onclick="loadFlareSolverrStatus()" type="button">Vérifier</button>
+      </div>
+      <div id="flaresolverr-detail" class="beta-note" style="margin-top:8px"></div>
+    </div>
     <div class="proxy-form" style="align-items:flex-start; margin-top:14px">
       <label class="toggle-switch" style="grid-column:span 5" title="Lecture rapide via curl-impersonate">
         <input type="checkbox" id="fast-fetch-enabled" onchange="saveFastFetch()">
@@ -6560,6 +6568,26 @@
     volumes_from:
       - tracker-dashboard`;
 
+  const FLARESOLVERR_INSTALL_COMMAND = `docker run -d \\
+  --name tracker-dashboard-flaresolverr \\
+  --restart unless-stopped \\
+  --network container:tracker-dashboard \\
+  -e HOST=127.0.0.1 \\
+  -e LOG_LEVEL=info \\
+  -e TZ=Europe/Paris \\
+  ghcr.io/flaresolverr/flaresolverr:latest`;
+
+  const FLARESOLVERR_COMPOSE_SNIPPET = `services:
+  tracker-dashboard-flaresolverr:
+    image: ghcr.io/flaresolverr/flaresolverr:latest
+    container_name: tracker-dashboard-flaresolverr
+    restart: unless-stopped
+    network_mode: "container:tracker-dashboard"
+    environment:
+      HOST: 127.0.0.1
+      LOG_LEVEL: info
+      TZ: Europe/Paris`;
+
   // Etat du runtime navigateur externe + versions.
   async function loadBrowserRuntimeStatus() {
     const badge = document.getElementById('browser-runtime-badge');
@@ -6602,6 +6630,41 @@
     }
   }
 
+  async function loadFlareSolverrStatus() {
+    const badge = document.getElementById('flaresolverr-badge');
+    const detail = document.getElementById('flaresolverr-detail');
+    if (!badge || !detail) return;
+    badge.textContent = 'Vérification…';
+    badge.className = 'definition-badge definition-badge-muted';
+    badge.style.color = '';
+    try {
+      const response = await fetch('/api/flaresolverr/status');
+      const data = await response.json();
+      const status = data.status || {};
+      if (status.available) {
+        badge.textContent = 'FlareSolverr — disponible';
+        badge.className = 'definition-badge';
+        detail.innerHTML = `Version <b>${escapeHtml(status.version || '?')}</b><br><span style="color:var(--muted)">${escapeHtml(status.url || '')}</span>`;
+      } else {
+        badge.textContent = 'FlareSolverr — absent';
+        badge.className = 'definition-badge definition-badge-muted';
+        badge.style.color = 'var(--red)';
+        detail.innerHTML = `Le sidecar FlareSolverr est absent ou injoignable${status.error ? ' : ' + escapeHtml(status.error) : ''}.
+          <div style="margin-top:10px"><b>Stack Compose / Dockge / Portainer</b></div>
+          <pre style="white-space:pre-wrap;margin-top:8px"><code>${escapeHtml(FLARESOLVERR_COMPOSE_SNIPPET)}</code></pre>
+          <button class="btn-test" style="padding:4px 10px;margin-top:6px" onclick="copyFlareSolverrInstall(this, 'compose')" type="button">Copier le compose</button>
+          <details style="margin-top:10px">
+            <summary style="cursor:pointer">Commande Docker équivalente</summary>
+            <pre style="white-space:pre-wrap;margin-top:8px"><code>${escapeHtml(FLARESOLVERR_INSTALL_COMMAND)}</code></pre>
+            <button class="btn-test" style="padding:4px 10px;margin-top:6px" onclick="copyFlareSolverrInstall(this, 'run')" type="button">Copier la commande</button>
+          </details>`;
+      }
+    } catch (error) {
+      badge.textContent = 'Inconnu';
+      detail.textContent = 'Statut indisponible : ' + error.message;
+    }
+  }
+
   async function saveBrowserEngine() {
     const engine = document.getElementById('browser-engine-cloak').checked ? 'cloak' : 'chromium';
     try {
@@ -6622,6 +6685,17 @@
     } catch (e) {
       button.textContent = 'Copie impossible';
       console.warn('copyBrowserRuntimeInstall:', e.message);
+    }
+  }
+
+  async function copyFlareSolverrInstall(button, mode) {
+    try {
+      await navigator.clipboard.writeText(mode === 'compose' ? FLARESOLVERR_COMPOSE_SNIPPET : FLARESOLVERR_INSTALL_COMMAND);
+      const previous = button.textContent;
+      button.textContent = 'Copié';
+      setTimeout(() => { button.textContent = previous; }, 1500);
+    } catch (error) {
+      console.warn('copyFlareSolverrInstall:', error.message);
     }
   }
 
@@ -6902,6 +6976,7 @@
     await loadProxySettings();
     await loadBrowserEngine();
     loadBrowserRuntimeStatus();
+    loadFlareSolverrStatus();
     await loadFastFetch();
     await loadTrackerDefinitionsPanel();
     getActiveGrid().innerHTML = renderSkeleton(trackerCount);

--- a/public/index.html
+++ b/public/index.html
@@ -1985,6 +1985,7 @@
         <button class="btn-test" style="padding:4px 10px" onclick="loadFlareSolverrStatus()" type="button">Vérifier</button>
       </div>
       <div id="flaresolverr-detail" class="beta-note" style="margin-top:8px"></div>
+      <p class="beta-note" style="margin-top:8px">Dernier recours automatique pour les challenges Cloudflare/anti-bot explicites. CloakBrowser reste le moteur normal ; les erreurs de credentials ou de regex ne déclenchent pas FlareSolverr.</p>
     </div>
     <div class="proxy-form" style="align-items:flex-start; margin-top:14px">
       <label class="toggle-switch" style="grid-column:span 5" title="Lecture rapide via curl-impersonate">

--- a/scripts/check-flaresolverr.mjs
+++ b/scripts/check-flaresolverr.mjs
@@ -1,0 +1,107 @@
+import http from 'node:http';
+import { fetchWithFlareSolverr, getFlareSolverrStatus } from '../dist/flareSolverr.js';
+
+const calls = [];
+const server = http.createServer(async (request, response) => {
+  if (request.method === 'GET') {
+    response.setHeader('Content-Type', 'application/json');
+    response.end(JSON.stringify({ msg: 'FlareSolverr is ready!', version: 'test', userAgent: 'Mock Browser' }));
+    return;
+  }
+
+  let raw = '';
+  for await (const chunk of request) raw += chunk;
+  const payload = JSON.parse(raw);
+  calls.push(payload);
+  response.setHeader('Content-Type', 'application/json');
+
+  if (payload.cmd === 'sessions.create') {
+    response.end(JSON.stringify({ status: 'ok', session: payload.session }));
+    return;
+  }
+  if (payload.cmd === 'sessions.destroy') {
+    response.end(JSON.stringify({ status: 'ok' }));
+    return;
+  }
+  if (payload.url.endsWith('/extra-fail')) {
+    response.end(JSON.stringify({ status: 'error', message: 'secondary request failed' }));
+    return;
+  }
+  if (payload.url.endsWith('/account/active-torrents')) {
+    response.end(JSON.stringify({
+      status: 'ok',
+      solution: { status: 200, url: payload.url, response: '<div>12 en partage</div>', cookies: [] },
+    }));
+    return;
+  }
+  response.end(JSON.stringify({
+    status: 'ok',
+    solution: {
+      status: 200,
+      url: payload.url,
+      response: '<div>910.27 GB</div><span>Upload</span><div>439.76 GB</div><span>Download</span>',
+      cookies: [{ name: 'cf_clearance', value: 'generated' }],
+    },
+  }));
+});
+
+await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+try {
+  const address = server.address();
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+  const tracker = {
+    id: 'yggreborn-test',
+    name: 'YGGReborn Test',
+    baseUrl: 'https://www.yggreborn.org',
+    login: { url: 'login', method: 'POST', contentType: 'form', body: {}, failurePatterns: [], cookieOnly: true },
+    fetch: {
+      url: 'account/',
+      mode: 'browser',
+      responseType: 'html',
+      fields: {},
+      extraFetch: { url: 'account/active-torrents', field: 'seeding', regex: '(?<value>\\d+) en partage', transform: 'integer' },
+    },
+  };
+  const result = await fetchWithFlareSolverr(tracker, { username: 'user', password: 'unused' }, {
+    baseUrl,
+    cookieRaw: 'remember_token=session; __ygg_sess=token',
+    proxy: { enabled: true, type: 'http', host: 'proxy.local', port: '8887', username: '', password: '', directConnectAllowed: false },
+    timeoutMs: 5_000,
+  });
+
+  if (!result.html.includes('Upload') || !result.extraHtml?.includes('12 en partage')) {
+    throw new Error('FlareSolverr primary or extra HTML was not returned');
+  }
+  if (calls[0]?.cmd !== 'sessions.create' || calls.at(-1)?.cmd !== 'sessions.destroy') {
+    throw new Error('FlareSolverr session lifecycle is incomplete');
+  }
+  if (calls[0]?.proxy?.url !== 'http://proxy.local:8887') {
+    throw new Error('Tracker proxy was not forwarded to FlareSolverr');
+  }
+  const mainRequest = calls.find(call => call.url?.endsWith('/account/'));
+  if (mainRequest?.cookies?.map(cookie => cookie.name).sort().join(',') !== '__ygg_sess,remember_token') {
+    throw new Error('Stored tracker cookies were not forwarded to FlareSolverr');
+  }
+
+  const bestEffortResult = await fetchWithFlareSolverr({
+    ...tracker,
+    id: 'yggreborn-extra-failure-test',
+    fetch: { ...tracker.fetch, extraFetch: { ...tracker.fetch.extraFetch, url: 'extra-fail' } },
+  }, { username: 'user', password: 'unused' }, {
+    baseUrl,
+    cookieRaw: 'remember_token=session; __ygg_sess=token',
+    proxy: { enabled: false, type: 'direct', host: '', port: '', username: '', password: '', directConnectAllowed: true },
+    timeoutMs: 5_000,
+  });
+  if (!bestEffortResult.html.includes('Upload') || bestEffortResult.extraHtml !== undefined) {
+    throw new Error('FlareSolverr extra fetch failures must remain best-effort');
+  }
+
+  const status = await getFlareSolverrStatus(baseUrl);
+  if (!status.available || status.version !== 'test') {
+    throw new Error('FlareSolverr status endpoint was not detected');
+  }
+  console.log('FlareSolverr checks OK: proxy, cookies, session lifecycle and extra fetch.');
+} finally {
+  await new Promise(resolve => server.close(resolve));
+}

--- a/scripts/check-flaresolverr.mjs
+++ b/scripts/check-flaresolverr.mjs
@@ -1,5 +1,5 @@
 import http from 'node:http';
-import { fetchWithFlareSolverr, getFlareSolverrStatus } from '../dist/flareSolverr.js';
+import { fetchWithFlareSolverr, getFlareSolverrStatus, isFlareSolverrCandidate } from '../dist/flareSolverr.js';
 
 const calls = [];
 const server = http.createServer(async (request, response) => {
@@ -100,6 +100,11 @@ try {
   const status = await getFlareSolverrStatus(baseUrl);
   if (!status.available || status.version !== 'test') {
     throw new Error('FlareSolverr status endpoint was not detected');
+  }
+  if (!isFlareSolverrCandidate(new Error('Challenge anti-bot/Cloudflare affiche'))
+    || isFlareSolverrCandidate(new Error('Identifiants invalides'))
+    || isFlareSolverrCandidate(new Error('Aucune donnee extraite'))) {
+    throw new Error('FlareSolverr fallback must remain limited to explicit anti-bot failures');
   }
   console.log('FlareSolverr checks OK: proxy, cookies, session lifecycle and extra fetch.');
 } finally {

--- a/scripts/check-integration.mjs
+++ b/scripts/check-integration.mjs
@@ -4,12 +4,14 @@ import path from 'node:path';
 const root = process.cwd();
 const htmlPath = path.join(root, 'public', 'index.html');
 const readmePath = path.join(root, 'README.md');
+const composePath = path.join(root, 'docker-compose.yml');
 const serverPath = path.join(root, 'src', 'server.ts');
 const redactedPath = path.join(root, 'config', 'trackers', 'redacted.json');
 const tr4kerPath = path.join(root, 'config', 'trackers', 'tr4ker.json');
 const lesRescapesPath = path.join(root, 'config', 'trackers', 'lesrescapesdeygg.json');
 const html = fs.readFileSync(htmlPath, 'utf8');
 const readme = fs.readFileSync(readmePath, 'utf8');
+const compose = fs.readFileSync(composePath, 'utf8');
 const server = fs.readFileSync(serverPath, 'utf8');
 const redacted = JSON.parse(fs.readFileSync(redactedPath, 'utf8'));
 const tr4ker = JSON.parse(fs.readFileSync(tr4kerPath, 'utf8'));
@@ -124,6 +126,27 @@ const documentsCookieIpBinding = (
 );
 if (!documentsCookieIpBinding) {
   errors.push('Session cookie guidance must document IP binding and cf_clearance in the WebUI and README');
+}
+
+const yggUsesFlareSolverrFallback = (
+  JSON.parse(fs.readFileSync(path.join(root, 'config', 'trackers', 'yggreborn.json'), 'utf8'))
+    .fetch?.antiBotFallback === 'flaresolverr'
+);
+if (!yggUsesFlareSolverrFallback) {
+  errors.push('YGGReborn must use the FlareSolverr anti-bot fallback');
+}
+
+const shipsFlareSolverrSidecar = (
+  compose.includes('tracker-dashboard-flaresolverr:')
+  && compose.includes('ghcr.io/flaresolverr/flaresolverr:latest')
+  && compose.includes('network_mode: "service:tracker-dashboard"')
+  && compose.includes('HOST: 127.0.0.1')
+  && html.includes('/api/flaresolverr/status')
+  && server.includes("app.get('/api/flaresolverr/status'")
+  && readme.includes('### Repli Cloudflare (FlareSolverr)')
+);
+if (!shipsFlareSolverrSidecar) {
+  errors.push('FlareSolverr sidecar wiring must remain available in Compose, WebUI and README');
 }
 
 if (errors.length > 0) {

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -21,6 +21,7 @@ import { getTrackerTotpSecret, loadTrackerConfigsFromDb, saveTrackerConfig } fro
 import { generateTotp } from './totp.js';
 import { selectUserAgent } from './userAgent.js';
 import { closeBrowserSession, closeBrowserSessions, fetchWithBrowser } from './browserBackend.js';
+import { fetchWithFlareSolverr } from './flareSolverr.js';
 
 // ─── Transforms ──────────────────────────────────────────────────────────────
 
@@ -1028,6 +1029,23 @@ export async function fetchTracker(
     };
   };
 
+  const attemptFlareSolverr = async (): Promise<TrackerStats | null> => {
+    try {
+      const solved = await fetchWithFlareSolverr(tracker, creds);
+      const failed = hasBrowserAuthFailure(tracker, solved.url, solved.html);
+      if (failed) {
+        console.log(`  [${tracker.name}] FlareSolverr: page non authentifiee (${failed}), repli navigateur`);
+        return null;
+      }
+      const stats = buildStatsFromHtml(solved.url, solved.html, solved.extraHtml);
+      console.log(`  [${tracker.name}] Lecture via FlareSolverr OK`);
+      return stats;
+    } catch (error) {
+      console.log(`  [${tracker.name}] FlareSolverr indisponible/echec, repli navigateur - ${error instanceof Error ? error.message : String(error)}`);
+      return null;
+    }
+  };
+
   // Fast-path curl-impersonate : pour un tracker en mode navigateur disposant d'un
   // cookie de session, on tente d'abord une requete HTTP impersonee (sans Chromium).
   // Si la page est rendue cote serveur et la session valide -> stats directes.
@@ -1280,6 +1298,10 @@ export async function fetchTracker(
         // avant de lancer le navigateur (plus léger, contourne Cloudflare passif)
         const viaCurlFull = await attemptHttpViaCurl();
         if (viaCurlFull) return viaCurlFull;
+        if (tracker.fetch.antiBotFallback === 'flaresolverr') {
+          const viaFlareSolverr = await attemptFlareSolverr();
+          if (viaFlareSolverr) return viaFlareSolverr;
+        }
       }
       const browserResult = await fetchWithBrowser(tracker, creds);
       // Si on a confirme la session via un indicateur DOM specifique (TR4KER : RATIO/UPLOAD/DOWNLOAD

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -21,7 +21,7 @@ import { getTrackerTotpSecret, loadTrackerConfigsFromDb, saveTrackerConfig } fro
 import { generateTotp } from './totp.js';
 import { selectUserAgent } from './userAgent.js';
 import { closeBrowserSession, closeBrowserSessions, fetchWithBrowser } from './browserBackend.js';
-import { fetchWithFlareSolverr } from './flareSolverr.js';
+import { fetchWithFlareSolverr, isFlareSolverrCandidate } from './flareSolverr.js';
 
 // ─── Transforms ──────────────────────────────────────────────────────────────
 
@@ -1303,27 +1303,37 @@ export async function fetchTracker(
           if (viaFlareSolverr) return viaFlareSolverr;
         }
       }
-      const browserResult = await fetchWithBrowser(tracker, creds);
-      // Si on a confirme la session via un indicateur DOM specifique (TR4KER : RATIO/UPLOAD/DOWNLOAD
-      // visibles apres hydratation SPA), on ignore les failurePatterns qui peuvent matcher
-      // la coquille initiale "non connectee".
-      const failed = browserResult.authConfirmed
-        ? null
-        : hasBrowserAuthFailure(tracker, browserResult.url, browserResult.html);
-      if (failed) {
-        if (!isRetry) {
-          console.log(`  [${tracker.name}] Session navigateur expiree, re-login...`);
-          // Reset complet du contexte navigateur (cookies en memoire) avant retry —
-          // pour les sites ou la session persistante est devenue invalide
-          await closeBrowserSession(tracker.id).catch(() => {});
-          await new Promise(resolve => setTimeout(resolve, 3000));
-          return attempt(true);
+      try {
+        const browserResult = await fetchWithBrowser(tracker, creds);
+        // Si on a confirme la session via un indicateur DOM specifique (TR4KER : RATIO/UPLOAD/DOWNLOAD
+        // visibles apres hydratation SPA), on ignore les failurePatterns qui peuvent matcher
+        // la coquille initiale "non connectee".
+        const failed = browserResult.authConfirmed
+          ? null
+          : hasBrowserAuthFailure(tracker, browserResult.url, browserResult.html);
+        if (failed) {
+          if (!isRetry) {
+            console.log(`  [${tracker.name}] Session navigateur expiree, re-login...`);
+            // Reset complet du contexte navigateur (cookies en memoire) avant retry —
+            // pour les sites ou la session persistante est devenue invalide
+            await closeBrowserSession(tracker.id).catch(() => {});
+            await new Promise(resolve => setTimeout(resolve, 3000));
+            return attempt(true);
+          }
+          const dumpPath = writeDebugDump(tracker, browserResult.url, browserResult.html, {}, 'browser-auth');
+          const suffix = dumpPath ? ` - dump: ${dumpPath}` : '';
+          throw new Error(`Session navigateur non authentifiee - verifier les credentials ou valider le challenge dans le profil navigateur${suffix}`);
         }
-        const dumpPath = writeDebugDump(tracker, browserResult.url, browserResult.html, {}, 'browser-auth');
-        const suffix = dumpPath ? ` - dump: ${dumpPath}` : '';
-        throw new Error(`Session navigateur non authentifiee - verifier les credentials ou valider le challenge dans le profil navigateur${suffix}`);
+        return buildStatsFromHtml(browserResult.url, browserResult.html, browserResult.extraHtml);
+      } catch (error) {
+        // Repli generique, uniquement pour une signature anti-bot explicite. Les
+        // erreurs de credentials, reseau ou extraction ne lancent pas un second navigateur.
+        if (tracker.fetch.antiBotFallback !== 'flaresolverr' && isFlareSolverrCandidate(error)) {
+          const viaFlareSolverr = await attemptFlareSolverr();
+          if (viaFlareSolverr) return viaFlareSolverr;
+        }
+        throw error;
       }
-      return buildStatsFromHtml(browserResult.url, browserResult.html, browserResult.extraHtml);
     }
 
     // Mode HTTP : on tente d'abord le login+fetch via curl-impersonate (empreinte

--- a/src/flareSolverr.ts
+++ b/src/flareSolverr.ts
@@ -1,0 +1,215 @@
+import { getTrackerCookie } from './db.js';
+import { parseCookies, type ParsedCookie } from './cookies.js';
+import { resolveProxyForTracker, toSshConfig, type ProxySettings } from './proxy.js';
+import { getSshLocalEndpoint } from './sshTunnel.js';
+import { type TrackerConfig } from './types.js';
+
+const DEFAULT_FLARESOLVERR_URL = 'http://127.0.0.1:8191';
+
+interface FlareCookie {
+  name: string;
+  value: string;
+}
+
+interface FlareSolution {
+  url?: string;
+  status?: number;
+  response?: string;
+  cookies?: FlareCookie[];
+  userAgent?: string;
+}
+
+interface FlareResponse {
+  status?: string;
+  message?: string;
+  session?: string;
+  solution?: FlareSolution;
+}
+
+export interface FlareSolverrFetchResult {
+  html: string;
+  url: string;
+  extraHtml?: string;
+}
+
+export interface FlareSolverrStatus {
+  available: boolean;
+  url: string;
+  version?: string;
+  userAgent?: string;
+  error?: string;
+}
+
+export interface FlareSolverrOverrides {
+  baseUrl?: string;
+  cookieRaw?: string;
+  proxy?: ProxySettings;
+  timeoutMs?: number;
+}
+
+function serviceUrl(override?: string): string {
+  return (override || process.env.FLARESOLVERR_URL || DEFAULT_FLARESOLVERR_URL).replace(/\/+$/, '');
+}
+
+function resolveUrl(baseUrl: string, relativePath: string): string {
+  const base = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
+  return /^https?:\/\//.test(relativePath) ? relativePath : new URL(relativePath, base).toString();
+}
+
+function interpolate(template: string, vars: Record<string, string>): string {
+  return template.replace(/\{\{(\w+)\}\}/g, (_, key) => vars[key] ?? '');
+}
+
+function flareCookies(cookies: ParsedCookie[]): FlareCookie[] {
+  return cookies.map(cookie => ({
+    name: cookie.name,
+    value: cookie.value,
+  }));
+}
+
+function flareProxy(proxy: ProxySettings): Record<string, string> | undefined {
+  if (!proxy.enabled || !proxy.host || !proxy.port) return undefined;
+
+  let url: string;
+  if (proxy.type === 'ssh') {
+    const ssh = toSshConfig(proxy);
+    const endpoint = ssh ? getSshLocalEndpoint(ssh) : null;
+    if (!endpoint) return undefined;
+    url = `socks5://${endpoint.host}:${endpoint.port}`;
+  } else {
+    url = `${proxy.type}://${proxy.host}:${proxy.port}`;
+  }
+
+  return {
+    url,
+    ...(proxy.username ? { username: proxy.username } : {}),
+    ...(proxy.password ? { password: proxy.password } : {}),
+  };
+}
+
+async function callFlareSolverr(
+  baseUrl: string,
+  payload: Record<string, unknown>,
+  timeoutMs: number,
+): Promise<FlareResponse> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs + 10_000);
+  try {
+    const response = await fetch(`${baseUrl}/v1`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+    const data = await response.json().catch(() => ({})) as FlareResponse;
+    if (!response.ok || data.status !== 'ok') {
+      throw new Error(data.message || `HTTP ${response.status}`);
+    }
+    return data;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function solve(
+  baseUrl: string,
+  session: string,
+  url: string,
+  cookies: FlareCookie[],
+  timeoutMs: number,
+): Promise<FlareSolution> {
+  const result = await callFlareSolverr(baseUrl, {
+    cmd: 'request.get',
+    session,
+    url,
+    cookies,
+    maxTimeout: timeoutMs,
+    waitInSeconds: 2,
+  }, timeoutMs);
+  const solution = result.solution;
+  if (!solution || typeof solution.response !== 'string' || (solution.status ?? 500) >= 400) {
+    throw new Error(`reponse invalide pour ${url}`);
+  }
+  return solution;
+}
+
+export async function fetchWithFlareSolverr(
+  tracker: TrackerConfig,
+  credentials: { username: string; password: string },
+  overrides: FlareSolverrOverrides = {},
+): Promise<FlareSolverrFetchResult> {
+  const baseUrl = serviceUrl(overrides.baseUrl);
+  const requestedTimeout = overrides.timeoutMs ?? Number.parseInt(process.env.FLARESOLVERR_TIMEOUT_MS || '90000', 10);
+  const timeoutMs = Number.isFinite(requestedTimeout)
+    ? Math.max(5_000, Math.min(180_000, requestedTimeout))
+    : 90_000;
+  const proxy = flareProxy(overrides.proxy ?? resolveProxyForTracker(tracker.id));
+  const cookies = flareCookies(parseCookies(overrides.cookieRaw ?? getTrackerCookie(tracker.id)));
+  const session = `tracker-dashboard-${tracker.id.replace(/[^a-z0-9_-]/gi, '_')}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+  const created = await callFlareSolverr(baseUrl, {
+    cmd: 'sessions.create',
+    session,
+    session_ttl_minutes: 5,
+    ...(proxy ? { proxy } : {}),
+  }, Math.min(timeoutMs, 30_000));
+  const activeSession = created.session || session;
+
+  try {
+    const vars: Record<string, string> = {
+      username: credentials.username,
+      password: credentials.password,
+    };
+    const primaryUrl = resolveUrl(tracker.baseUrl, interpolate(tracker.fetch.url, vars));
+    const primary = await solve(baseUrl, activeSession, primaryUrl, cookies, timeoutMs);
+
+    let extraHtml: string | undefined;
+    const extra = tracker.fetch.extraFetch;
+    if (extra) {
+      if (extra.idExtract) {
+        const match = new RegExp(extra.idExtract.regex, 's').exec(primary.response ?? '');
+        const id = match?.groups?.['value'];
+        if (id) vars.id = id;
+      }
+      if (!extra.idExtract || vars.id) {
+        try {
+          const extraUrl = resolveUrl(tracker.baseUrl, interpolate(extra.url, vars));
+          const solvedExtra = await solve(baseUrl, activeSession, extraUrl, [], timeoutMs);
+          extraHtml = solvedExtra.response;
+        } catch {
+          // Comme les autres implementations extraFetch : le champ secondaire
+          // reste best-effort et ne doit jamais invalider les statistiques principales.
+        }
+      }
+    }
+
+    return {
+      html: primary.response ?? '',
+      url: primary.url || primaryUrl,
+      extraHtml,
+    };
+  } finally {
+    await callFlareSolverr(baseUrl, { cmd: 'sessions.destroy', session: activeSession }, 15_000).catch(() => {});
+  }
+}
+
+export async function getFlareSolverrStatus(baseUrlOverride?: string): Promise<FlareSolverrStatus> {
+  const url = serviceUrl(baseUrlOverride);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 5_000);
+  try {
+    const response = await fetch(`${url}/`, { signal: controller.signal });
+    const data = await response.json().catch(() => ({})) as Record<string, unknown>;
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    return {
+      available: true,
+      url,
+      version: typeof data.version === 'string' ? data.version : undefined,
+      userAgent: typeof data.userAgent === 'string' ? data.userAgent : undefined,
+    };
+  } catch (error) {
+    return { available: false, url, error: error instanceof Error ? error.message : String(error) };
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/flareSolverr.ts
+++ b/src/flareSolverr.ts
@@ -47,6 +47,11 @@ export interface FlareSolverrOverrides {
   timeoutMs?: number;
 }
 
+export function isFlareSolverrCandidate(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /challenge|anti-bot|cloudflare|turnstile|cf-chl|just a moment|un instant/i.test(message);
+}
+
 function serviceUrl(override?: string): string {
   return (override || process.env.FLARESOLVERR_URL || DEFAULT_FLARESOLVERR_URL).replace(/\/+$/, '');
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'url';
 import axios from 'axios';
 import { fetchTracker, invalidateAllSessions, invalidateSession } from './fetcher.js';
 import { resetBrowserProfile, closeBrowserSession, fetchRawHtmlWithBrowser, getBrowserRuntimeStatus } from './browserBackend.js';
+import { getFlareSolverrStatus } from './flareSolverr.js';
 import { type FieldExtractor, type TrackerConfig, type TrackerStats } from './types.js';
 import {
   listEngines,
@@ -3203,6 +3204,10 @@ export async function start(): Promise<void> {
   // Etat du runtime navigateur (local embarque ou service externe) + versions.
   app.get('/api/browser-runtime/status', async (_req, res) => {
     res.json({ ok: true, status: await getBrowserRuntimeStatus() });
+  });
+
+  app.get('/api/flaresolverr/status', async (_req, res) => {
+    res.json({ ok: true, status: await getFlareSolverrStatus() });
   });
 
   app.post('/api/settings/browser-engine', (req, res) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -113,6 +113,8 @@ export interface FieldExtractor {
 export interface FetchStep {
   url: string;
   mode?: 'http' | 'browser';
+  /** Repli anti-bot optionnel via le sidecar FlareSolverr avant le navigateur standard. */
+  antiBotFallback?: 'flaresolverr';
   responseType: 'json' | 'html';
   fields: Record<string, FieldExtractor>;
   /**


### PR DESCRIPTION
## Résumé

- ajoute un sidecar Compose FlareSolverr, interne au réseau du conteneur principal et sans port exposé ;
- utilise ce repli en dernier recours pour tout tracker qui échoue sur un challenge Cloudflare/anti-bot explicite, sans le déclencher pour les erreurs de credentials, réseau ou extraction ;
- permet aux trackers connus comme YGGReborn de tenter FlareSolverr plus tôt, après les lectures HTTP légères ;
- transmet les cookies et le proxy propres au tracker, conserve une session temporaire entre la page principale et le fetch secondaire, puis la détruit systématiquement ;
- affiche l’état de FlareSolverr et les commandes d’installation dans la WebUI ;
- documente le déploiement et verrouille le flux par des tests d’intégration.

## Validation

- test réel YGGReborn via le proxy configuré : challenge résolu, `cf_clearance` obtenu et page du compte authentifiée ;
- test réel de `/account/active-torrents` dans la même session, sans nouveau challenge ;
- `npm ci`
- `npm run build`
- `npm run check:integration`
- `npm audit --omit=dev --audit-level=high`
- `git diff --check`
- `docker compose config --quiet` sur l’hôte Docker
- contrôle du rendu WebUI sur une instance locale
