### PR TITLE
Ajoute le tracker DarkPeers

### DIFF
--- a/config/trackers/darkpeers.json
+++ b/config/trackers/darkpeers.json
@@ -1,0 +1,13 @@
+{
+  "id": "darkpeers",
+  "name": "DarkPeers",
+  "baseUrl": "https://darkpeers.org",
+  "enabled": true,
+  "engine": "unit3d",
+  "login": {
+    "cookieOnly": true
+  },
+  "fetch": {
+    "mode": "browser"
+  }
+}


### PR DESCRIPTION
## Résumé

- ajoute DarkPeers à la liste des trackers intégrés
- utilise le preset UNIT3D existant pour les champs de statistiques
- configure l'authentification par cookie et la lecture via le navigateur

## Contribution

Définition JSON fournie par **matt.usk**.

## Validation

- validation du preset UNIT3D et des champs hérités
- `npm ci`
- `npm run build`
- `npm run check:integration`
- `git diff --check`
