### PR TITLE
Corrige les faux diagnostics de connexion des trackers

### DIFF
--- a/config/trackers/lesrescapesdeygg.json
+++ b/config/trackers/lesrescapesdeygg.json
@@ -14,7 +14,6 @@
     },
     "failurePatterns": [
       "id=\"login-form\"",
-      "name=\"pass\"",
       "Connexion sur Les Rescapés de Ygg"
     ]
   },

--- a/scripts/check-integration.mjs
+++ b/scripts/check-integration.mjs
@@ -6,6 +6,8 @@ const htmlPath = path.join(root, 'public', 'index.html');
 const readmePath = path.join(root, 'README.md');
 const composePath = path.join(root, 'docker-compose.yml');
 const serverPath = path.join(root, 'src', 'server.ts');
+const fetcherPath = path.join(root, 'src', 'fetcher.ts');
+const browserFetcherPath = path.join(root, 'src', 'browserFetcher.ts');
 const redactedPath = path.join(root, 'config', 'trackers', 'redacted.json');
 const tr4kerPath = path.join(root, 'config', 'trackers', 'tr4ker.json');
 const torr9Path = path.join(root, 'config', 'trackers', 'torr9.json');
@@ -14,6 +16,8 @@ const html = fs.readFileSync(htmlPath, 'utf8');
 const readme = fs.readFileSync(readmePath, 'utf8');
 const compose = fs.readFileSync(composePath, 'utf8');
 const server = fs.readFileSync(serverPath, 'utf8');
+const fetcher = fs.readFileSync(fetcherPath, 'utf8');
+const browserFetcher = fs.readFileSync(browserFetcherPath, 'utf8');
 const redacted = JSON.parse(fs.readFileSync(redactedPath, 'utf8'));
 const tr4ker = JSON.parse(fs.readFileSync(tr4kerPath, 'utf8'));
 const torr9 = JSON.parse(fs.readFileSync(torr9Path, 'utf8'));
@@ -154,13 +158,25 @@ if (!torr9UsesDisplayedHomeStats) {
 const lesRescapesUsesBrowserLogin = (
   lesRescapes.login?.cookieOnly !== true
   && lesRescapes.login?.failurePatterns?.includes('id="login-form"')
+  && !lesRescapes.login?.failurePatterns?.includes('name="pass"')
   && lesRescapes.login?.body?.id === '{{username}}'
   && lesRescapes.login?.body?.pass === '{{password}}'
   && lesRescapes.login?.body?.remember_me === 'on'
   && lesRescapes.fetch?.url === '?action=my-tracker-activity'
+  && browserFetcher.includes("tracker.id === 'lesrescapesdeygg'")
+  && browserFetcher.includes("text.includes('Sessions tracker actives')")
 );
 if (!lesRescapesUsesBrowserLogin) {
   errors.push('Les Rescapes de Ygg must submit its browser login form when the session expires');
+}
+
+const preservesRateLimitErrors = (
+  fetcher.includes('Login temporairement limité — HTTP 429')
+  && fetcher.includes("error.message.includes('HTTP 429')")
+  && fetcher.includes("reason: 'curl-rate-limited'")
+);
+if (!preservesRateLimitErrors) {
+  errors.push('HTTP 429 login responses must stop fallback retries and keep their real error message');
 }
 
 const browserLoginTrackerIds = ['crazyspirits', 'lesrescapesdeygg', 'yggreborn'];

--- a/src/browserFetcher.ts
+++ b/src/browserFetcher.ts
@@ -209,6 +209,23 @@ async function waitForTurnstile(page: Page): Promise<void> {
  * une coquille "non connecte" avant hydratation (cas TR4KER).
  */
 async function waitForTrackerContent(tracker: TrackerConfig, page: Page): Promise<boolean> {
+  if (tracker.id === 'lesrescapesdeygg') {
+    try {
+      await page.waitForFunction(
+        () => {
+          const text = document.body?.innerText ?? '';
+          return text.includes('Upload total')
+            && /Ratio r[ée]el/i.test(text)
+            && text.includes('Sessions tracker actives');
+        },
+        null,
+        { timeout: 20_000 },
+      );
+      return true;
+    } catch {
+      return false;
+    }
+  }
   if (tracker.id === 'milkie') {
     try {
       await page.waitForFunction(

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -183,9 +183,22 @@ function friendlyError(err: unknown): string {
     message.includes('packet length too long') ||
     message.includes('EPROTO')
   ) {
-    return `${message} - erreur TLS/proxy probable : verifier le type du proxy configure (HTTP vs HTTPS vs SOCKS)`;
+    return `${message} - échec TLS sur le trajet proxy : la route est indisponible ou incompatible pour ce tracker (le type de proxy configuré n'est pas forcément en cause)`;
   }
   return message;
+}
+
+function apiErrorMessage(body: string): string {
+  const parsed = parseJsonRecord(body);
+  return typeof parsed?.message === 'string' ? parsed.message.trim() : '';
+}
+
+function loginHttpError(status: number, body: string): string {
+  const detail = apiErrorMessage(body);
+  const suffix = detail ? ` : ${detail}` : '';
+  return status === 429
+    ? `Login temporairement limité — HTTP 429${suffix}`
+    : `Login échoué — HTTP ${status}${suffix}`;
 }
 
 function missingExtractedFields(
@@ -716,6 +729,18 @@ async function doLogin(
     // succes, et jeton Bearer eventuel — flux entierement distinct du HTML.
     let resultJson = parseJsonRecord(loginRes.data);
 
+    // Un JSON d'erreur (notamment le rate-limit C411) ne contient naturellement
+    // pas successField. Rapporter d'abord le vrai statut et son message au lieu
+    // du trompeur « champ authenticated absent/false ».
+    if (loginRes.status >= 400) {
+      const dumpPath = writeLoginDebugDump(tracker, loginUrl, loginRes.data, {
+        status: loginRes.status,
+        reason: 'http-error',
+      });
+      const suffix = dumpPath ? ` - dump: ${dumpPath}` : '';
+      throw new Error(`${loginHttpError(loginRes.status, loginRes.data)}${suffix}`);
+    }
+
     if (cfg.mfaStep && resultJson?.[cfg.mfaStep.triggerField]) {
       if (!vars.otp) {
         const dumpPath = writeLoginDebugDump(tracker, loginUrl, loginRes.data, { reason: 'mfa-no-secret' });
@@ -1156,6 +1181,18 @@ export async function fetchTracker(
       if (!postRes) { console.log(`  [${tracker.name}] curl: POST login null`); return null; }
       console.log(`  [${tracker.name}] curl: POST status=${postRes.status} len=${postRes.body.length} 2fa=${isTwoFactorPage(postRes.body)} body=${postRes.body.slice(0,300)}`);
 
+      // Ne pas enchaîner immédiatement une seconde tentative Axios lorsque le
+      // tracker vient de demander de ralentir : cela prolonge le rate-limit.
+      if (postRes.status === 429) {
+        const dumpPath = writeLoginDebugDump(tracker, loginUrl, postRes.body, {
+          reason: 'curl-rate-limited',
+          status: postRes.status,
+          bodyFieldNames: Object.keys(bodyObj),
+        });
+        const suffix = dumpPath ? ` - dump: ${dumpPath}` : '';
+        throw new Error(`${loginHttpError(postRes.status, postRes.body)}${suffix}`);
+      }
+
       if (!isJson && !cfg.mfaStep && hasFailurePattern(postRes.body, cfg.failurePatterns)) {
         const dumpPath = writeLoginDebugDump(tracker, loginUrl, postRes.body, {
           reason: 'curl-login-failed',
@@ -1282,7 +1319,8 @@ export async function fetchTracker(
       } catch {
         return null;
       }
-    } catch {
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('HTTP 429')) throw error;
       return null;
     } finally {
       sess.dispose();


### PR DESCRIPTION
## Résumé

- reconnaît la page d'activité authentifiée des Rescapés de Ygg malgré le formulaire de mot de passe présent dans le menu
- conserve le vrai retour `HTTP 429` de C411 et évite une seconde tentative immédiate qui prolongerait la limitation
- remplace le conseil trompeur sur le type du proxy par un diagnostic TLS/proxy adapté à Nexum
- ajoute des garde-fous d'intégration pour ces deux régressions

## Validation

- `npm run build`
- `npm run check:integration`
- `npm audit --omit=dev --audit-level=high`
- `git diff --check`
- contrôle du dump réel `lesrescapesdeygg-browser-auth-last.html` : page d'activité présente, aucun `id=login-form`
- contrôle réseau Nexum via le proxy HTTP configuré : route expirée ; le même proxy déclaré à tort en HTTPS reproduit bien `wrong version number`