### PR TITLE
feat(trackers): ajout de KaraGarga

### DIFF
--- a/config/trackers/karagarga.json
+++ b/config/trackers/karagarga.json
@@ -1,0 +1,45 @@
+{
+  "id": "karagarga",
+  "name": "KaraGarga",
+  "baseUrl": "https://karagarga.in",
+  "enabled": false,
+  "login": {
+    "url": "login.php",
+    "postUrl": "takelogin.php",
+    "method": "POST",
+    "contentType": "form",
+    "body": {
+      "username": "{{username}}",
+      "password": "{{password}}"
+    },
+    "failurePatterns": [
+      "type=\"password\"",
+      "name=\"password\""
+    ]
+  },
+  "fetch": {
+    "url": "/",
+    "responseType": "html",
+    "fields": {
+      "uploadedBytes": {
+        "regex": "Ratio:[\\s\\S]{0,120}?&#8593;<font[^>]*>\\s*(?<value>[\\d.,]+\\s*[KMGTPE]i?B)\\s*</font>",
+        "transform": "bytes"
+      },
+      "downloadedBytes": {
+        "regex": "Ratio:[\\s\\S]{0,160}?w/\\s*(?<value>[\\d.,]+\\s*[KMGTPE]i?B)",
+        "transform": "bytes"
+      },
+      "ratio": {
+        "regex": "Ratio:\\s*<font[^>]*>\\s*(?<value>[\\d.,]+)\\s*</font>",
+        "transform": "number"
+      },
+      "memberClass": {
+        "regex": "<font color=blue>\\s*(?<value>[^<]+?)\\s*</font>",
+        "transform": "string"
+      }
+    }
+  },
+  "dashboard": {
+    "byteUnit": "decimal"
+  }
+}


### PR DESCRIPTION
## Ajout de KaraGarga

Skin unique (form classique `login.php` → `takelogin.php`, sans CSRF ni
champ caché — confirmé sur le vrai HTML de la page de login). Pas d'`engine`,
tracker autonome.

### Fetch (stats)
Regex reprises et adaptées depuis `tracker-autovisit` (converties en groupe
nommé `(?<value>...)`) : `uploadedBytes`, `downloadedBytes`, `ratio`,
`memberClass`. **Non vérifiées contre le vrai HTML d'une page de profil**
(pas de compte KaraGarga disponible pour confirmer) — à valider avant
activation.