### PR TITLE
Sécurise les journaux FlareSolverr

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,8 @@ services:
     network_mode: "container:tracker-dashboard"
     environment:
       HOST: 127.0.0.1
-      LOG_LEVEL: info
+      # Évite de journaliser les corps de requête, qui contiennent les cookies de session.
+      LOG_LEVEL: warning
       TZ: Europe/Paris
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,5 +22,6 @@ services:
     network_mode: "service:tracker-dashboard"
     environment:
       HOST: 127.0.0.1
-      LOG_LEVEL: info
+      # Evite de journaliser les corps de requete, qui contiennent les cookies de session.
+      LOG_LEVEL: warning
       TZ: Europe/Paris

--- a/scripts/check-integration.mjs
+++ b/scripts/check-integration.mjs
@@ -139,6 +139,7 @@ if (!yggUsesFlareSolverrFallback) {
 const shipsFlareSolverrSidecar = (
   compose.includes('tracker-dashboard-flaresolverr:')
   && compose.includes('ghcr.io/flaresolverr/flaresolverr:latest')
+  && compose.includes('LOG_LEVEL: warning')
   && compose.includes('network_mode: "service:tracker-dashboard"')
   && compose.includes('HOST: 127.0.0.1')
   && html.includes('/api/flaresolverr/status')


### PR DESCRIPTION
## Résumé

- configure FlareSolverr avec `LOG_LEVEL=warning` dans le Compose et le README ;
- évite la journalisation des corps de requête susceptibles de contenir des cookies de session ;
- verrouille ce réglage dans les contrôles d'intégration.

## Validation

- `npm run build`
- `npm run check:integration`
- `npm audit --omit=dev --audit-level=high`
- `git diff --check`
- déploiement réel validé avec `LOG_LEVEL=warning`
