### PR TITLE
Corrige les statistiques Torr9 depuis l'accueil

### DIFF
--- a/config/trackers/torr9.json
+++ b/config/trackers/torr9.json
@@ -4,38 +4,27 @@
   "baseUrl": "https://torr9.net",
   "enabled": true,
   "login": {
-    "url": "https://torr9.net/login",
-    "postUrl": "https://api.torr9.net/api/v1/auth/login",
+    "url": "login",
     "method": "POST",
-    "contentType": "json",
+    "contentType": "form",
     "body": {
       "username": "{{username}}",
       "password": "{{password}}"
     },
-    "successField": "token",
-    "tokenField": "token",
     "failurePatterns": [
-      "\"message\":\"Unauthorized",
-      "\"statusCode\":401"
+      "type=\"password\"",
+      "name=\"password\"",
+      "href=\"/login\""
     ]
   },
   "fetch": {
-    "url": "https://api.torr9.net/api/v1/users/me",
-    "mode": "http",
-    "responseType": "json",
+    "url": "/",
+    "mode": "browser",
+    "responseType": "html",
     "fields": {
-      "downloadedBytes": { "path": "total_downloaded_bytes", "transform": "bytes" },
-      "uploadedBytes":   { "path": "total_uploaded_bytes",   "transform": "bytes" },
-      "seedBonus":       { "path": "jeton_balance",          "transform": "integer" },
-      "memberClass":     { "path": "role",                   "transform": "string" }
-    },
-    "unreadFetch": { "url": "https://api.torr9.net/api/v1/chat/unread-counts", "responseType": "json", "path": "total_dms", "transform": "integer" },
-    "extraFetch": {
-      "url": "https://api.torr9.net/api/v1/users/{{id}}/stats?page=1&limit=20",
-      "idExtract": { "regex": "\"id\"\\s*:\\s*(?<value>\\d+)" },
-      "field": "seeding",
-      "path": "statistics.torrents_seeding",
-      "transform": "integer"
+      "uploadedBytes":   { "regex": "(?:lucide-upload|data-lucide=\\\"upload\\\"|aria-label=\\\"Upload\\\")[\\s\\S]{0,600}?(?<value>\\d[\\d\\s.,]*\\s*[KMGTPE](?:i?B|B))",   "transform": "bytes" },
+      "downloadedBytes": { "regex": "(?:lucide-download|data-lucide=\\\"download\\\"|aria-label=\\\"Download\\\")[\\s\\S]{0,600}?(?<value>\\d[\\d\\s.,]*\\s*[KMGTPE](?:i?B|B))", "transform": "bytes" },
+      "ratio":           { "regex": ">\\s*RATIO\\s*<[\\s\\S]{0,300}?>\\s*(?<value>\\d[\\d\\s.,]*)\\s*<",                                                    "transform": "number" }
     }
   },
   "dashboard": { "byteUnit": "decimal" }

--- a/scripts/check-integration.mjs
+++ b/scripts/check-integration.mjs
@@ -8,6 +8,7 @@ const composePath = path.join(root, 'docker-compose.yml');
 const serverPath = path.join(root, 'src', 'server.ts');
 const redactedPath = path.join(root, 'config', 'trackers', 'redacted.json');
 const tr4kerPath = path.join(root, 'config', 'trackers', 'tr4ker.json');
+const torr9Path = path.join(root, 'config', 'trackers', 'torr9.json');
 const lesRescapesPath = path.join(root, 'config', 'trackers', 'lesrescapesdeygg.json');
 const html = fs.readFileSync(htmlPath, 'utf8');
 const readme = fs.readFileSync(readmePath, 'utf8');
@@ -15,6 +16,7 @@ const compose = fs.readFileSync(composePath, 'utf8');
 const server = fs.readFileSync(serverPath, 'utf8');
 const redacted = JSON.parse(fs.readFileSync(redactedPath, 'utf8'));
 const tr4ker = JSON.parse(fs.readFileSync(tr4kerPath, 'utf8'));
+const torr9 = JSON.parse(fs.readFileSync(torr9Path, 'utf8'));
 const lesRescapes = JSON.parse(fs.readFileSync(lesRescapesPath, 'utf8'));
 const errors = [];
 
@@ -115,6 +117,26 @@ const tr4kerUsesDisplayedTotals = (
 );
 if (!tr4kerUsesDisplayedTotals) {
   errors.push('TR4KER must use the totals displayed by the site and keep seeding from api/me/stats');
+}
+
+const torr9HomeFixture = `
+  <div class="account-stats">
+    <svg class="lucide lucide-upload"></svg><span>1.54 TB</span>
+    <svg class="lucide lucide-download"></svg><span>19.85 GB</span>
+    <span>RATIO</span><strong>79.30</strong>
+  </div>`;
+const torr9Value = field => new RegExp(field.regex, 's').exec(torr9HomeFixture)?.groups?.value;
+const torr9UsesDisplayedHomeStats = (
+  torr9.fetch?.url === '/'
+  && torr9.fetch?.mode === 'browser'
+  && torr9.fetch?.responseType === 'html'
+  && torr9Value(torr9.fetch.fields?.uploadedBytes) === '1.54 TB'
+  && torr9Value(torr9.fetch.fields?.downloadedBytes) === '19.85 GB'
+  && torr9Value(torr9.fetch.fields?.ratio) === '79.30'
+  && !JSON.stringify(torr9.fetch).includes('api.torr9.net')
+);
+if (!torr9UsesDisplayedHomeStats) {
+  errors.push('Torr9 must scrape upload, download and ratio displayed on the authenticated home page');
 }
 
 const lesRescapesDetectsExpiredCookies = (

--- a/src/browserFetcher.ts
+++ b/src/browserFetcher.ts
@@ -269,6 +269,23 @@ async function waitForTrackerContent(tracker: TrackerConfig, page: Page): Promis
       return false;
     }
   }
+  if (tracker.id === 'torr9') {
+    try {
+      await page.waitForFunction(
+        () => {
+          const text = document.body?.innerText ?? '';
+          const hasRatio = /RATIO\s*[\d.,]+/i.test(text);
+          const byteValues = text.match(/\d[\d\s.,]*\s*[KMGTPE](?:i?B|B)/gi) ?? [];
+          return hasRatio && byteValues.length >= 2;
+        },
+        null,
+        { timeout: 30_000 },
+      );
+      return true;
+    } catch {
+      return false;
+    }
+  }
   if (tracker.id !== 'tr4ker') return false;
   try {
     await page.waitForFunction(
@@ -585,6 +602,16 @@ export async function fetchWithBrowser(
     await waitForAnubis(page);
     await waitForAntiBotChallenge(page);
     await waitForLiveView(page);
+    if (tracker.id === 'torr9') {
+      await page.waitForFunction(
+        () => {
+          const text = document.body?.innerText ?? '';
+          return Boolean(document.querySelector('input[type="password"]')) || /RATIO\s*[\d.,]+/i.test(text);
+        },
+        null,
+        { timeout: 30_000 },
+      ).catch(() => {});
+    }
     await ensureLoggedIn(tracker, credentials, page, overrides);
     await page.goto(url, { waitUntil: 'commit', timeout: 45_000 });
     await page.waitForLoadState('domcontentloaded', { timeout: 30_000 }).catch(() => {});


### PR DESCRIPTION
## Résumé

- remplace les totaux incomplets de l'API Torr9 par les valeurs affichées sur l'accueil authentifié
- rétablit le login navigateur et attend l'hydratation complète de la SPA avant l'extraction
- extrait directement l'upload, le download et le ratio visibles à côté de leurs icônes

## Validation

- `npm ci`
- `npm run build`
- `npm run check:integration`
- `git diff --check`
