### PR TITLE
Ajuste les sélecteurs Torr9 au DOM réel

### DIFF
--- a/config/trackers/torr9.json
+++ b/config/trackers/torr9.json
@@ -22,9 +22,9 @@
     "mode": "browser",
     "responseType": "html",
     "fields": {
-      "uploadedBytes":   { "regex": "(?:lucide-upload|data-lucide=\\\"upload\\\"|aria-label=\\\"Upload\\\")[\\s\\S]{0,600}?(?<value>\\d[\\d\\s.,]*\\s*[KMGTPE](?:i?B|B))",   "transform": "bytes" },
-      "downloadedBytes": { "regex": "(?:lucide-download|data-lucide=\\\"download\\\"|aria-label=\\\"Download\\\")[\\s\\S]{0,600}?(?<value>\\d[\\d\\s.,]*\\s*[KMGTPE](?:i?B|B))", "transform": "bytes" },
-      "ratio":           { "regex": ">\\s*RATIO\\s*<[\\s\\S]{0,300}?>\\s*(?<value>\\d[\\d\\s.,]*)\\s*<",                                                    "transform": "number" }
+      "uploadedBytes":   { "regex": "title=\\\"Upload\\\"[\\s\\S]{0,600}?(?<value>\\d[\\d\\s.,]*\\s*[KMGTPE](?:i?B|B))",   "transform": "bytes" },
+      "downloadedBytes": { "regex": "title=\\\"Download\\\"[\\s\\S]{0,600}?(?<value>\\d[\\d\\s.,]*\\s*[KMGTPE](?:i?B|B))", "transform": "bytes" },
+      "ratio":           { "regex": "title=\\\"Ratio\\\"[\\s\\S]{0,300}?>\\s*Ratio\\s*<[\\s\\S]{0,300}?>\\s*(?<value>\\d[\\d\\s.,]*)\\s*<", "transform": "number" }
     }
   },
   "dashboard": { "byteUnit": "decimal" }

--- a/scripts/check-integration.mjs
+++ b/scripts/check-integration.mjs
@@ -121,18 +121,18 @@ if (!tr4kerUsesDisplayedTotals) {
 
 const torr9HomeFixture = `
   <div class="account-stats">
-    <svg class="lucide lucide-upload"></svg><span>1.54 TB</span>
-    <svg class="lucide lucide-download"></svg><span>19.85 GB</span>
-    <span>RATIO</span><strong>79.30</strong>
+    <div title="Upload"><svg></svg><span>12.34 TB</span></div>
+    <div title="Download"><svg></svg><span>56.78 GB</span></div>
+    <div title="Ratio"><span>Ratio</span><strong>90.12</strong></div>
   </div>`;
 const torr9Value = field => new RegExp(field.regex, 's').exec(torr9HomeFixture)?.groups?.value;
 const torr9UsesDisplayedHomeStats = (
   torr9.fetch?.url === '/'
   && torr9.fetch?.mode === 'browser'
   && torr9.fetch?.responseType === 'html'
-  && torr9Value(torr9.fetch.fields?.uploadedBytes) === '1.54 TB'
-  && torr9Value(torr9.fetch.fields?.downloadedBytes) === '19.85 GB'
-  && torr9Value(torr9.fetch.fields?.ratio) === '79.30'
+  && torr9Value(torr9.fetch.fields?.uploadedBytes) === '12.34 TB'
+  && torr9Value(torr9.fetch.fields?.downloadedBytes) === '56.78 GB'
+  && torr9Value(torr9.fetch.fields?.ratio) === '90.12'
   && !JSON.stringify(torr9.fetch).includes('api.torr9.net')
 );
 if (!torr9UsesDisplayedHomeStats) {


### PR DESCRIPTION
## Résumé

- aligne les sélecteurs Torr9 sur les attributs `title` réellement présents dans le DOM rendu
- valide l'extraction de l'upload, du download et du ratio directement contre le dump produit en production
- remplace les valeurs issues de la capture dans le garde-fou par des données synthétiques fictives

## Validation

- extraction sur le dump réel : upload `1.54 TB`, download `19.85 GB`, ratio `79.30`
- `npm ci`
- `npm run build`
- `npm run check:integration`
- `git diff --check`
