### PR TITLE
Corrige l’affichage du fuseau horaire

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
-    "check:integration": "node scripts/check-integration.mjs && node scripts/check-unread-messages.mjs && node scripts/check-extra-fetch.mjs && node scripts/check-flaresolverr.mjs && node scripts/check-cross-seed.mjs && node --experimental-sqlite scripts/check-retired-trackers.mjs",
+    "check:integration": "node scripts/check-integration.mjs && node scripts/check-unread-messages.mjs && node scripts/check-extra-fetch.mjs && node scripts/check-flaresolverr.mjs && node scripts/check-cross-seed.mjs && node --experimental-sqlite scripts/check-retired-trackers.mjs && node --experimental-sqlite scripts/check-timezone.mjs",
     "start": "node --experimental-sqlite dist/index.js",
     "start:browser": "node --experimental-sqlite dist/browserRuntime.js"
   },

--- a/public/index.html
+++ b/public/index.html
@@ -2572,6 +2572,17 @@
 </div>
 
 <script>
+  let dashboardTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+
+  function setDashboardTimeZone(value) {
+    if (!value || typeof value !== 'string') return;
+    try {
+      new Intl.DateTimeFormat('fr-FR', { timeZone: value }).format();
+      dashboardTimeZone = value;
+    } catch {
+      // Conserver le fuseau du navigateur si le serveur fournit une valeur invalide.
+    }
+  }
   // ─── Formatage ─────────────────────────────────────────────────────────────
 
   function formatBytes(bytes, byteUnit = 'binary') {
@@ -2653,6 +2664,7 @@
     return new Intl.DateTimeFormat('fr-FR', {
       dateStyle: 'short',
       timeStyle: 'short',
+      timeZone: dashboardTimeZone,
     }).format(new Date(iso));
   }
 
@@ -4979,7 +4991,7 @@
       <div id="beta-schedule-weekdays" class="beta-form-row" style="grid-template-columns:1fr">
         <div class="beta-field"><label>Jours</label><div style="display:flex;gap:8px;flex-wrap:wrap">${dayLabels.map((label, day) => `<label><input type="checkbox" data-beta-weekday="${day}" ${weekdays.has(day) ? 'checked' : ''}> ${label}</label>`).join('')}</div></div>
       </div>
-      <p class="beta-note">Prochaine exécution : ${schedule.nextRunAt ? escapeHtml(new Date(schedule.nextRunAt).toLocaleString('fr-FR')) : 'non planifiée'}${schedule.lastRunAt ? ` · Dernière : ${escapeHtml(new Date(schedule.lastRunAt).toLocaleString('fr-FR'))}` : ''}</p>
+      <p class="beta-note">Prochaine exécution : ${schedule.nextRunAt ? escapeHtml(formatDateTime(schedule.nextRunAt)) : 'non planifiée'}${schedule.lastRunAt ? ` · Dernière : ${escapeHtml(formatDateTime(schedule.lastRunAt))}` : ''}</p>
       <div style="margin:10px 0 6px; display:flex; gap:8px; flex-wrap:wrap">
         <button class="beta-icon-btn primary" onclick="saveBetaSettings()" type="button">Enregistrer</button>
       </div>
@@ -4990,7 +5002,7 @@
         ${trackerConfig.filter(tracker => tracker.enabled !== false).map(tracker => {
           const override = (betaSettings.scheduleOverrides || []).find(item => item.trackerId === tracker.id) || { mode: 'global', intervalHours: 24 };
           const value = override.mode === 'interval' ? String(override.intervalHours) : override.mode;
-          const next = override.nextRunAt ? ` · prochaine ${escapeHtml(new Date(override.nextRunAt).toLocaleString('fr-FR'))}` : '';
+          const next = override.nextRunAt ? ` · prochaine ${escapeHtml(formatDateTime(override.nextRunAt))}` : '';
           return `<div class="beta-form-row" data-beta-schedule-override="${escapeHtml(tracker.id)}" style="grid-template-columns:2fr 1fr">
             <div class="beta-field"><label>${escapeHtml(tracker.name)}</label><span class="beta-note">${value === 'global' ? 'Suit le calendrier global' : value === 'disabled' ? 'Login planifié désactivé' : `Toutes les ${value}h${next}`}</span></div>
             <div class="beta-field"><label>Fréquence</label><select data-field="scheduleMode"><option value="global" ${value === 'global' ? 'selected' : ''}>Global</option><option value="disabled" ${value === 'disabled' ? 'selected' : ''}>Désactivé</option>${[6,12,24,48,168,504].map(hours => `<option value="${hours}" ${value === String(hours) ? 'selected' : ''}>${hours < 168 ? `${hours}h` : `${hours / 24}j`}</option>`).join('')}</select></div>
@@ -6573,6 +6585,7 @@
     try {
       const r = await fetch('/api/config');
       const d = await r.json();
+      setDashboardTimeZone(d.timeZone);
       trackerConfig = d.trackers || [];
       trackerCount = d.trackers.filter(t => t.enabled).length;
       renderSchedulePanel(trackerConfig);

--- a/scripts/check-integration.mjs
+++ b/scripts/check-integration.mjs
@@ -54,6 +54,15 @@ if (!avistazPresetIsUsable) {
   errors.push('AvistaZ Network definitions must resolve their cookie-only login and site-specific overrides before configuration');
 }
 
+const honorsServerTimeZone = (
+  server.includes('timeZone: appTimeZone()')
+  && html.includes('setDashboardTimeZone(d.timeZone)')
+  && html.includes('timeZone: dashboardTimeZone')
+);
+if (!honorsServerTimeZone) {
+  errors.push('Displayed timestamps must honor the server TZ setting');
+}
+
 const retiresClosedNexumTracker = (
   !fs.existsSync(nexumPath)
   && readme.includes('Retrait de Nexum')

--- a/scripts/check-timezone.mjs
+++ b/scripts/check-timezone.mjs
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const root = process.cwd();
+const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'tracker-dashboard-timezone-'));
+let sqlite;
+
+try {
+  fs.mkdirSync(path.join(temp, 'config'), { recursive: true });
+  fs.mkdirSync(path.join(temp, 'default-trackers'), { recursive: true });
+  process.chdir(temp);
+
+  const db = await import(`${pathToFileURL(path.join(root, 'dist', 'db.js')).href}?timezone=${Date.now()}`);
+  sqlite = db.getDb();
+  db.ensureTrackerSchedules([{ id: 'fixture' }]);
+  sqlite.prepare(`
+    UPDATE tracker_schedule
+    SET last_run_at = '2026-07-03 04:20:00',
+        next_run_at = '2026-07-03T07:20:00.000Z'
+    WHERE tracker_id = 'fixture'
+  `).run();
+  db.saveStatSnapshots([{
+    id: 'fixture',
+    name: 'Fixture',
+    trackerUrl: 'https://fixture.invalid',
+    status: 'ok',
+    lastUpdated: '2026-07-03 04:20:00',
+    fields: {},
+  }]);
+
+  const schedule = db.getTrackerSchedule('fixture');
+  assert.equal(schedule.lastRunAt, '2026-07-03T04:20:00Z');
+  assert.equal(schedule.nextRunAt, '2026-07-03T07:20:00.000Z');
+  assert.equal(db.listStatSnapshots('fixture', 1)[0].capturedAt, '2026-07-03T04:20:00Z');
+
+  const paris = new Intl.DateTimeFormat('fr-FR', {
+    dateStyle: 'short',
+    timeStyle: 'short',
+    timeZone: 'Europe/Paris',
+  }).format(new Date(schedule.lastRunAt));
+  assert.match(paris, /03\/07\/2026 06:20/);
+
+  console.log('Timezone checks OK: SQLite UTC timestamps render at Europe/Paris local time.');
+} finally {
+  sqlite?.close();
+  process.chdir(root);
+  fs.rmSync(temp, { recursive: true, force: true });
+}

--- a/src/db.ts
+++ b/src/db.ts
@@ -59,6 +59,16 @@ export interface StatSnapshotSummary {
 
 let db: Database | null = null;
 
+// SQLite CURRENT_TIMESTAMP est en UTC mais renvoie "YYYY-MM-DD HH:MM:SS",
+// sans suffixe de fuseau. Les navigateurs l'interprètent alors comme une heure
+// locale. Normaliser ce format en ISO UTC avant de l'exposer à l'API.
+function dbTimestampToIso(value: unknown): string | null {
+  if (value === null || value === undefined || value === '') return null;
+  const raw = String(value).trim();
+  const sqliteUtc = /^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2}(?:\.\d+)?)$/.exec(raw);
+  return sqliteUtc ? `${sqliteUtc[1]}T${sqliteUtc[2]}Z` : raw;
+}
+
 export function getDb(): Database {
   if (!db) {
     fs.mkdirSync(CONFIG_DIR, { recursive: true });
@@ -515,7 +525,7 @@ export function listTrackerCredentialSummaries(): TrackerCredentialSummary[] {
       trackerId: String(row.tracker_id),
       username: String(row.username),
       hasPassword: Boolean(row.password),
-      updatedAt: row.updated_at ? String(row.updated_at) : null,
+      updatedAt: dbTimestampToIso(row.updated_at),
     }));
 }
 
@@ -604,8 +614,8 @@ export function listTrackerSchedules(): TrackerSchedule[] {
       trackerId: String(row.tracker_id),
       enabled: Boolean(row.enabled),
       intervalHours: Number(row.interval_hours),
-      nextRunAt: row.next_run_at ? String(row.next_run_at) : null,
-      lastRunAt: row.last_run_at ? String(row.last_run_at) : null,
+      nextRunAt: dbTimestampToIso(row.next_run_at),
+      lastRunAt: dbTimestampToIso(row.last_run_at),
     }));
 }
 
@@ -622,8 +632,8 @@ export function getTrackerSchedule(trackerId: string): TrackerSchedule | null {
     trackerId: String(row.tracker_id),
     enabled: Boolean(row.enabled),
     intervalHours: Number(row.interval_hours),
-    nextRunAt: row.next_run_at ? String(row.next_run_at) : null,
-    lastRunAt: row.last_run_at ? String(row.last_run_at) : null,
+    nextRunAt: dbTimestampToIso(row.next_run_at),
+    lastRunAt: dbTimestampToIso(row.last_run_at),
   };
 }
 
@@ -700,7 +710,7 @@ export function getLatestOkStatSnapshot(tracker: TrackerConfig): TrackerStats | 
       name: String(row.tracker_name || tracker.name),
       trackerUrl: tracker.baseUrl,
       status: 'ok',
-      lastUpdated: String(row.captured_at),
+      lastUpdated: dbTimestampToIso(row.captured_at) ?? String(row.captured_at),
       byteUnit: tracker.dashboard?.byteUnit ?? 'binary',
       fields,
     };
@@ -739,7 +749,7 @@ export function listStatSnapshots(trackerId: string | null, limit = 500): StatSn
           status: String(row.status),
           error: row.error === null || row.error === undefined ? null : String(row.error),
           fields: JSON.parse(String(row.fields_json)) as Record<string, string | number>,
-          capturedAt: String(row.captured_at),
+          capturedAt: dbTimestampToIso(row.captured_at) ?? String(row.captured_at),
         };
       } catch {
         return null;

--- a/src/server.ts
+++ b/src/server.ts
@@ -126,6 +126,19 @@ function startupBanner(port: number): string {
 
 let cachedStats: TrackerStats[] = [];
 let lastRefresh: string | null  = null;
+
+function appTimeZone(): string {
+  const configured = String(process.env.TZ || '').trim();
+  if (configured) {
+    try {
+      new Intl.DateTimeFormat('fr-FR', { timeZone: configured }).format();
+      return configured;
+    } catch {
+      console.warn(`[Fuseau horaire] TZ invalide: ${configured}`);
+    }
+  }
+  return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+}
 let isRefreshing                = false;
 const pendingScheduledRuns = new Set<string>();
 
@@ -2682,7 +2695,7 @@ export async function start(): Promise<void> {
       ratioless: Boolean(ratioless),
       baseId,
     }));
-    res.json({ trackers: safe });
+    res.json({ trackers: safe, timeZone: appTimeZone() });
   });
 
   app.get('/api/beta/cross-seed/summary', (_req, res) => {


### PR DESCRIPTION
## Résumé

- expose le fuseau configuré par `TZ` au frontend et l'utilise explicitement pour l'affichage des dates
- normalise les timestamps UTC produits par SQLite (`YYYY-MM-DD HH:MM:SS`) en ISO avec suffixe `Z`
- applique le même formatage aux heures de planification et à l'historique
- ajoute un test reproductible couvrant précisément la conversion `04:20 UTC` vers `06:20 Europe/Paris`

## Diagnostic

Le conteneur et Node utilisaient déjà correctement `Europe/Paris`. Le décalage venait de timestamps SQLite sans information de fuseau et du frontend qui dépendait du fuseau de l'appareil client.

## Validation

- `npm run build`
- `npm run check:integration`
- `npm audit --omit=dev --audit-level=high`
- `git diff --check`
- rebase sur `main` après l'intégration de la famille AvistaZ Network