### PR TITLE
feat(webui): bouton Fiche sur les cartes et compteurs en bas de menu

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -156,6 +156,19 @@
     .nav-cardsize #cardsize-value { font-variant-numeric: tabular-nums; min-width: 36px; text-align: right; }
     /* Bas de barre : horodatage + bascule de thème */
     .sidebar-updated { padding: 8px 16px 2px; font-size: 11px; color: var(--muted); text-align: center; }
+    /* Compteurs de trackers en bas de menu : icône + nombre, tooltip explicatif. */
+    .sidebar-tracker-stats {
+      display: flex; justify-content: center; align-items: center; gap: 12px;
+      padding: 4px 16px 2px; font-size: 12px; color: var(--muted);
+    }
+    .sidebar-tracker-stats:empty { display: none; }
+    .sidebar-stat { display: inline-flex; align-items: center; gap: 4px; cursor: help; }
+    .sidebar-stat svg { width: 13px; height: 13px; flex: none; }
+    .sidebar-stat b { color: var(--text); font-weight: 600; }
+    .sidebar-stat-active { color: var(--green); }
+    .sidebar-stat-creds { color: var(--muted); }
+    .sidebar-stat-cookie { color: var(--yellow); }
+    .sidebar-stat-browser { color: var(--blue); }
     .theme-switch {
       display: flex;
       gap: 4px;
@@ -1917,6 +1930,7 @@
   <span class="nav-spacer"></span>
   <button class="sidebar-run-btn" id="sidebar-run-btn" onclick="refresh()">▶ Synchroniser les sites</button>
   <div class="sidebar-updated" id="last-updated">—</div>
+  <div class="sidebar-tracker-stats" id="sidebar-tracker-stats"></div>
   <div class="theme-switch" role="group" aria-label="Thème">
     <button type="button" data-theme-mode="light" onclick="setThemeMode('light')" title="Clair" aria-label="Clair">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>
@@ -2976,6 +2990,26 @@
   // Icônes de prérequis (style Lucide, trait fin, couleur héritée).
   const REQ_ICON_COOKIE = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 2a10 10 0 1 0 10 10 4 4 0 0 1-5-5 4 4 0 0 1-5-5"/><path d="M8.5 8.5v.01"/><path d="M16 15.5v.01"/><path d="M12 12v.01"/><path d="M11 17v.01"/><path d="M7 14v.01"/></svg>';
   const REQ_ICON_BROWSER = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="M10 4v4"/><path d="M2 8h20"/><path d="M6 4v4"/></svg>';
+  const STAT_ICON_ACTIVE = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="m9 12 2 2 4-4"/></svg>';
+  const STAT_ICON_CREDS = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2.586 17.414A2 2 0 0 0 2 18.828V21a1 1 0 0 0 1 1h3a1 1 0 0 0 1-1v-1a1 1 0 0 1 1-1h1a1 1 0 0 0 1-1v-1a1 1 0 0 1 1-1h.172a2 2 0 0 0 1.414-.586l.814-.814a6.5 6.5 0 1 0-4-4z"/><circle cx="16.5" cy="7.5" r=".5" fill="currentColor"/></svg>';
+
+  // Compteurs du bas de menu : trackers activés, répartis par mode de connexion
+  // (identifiants / cookie collé) + dépendance au runtime navigateur.
+  function renderSidebarTrackerStats() {
+    const el = document.getElementById('sidebar-tracker-stats');
+    if (!el) return;
+    const active = cachedTrackerDefinitions.filter(def => def.enabled);
+    if (!active.length) { el.innerHTML = ''; return; }
+    const cookieCount = active.filter(def => def.requiresCookie).length;
+    const browserCount = active.filter(def => def.requiresBrowser).length;
+    const item = (cls, icon, count, title) => `<span class="sidebar-stat ${cls}" title="${title}">${icon}<b>${count}</b></span>`;
+    el.innerHTML = [
+      item('sidebar-stat-active', STAT_ICON_ACTIVE, active.length, 'Trackers activés'),
+      item('sidebar-stat-creds', STAT_ICON_CREDS, active.length - cookieCount, 'Connexion par identifiants (utilisateur + mot de passe)'),
+      item('sidebar-stat-cookie', REQ_ICON_COOKIE, cookieCount, 'Connexion par cookie de session collé'),
+      item('sidebar-stat-browser', REQ_ICON_BROWSER, browserCount, 'Dépendent du runtime navigateur (tracker-dashboard-browser)'),
+    ].join('');
+  }
 
   // Disponibilité du runtime navigateur externe : null = inconnue, sinon booléen.
   // Alimenté par loadBrowserRuntimeStatus() ; colore la pastille « navigateur ».
@@ -3038,6 +3072,15 @@
     return `
       <button class="card-refresh card-edit-btn" data-tracker="${escapeHtml(stat.id)}" onclick="openTrackerEdit(this.dataset.tracker)" title="Éditer ce tracker" aria-label="Éditer ce tracker">
         ✎
+      </button>`;
+  }
+
+  // Ouvre la fiche détaillée du tracker depuis une carte (équivalent du bouton
+  // « Fiche » de la vue lignes).
+  function cardFicheButton(stat) {
+    return `
+      <button class="card-refresh card-fiche-btn" data-tracker="${escapeHtml(stat.id)}" onclick="openTrackerFiche(this.dataset.tracker)" title="Ouvrir la fiche du tracker" aria-label="Ouvrir la fiche du tracker">
+        Fiche
       </button>`;
   }
 
@@ -5977,6 +6020,7 @@
           <div class="card-header">
             ${trackerName(stat)}
             <div class="card-header-actions">
+              ${cardFicheButton(stat)}
               ${editTrackerButton(stat)}
               ${cardRefreshButton(stat)}
             </div>
@@ -6045,6 +6089,7 @@
         <div class="card-header">
           ${trackerName(stat)}
           <div class="card-header-actions">
+            ${cardFicheButton(stat)}
             ${editTrackerButton(stat)}
             ${cardRefreshButton(stat)}
           </div>
@@ -6269,6 +6314,7 @@
       }
       renderTrackerConfigNav();
       renderSelectedTrackerCard();
+      renderSidebarTrackerStats();
     } catch(e) {
       const list = document.getElementById('tracker-definitions-list');
       if (list) list.innerHTML = 'Impossible de lire /config/trackers.';


### PR DESCRIPTION
## Objectif

Deux manques d'ergonomie : la vue Cartes n'offrait aucun lien vers la fiche
détaillée d'un tracker (contrairement à la vue lignes), et aucun résumé global
n'était visible en un coup d'œil.

## Changements

- **Vue Cartes** : chaque carte (normale et en erreur) gagne un bouton « Fiche »
  dans l'entête, à côté des boutons d'édition et de rafraîchissement — même
  comportement que le bouton « Fiche » de la vue lignes.
- **Bas du menu latéral**, sous « Mis à jour » : rangée de compteurs, icône +
  nombre, avec tooltip explicatif :
  - trackers activés (coche) ;
  - connexion par identifiants (clé) ;
  - connexion par cookie de session collé (cookie) ;
  - dépendance au runtime navigateur (fenêtre).
  La rangée reste masquée tant que les définitions ne sont pas chargées, et se
  met à jour à chaque activation/retrait de tracker.