### PR TITLE
Autorise plusieurs clients par instance cross-seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Dans **Configuration → Clients BitTorrent**, ajoutez un ou plusieurs clients *
 
 Dans la même page, la section **Instances cross-seed** permet d'associer une ou plusieurs instances [cross-seed](https://github.com/cross-seed/cross-seed) à leurs clients BitTorrent :
 
-- renseignez l'URL de la WebUI cross-seed (port par défaut `2468`) et choisissez le client qBittorrent ou ruTorrent/rTorrent alimenté par cette instance ;
+- renseignez l'URL de la WebUI cross-seed (port par défaut `2468`) et sélectionnez tous les clients qBittorrent ou ruTorrent/rTorrent alimentés par cette instance ;
 - conservez les marqueurs par défaut `cross-seed-link, cross-seed`, ou indiquez le `linkCategory`, la catégorie ou le tag utilisé par votre installation ;
 - lancez une synchronisation des clients BitTorrent : le logo cross-seed apparaît discrètement près des trackers et des torrents concernés ;
 - cliquez sur le logo ou sur **Ouvrir cross-seed** dans une fiche tracker pour rejoindre directement la bonne WebUI.

--- a/public/index.html
+++ b/public/index.html
@@ -907,6 +907,16 @@
       border-top: 1px solid var(--border);
     }
     .beta-form-row:first-child { border-top: 0; padding-top: 0; }
+    .cross-seed-client-list {
+      min-height: 32px; display: flex; flex-wrap: wrap; align-items: center; gap: 5px;
+      padding: 4px 6px; border: 1px solid var(--border); border-radius: 6px; background: var(--bg);
+    }
+    .cross-seed-client-choice {
+      display: inline-flex !important; align-items: center; gap: 5px; padding: 3px 7px;
+      border: 1px solid var(--border); border-radius: 999px; color: var(--text) !important;
+      font-size: 11px; cursor: pointer;
+    }
+    .beta-field .cross-seed-client-choice input { width: 14px; height: 14px; margin: 0; }
     .beta-icon-btn {
       border: 1px solid var(--border);
       background: transparent;
@@ -2452,7 +2462,7 @@
           </section>
         <section class="beta-panel">
           <h3>Instances cross-seed</h3>
-          <p class="beta-note" style="margin-bottom:10px">Reliez chaque instance cross-seed au client BitTorrent qu'elle alimente. Les marqueurs correspondent au <code>linkCategory</code>, à une catégorie se terminant par <code>.cross-seed</code>, ou à un tag appliqué aux torrents injectés.</p>
+          <p class="beta-note" style="margin-bottom:10px">Reliez chaque instance cross-seed à tous les clients BitTorrent qu'elle alimente. Les marqueurs correspondent au <code>linkCategory</code>, à une catégorie se terminant par <code>.cross-seed</code>, ou à un tag appliqué aux torrents injectés.</p>
           <div id="beta-cross-seed-instances"></div>
           <div style="margin-top:10px; display:flex; gap:8px; flex-wrap:wrap">
             <button class="beta-icon-btn" onclick="addBetaCrossSeedInstance()" type="button">Ajouter une instance</button>
@@ -4889,14 +4899,14 @@
     if (!container) return;
     const instances = betaSettings.crossSeedInstances || [];
     const clients = betaSettings.qbitClients || [];
-    const clientOptions = selectedId => clients.map(client => `
-      <option value="${escapeHtml(client.id)}" ${client.id === selectedId ? 'selected' : ''}>${escapeHtml(client.label || client.id)}</option>
-    `).join('');
     container.innerHTML = instances.map((instance, idx) => `
-      <div class="beta-form-row" data-beta-cross-seed="${idx}" style="grid-template-columns:minmax(0,1fr) minmax(0,2fr) minmax(0,1.4fr) minmax(0,1.5fr) 80px auto">
+      <div class="beta-form-row" data-beta-cross-seed="${idx}" style="grid-template-columns:minmax(0,1fr) minmax(0,2fr) minmax(0,2fr) minmax(0,1.5fr) 80px auto">
         <div class="beta-field"><label>Nom</label><input data-field="label" value="${escapeHtml(instance.label || '')}" placeholder="cross-seed principal"></div>
         <div class="beta-field"><label>URL WebUI</label><input data-field="baseUrl" value="${escapeHtml(instance.baseUrl || '')}" placeholder="http://cross-seed:2468"></div>
-        <div class="beta-field"><label>Client lié</label><select data-field="clientId"><option value="">— choisir —</option>${clientOptions(instance.clientId)}</select></div>
+        <div class="beta-field"><label>Clients liés</label><div class="cross-seed-client-list">${clients.map(client => {
+          const selectedIds = instance.clientIds || (instance.clientId ? [instance.clientId] : []);
+          return `<label class="cross-seed-client-choice"><input type="checkbox" data-field="clientIds" value="${escapeHtml(client.id)}" ${selectedIds.includes(client.id) ? 'checked' : ''}>${escapeHtml(client.label || client.id)}</label>`;
+        }).join('') || '<span class="beta-note">Ajoutez d’abord un client BitTorrent.</span>'}</div></div>
         <div class="beta-field"><label title="Catégories ou tags séparés par des virgules">Marqueurs</label><input data-field="markers" value="${escapeHtml((instance.markers || ['cross-seed-link', 'cross-seed']).join(', '))}" placeholder="cross-seed-link, cross-seed"></div>
         <div class="beta-field"><label>Actif</label><select data-field="enabled"><option value="true" ${instance.enabled !== false ? 'selected' : ''}>Oui</option><option value="false" ${instance.enabled === false ? 'selected' : ''}>Non</option></select></div>
         <div style="display:flex; gap:6px; align-items:flex-end">${instance.baseUrl ? `<a class="beta-icon-btn" href="${escapeHtml(instance.baseUrl)}" target="_blank" rel="noreferrer noopener">Ouvrir</a>` : ''}<button class="beta-icon-btn" onclick="testBetaCrossSeedInstance(${idx})" type="button">Tester</button><button class="beta-icon-btn" onclick="removeBetaCrossSeedInstance(${idx})" type="button">X</button></div>
@@ -5248,10 +5258,10 @@
       id: betaSettings.crossSeedInstances?.[idx]?.id || genId(),
       label: row.querySelector('[data-field="label"]').value.trim(),
       baseUrl: row.querySelector('[data-field="baseUrl"]').value.trim(),
-      clientId: row.querySelector('[data-field="clientId"]').value,
+      clientIds: Array.from(row.querySelectorAll('[data-field="clientIds"]:checked')).map(input => input.value),
       markers: row.querySelector('[data-field="markers"]').value.split(',').map(value => value.trim()).filter(Boolean),
       enabled: row.querySelector('[data-field="enabled"]').value === 'true',
-    })).filter(instance => instance.baseUrl && instance.clientId);
+    })).filter(instance => instance.baseUrl && instance.clientIds.length > 0);
     const announceMappings = Array.from(document.querySelectorAll('[data-beta-mapping]')).map((row) => ({
       announceHost: row.querySelector('[data-field="announceHost"]').value.trim(),
       trackerId: row.querySelector('[data-field="trackerId"]').value,
@@ -5367,7 +5377,7 @@
       id: genId(),
       label: 'cross-seed',
       baseUrl: '',
-      clientId: betaSettings.qbitClients?.[0]?.id || '',
+      clientIds: betaSettings.qbitClients?.[0]?.id ? [betaSettings.qbitClients[0].id] : [],
       markers: ['cross-seed-link', 'cross-seed'],
       enabled: true,
     });

--- a/scripts/check-cross-seed.mjs
+++ b/scripts/check-cross-seed.mjs
@@ -1,13 +1,14 @@
 import {
   cleanCrossSeedBaseUrl,
   detectCrossSeedInstanceIds,
+  normalizeCrossSeedClientIds,
   normalizeCrossSeedMarkers,
 } from '../dist/crossSeed.js';
 
 const instances = [
-  { id: 'main', label: 'cross-seed principal', baseUrl: 'http://cross-seed:2468', clientId: 'qbit-main', markers: ['cross-seed-link', 'cross-seed'], enabled: true },
-  { id: 'other', label: 'cross-seed secondaire', baseUrl: 'http://cross-seed-2:2468', clientId: 'qbit-other', markers: ['secondary-cross-seed'], enabled: true },
-  { id: 'disabled', label: 'désactivé', baseUrl: 'http://disabled:2468', clientId: 'qbit-main', markers: ['cross-seed-link'], enabled: false },
+  { id: 'main', label: 'cross-seed principal', baseUrl: 'http://cross-seed:2468', clientIds: ['qbit-main', 'qbit-other'], markers: ['cross-seed-link', 'cross-seed'], enabled: true },
+  { id: 'other', label: 'cross-seed secondaire', baseUrl: 'http://cross-seed-2:2468', clientIds: ['qbit-other'], markers: ['secondary-cross-seed'], enabled: true },
+  { id: 'disabled', label: 'désactivé', baseUrl: 'http://disabled:2468', clientIds: ['qbit-main'], markers: ['cross-seed-link'], enabled: false },
 ];
 
 const linked = detectCrossSeedInstanceIds(instances, 'qbit-main', 'cross-seed-link', []);
@@ -18,6 +19,13 @@ if (duplicated.join(',') !== 'main') throw new Error(`duplicate category detecti
 
 const tagged = detectCrossSeedInstanceIds(instances, 'qbit-other', '', ['secondary-cross-seed']);
 if (tagged.join(',') !== 'other') throw new Error(`tag detection failed: ${tagged.join(',')}`);
+
+const shared = detectCrossSeedInstanceIds(instances, 'qbit-other', 'cross-seed-link', []);
+if (shared.join(',') !== 'main') throw new Error(`multi-client detection failed: ${shared.join(',')}`);
+
+if (normalizeCrossSeedClientIds({ clientId: 'legacy-client' }).join(',') !== 'legacy-client') {
+  throw new Error('legacy single-client settings must migrate transparently');
+}
 
 if (normalizeCrossSeedMarkers([]).join(',') !== 'cross-seed-link,cross-seed') {
   throw new Error('default cross-seed markers are missing');
@@ -31,4 +39,4 @@ if (cleanCrossSeedBaseUrl('file:///config/cross-seed.db') !== '') {
   throw new Error('cross-seed base URL must only accept HTTP(S)');
 }
 
-console.log('cross-seed checks OK: client isolation, categories, tags and safe URLs.');
+console.log('cross-seed checks OK: multi-client instances, legacy migration, categories, tags and safe URLs.');

--- a/scripts/check-integration.mjs
+++ b/scripts/check-integration.mjs
@@ -165,9 +165,11 @@ const shipsCrossSeedIntegration = (
   && html.includes("fetch('/api/beta/cross-seed/summary'")
   && html.includes('crossSeedTrackerMarks(stat.id')
   && html.includes('torrent.crossSeedInstanceIds')
+  && html.includes('data-field="clientIds"')
   && server.includes("app.post('/api/beta/cross-seed/test'")
   && server.includes("app.get('/api/beta/cross-seed/summary'")
   && server.includes('detectCrossSeedInstanceIds')
+  && server.includes('normalizeCrossSeedClientIds')
   && readme.includes('### Instances cross-seed')
   && readme.includes('Aucune clé API cross-seed')
 );

--- a/src/crossSeed.ts
+++ b/src/crossSeed.ts
@@ -2,7 +2,8 @@ export interface CrossSeedInstanceConfig {
   id: string;
   label: string;
   baseUrl: string;
-  clientId: string;
+  clientIds: string[];
+  clientId?: string;
   markers: string[];
   enabled: boolean;
 }
@@ -15,6 +16,13 @@ export function normalizeCrossSeedMarkers(value: unknown): string[] {
     .map(marker => String(marker).trim().toLowerCase())
     .filter(Boolean);
   return [...new Set(markers.length ? markers : DEFAULT_CROSS_SEED_MARKERS)];
+}
+
+export function normalizeCrossSeedClientIds(instance: { clientIds?: unknown; clientId?: unknown }): string[] {
+  const raw = Array.isArray(instance.clientIds)
+    ? instance.clientIds
+    : [instance.clientId];
+  return [...new Set(raw.map(clientId => String(clientId ?? '').trim()).filter(Boolean))];
 }
 
 function matchesMarker(value: string, marker: string): boolean {
@@ -33,7 +41,7 @@ export function detectCrossSeedInstanceIds(
     .filter(Boolean);
 
   return instances
-    .filter(instance => instance.enabled && instance.clientId === clientId)
+    .filter(instance => instance.enabled && normalizeCrossSeedClientIds(instance).includes(clientId))
     .filter(instance => normalizeCrossSeedMarkers(instance.markers).some(marker => (
       matchesMarker(normalizedCategory, marker)
       || normalizedTags.some(tag => matchesMarker(tag, marker))

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,6 +9,7 @@ import { getFlareSolverrStatus } from './flareSolverr.js';
 import {
   cleanCrossSeedBaseUrl,
   detectCrossSeedInstanceIds,
+  normalizeCrossSeedClientIds,
   normalizeCrossSeedMarkers,
   type CrossSeedInstanceConfig,
 } from './crossSeed.js';
@@ -1632,7 +1633,11 @@ function loadBetaSettings(): BetaSettings {
     defaults: { ...defaultBetaSettings().defaults, ...(settings.defaults ?? {}) },
     features: { ...defaultBetaSettings().features, ...(settings.features ?? {}) },
     qbitClients: Array.isArray(settings.qbitClients) ? settings.qbitClients : [],
-    crossSeedInstances: Array.isArray(settings.crossSeedInstances) ? settings.crossSeedInstances : [],
+    crossSeedInstances: Array.isArray(settings.crossSeedInstances) ? settings.crossSeedInstances.map(rawInstance => {
+      const instance = rawInstance as CrossSeedInstanceConfig;
+      const { clientId: _legacyClientId, ...current } = instance;
+      return { ...current, clientIds: normalizeCrossSeedClientIds(instance) };
+    }) : [],
     announceMappings: Array.isArray(settings.announceMappings) ? settings.announceMappings : [],
     accountAnnounceMappings: Array.isArray(settings.accountAnnounceMappings) ? settings.accountAnnounceMappings : [],
     notificationTargets: Array.isArray(settings.notificationTargets) ? settings.notificationTargets : [],
@@ -1692,15 +1697,16 @@ function saveBetaSettingsPayload(raw: unknown): BetaSettings {
   const crossSeedInstances: CrossSeedInstanceConfig[] = Array.isArray(body.crossSeedInstances)
     ? body.crossSeedInstances.map(rawInstance => {
       const instance = rawInstance as Partial<CrossSeedInstanceConfig>;
+      const clientIds = normalizeCrossSeedClientIds(instance).filter(clientId => validClientIds.has(clientId));
       return {
         id: typeof instance.id === 'string' && instance.id ? instance.id : crypto.randomUUID(),
         label: String(instance.label || 'cross-seed').trim().slice(0, 80),
         baseUrl: cleanCrossSeedBaseUrl(instance.baseUrl),
-        clientId: String(instance.clientId || '').trim(),
+        clientIds,
         markers: normalizeCrossSeedMarkers(instance.markers),
         enabled: instance.enabled !== false,
       };
-    }).filter(instance => instance.baseUrl && validClientIds.has(instance.clientId))
+    }).filter(instance => instance.baseUrl && instance.clientIds.length > 0)
     : current.crossSeedInstances;
 
   const notificationTargets: BetaNotificationTarget[] = Array.isArray(body.notificationTargets) ? body.notificationTargets.map(rawTarget => {


### PR DESCRIPTION
## Résumé

- permet d'associer une même instance cross-seed à plusieurs clients BitTorrent
- remplace la sélection unique par des cases à cocher explicites dans la WebUI
- migre automatiquement les réglages existants utilisant encore `clientId`
- étend les contrôles d'intégration à la détection multi-client et à la compatibilité ascendante

## Validation

- `npm ci`
- `npm run build`
- `npm run check:integration`
- `git diff --check`
- contrôle manuel avec deux clients cochés sur une seule instance cross-seed
