### PR TITLE
Corrige l’édition d’un tracker depuis la vue Cartes

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2920,14 +2920,7 @@
   }
 
   function openTrackerEdit(trackerId) {
-    // Ouvrir le panneau Trackers
-    const panel = document.getElementById('tracker-definitions-panel');
-    if (panel && !panel.open) panel.open = true;
-    // Scroller vers la ligne du tracker
-    setTimeout(() => {
-      const row = document.getElementById('tracker-def-' + trackerId);
-      if (row) row.scrollIntoView({ behavior: 'smooth', block: 'center' });
-    }, 100);
+    openTrackerConfig(trackerId);
   }
 
   function cardRefreshButton(stat) {

--- a/scripts/check-integration.mjs
+++ b/scripts/check-integration.mjs
@@ -90,6 +90,14 @@ if (!seedingSourcesAreStacked) {
   errors.push('Site and BitTorrent seeding sources must remain vertically stacked');
 }
 
+const cardEditOpensSelectedTracker = (
+  html.includes("function openTrackerEdit(trackerId) {\n    openTrackerConfig(trackerId);\n  }")
+  && !html.includes("document.getElementById('tracker-definitions-panel')")
+);
+if (!cardEditOpensSelectedTracker) {
+  errors.push('Card edit buttons must open the selected tracker configuration view');
+}
+
 const synchronizesAllBundledTrackers = (
   server.includes('const definition = loadDefaultTrackerDefinition(tracker.baseId ?? tracker.id);')
   && !server.includes('CANONICAL_CONNECTION_TRACKERS')


### PR DESCRIPTION
## Résumé

- corrige le bouton « Éditer ce tracker » affiché sur les cartes du dashboard ;
- ouvre directement la vue de configuration du tracker sélectionné ;
- supprime l'ancien chemin vers un panneau qui n'existe plus ;
- ajoute un contrôle d'intégration pour empêcher la régression.

## Validation

- reproduction du défaut dans une WebUI locale isolée ;
- vérification de la navigation vers le tracker sélectionné ;
- `npm ci`
- `npm run build`
- `npm run check:integration`
- `npm audit --omit=dev --audit-level=high`
- `git diff --check`
