### PR TITLE
Ajoute des templates Unraid en bêta

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,10 @@ Avec le type **SSH**, le dashboard ouvre un tunnel SSH (SOCKS5 local adossé au 
 
 ## Runtime navigateur
 
+### Unraid — templates bêta
+
+Des templates Unraid sont disponibles pour installer séparément l'application, le runtime navigateur et FlareSolverr sans Docker Compose. Consultez le [guide Unraid](unraid/README.md). Nous recherchons activement des retours avant une éventuelle publication dans Community Applications.
+
 Le navigateur (Playwright/Chromium/CloakBrowser) est externalisé dans l'image `ghcr.io/tracker-dashboard/tracker-dashboard-browser:latest`. L'image principale reste allégée.
 
 Si vous gérez Tracker Dashboard avec Compose, ajoutez une petite stack parallèle pour le runtime navigateur :

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
-    "check:integration": "node scripts/check-integration.mjs && node scripts/check-unread-messages.mjs && node scripts/check-extra-fetch.mjs && node scripts/check-flaresolverr.mjs && node scripts/check-cross-seed.mjs && node --experimental-sqlite scripts/check-retired-trackers.mjs && node --experimental-sqlite scripts/check-timezone.mjs",
+    "check:integration": "node scripts/check-integration.mjs && node scripts/check-unread-messages.mjs && node scripts/check-extra-fetch.mjs && node scripts/check-flaresolverr.mjs && node scripts/check-cross-seed.mjs && node --experimental-sqlite scripts/check-retired-trackers.mjs && node --experimental-sqlite scripts/check-timezone.mjs && node scripts/check-unraid-templates.mjs",
     "start": "node --experimental-sqlite dist/index.js",
     "start:browser": "node --experimental-sqlite dist/browserRuntime.js"
   },

--- a/scripts/check-unraid-templates.mjs
+++ b/scripts/check-unraid-templates.mjs
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { load } from 'cheerio';
+
+const root = process.cwd();
+const unraidDir = path.join(root, 'unraid');
+const templateNames = [
+  'tracker-dashboard',
+  'tracker-dashboard-browser',
+  'tracker-dashboard-flaresolverr',
+];
+
+const parsed = new Map();
+for (const name of templateNames) {
+  const file = path.join(unraidDir, `${name}.xml`);
+  assert.equal(fs.existsSync(file), true, `Template Unraid manquant : ${name}`);
+  const xml = fs.readFileSync(file, 'utf8');
+  const $ = load(xml, { xmlMode: true });
+  assert.equal($('Container').attr('version'), '2');
+  assert.equal($('Container > Name').text(), name);
+  assert.match($('Container > Repository').text(), /^ghcr\.io\//);
+  assert.match($('Container > TemplateURL').text(), new RegExp(`/unraid/${name}\\.xml$`));
+  assert.equal($('Container > Privileged').text(), 'false');
+  parsed.set(name, $);
+}
+
+const main = parsed.get('tracker-dashboard');
+assert.equal(main('Container > Network').text(), 'bridge');
+assert.equal(main('Config[Type="Port"][Target="3000"]').text(), '4832');
+assert.equal(main('Config[Type="Path"][Target="/app/config"]').text(), '/mnt/user/appdata/tracker-dashboard');
+
+for (const name of ['tracker-dashboard-browser', 'tracker-dashboard-flaresolverr']) {
+  const $ = parsed.get(name);
+  assert.equal($('Container > Network').text(), 'container:tracker-dashboard');
+  assert.equal($('Config[Type="Port"]').length, 0, `${name} ne doit exposer aucun port`);
+}
+
+const browser = parsed.get('tracker-dashboard-browser');
+assert.equal(browser('Config[Type="Path"][Target="/app/config"]').text(), '/mnt/user/appdata/tracker-dashboard');
+
+const flare = parsed.get('tracker-dashboard-flaresolverr');
+assert.equal(flare('Config[Type="Variable"][Target="HOST"]').text(), '127.0.0.1');
+
+const guide = fs.readFileSync(path.join(unraidDir, 'README.md'), 'utf8');
+const installer = fs.readFileSync(path.join(unraidDir, 'install-templates.sh'), 'utf8');
+assert.match(guide, /phase bêta/i);
+assert.match(guide, /Retours recherchés/);
+assert.match(guide, /N'incluez jamais d'identifiants/);
+for (const name of templateNames) assert.match(installer, new RegExp(name));
+
+console.log('Unraid template checks OK: three DockerMan templates, private sidecars, installer and feedback guide.');

--- a/unraid/README.md
+++ b/unraid/README.md
@@ -1,0 +1,68 @@
+# Templates Unraid — bêta
+
+Ce dossier fournit trois templates DockerMan pour installer Tracker Dashboard sur Unraid sans Docker Compose :
+
+1. `tracker-dashboard` — application et WebUI ;
+2. `tracker-dashboard-browser` — runtime Playwright/Chromium/CloakBrowser requis par les trackers en mode navigateur ;
+3. `tracker-dashboard-flaresolverr` — repli anti-bot facultatif.
+
+> [!IMPORTANT]
+> Ces templates sont en phase bêta. Nous recherchons des retours d'utilisateurs Unraid avant de proposer une publication dans Community Applications.
+
+## Installation
+
+Depuis le terminal Unraid, téléchargez puis examinez le script :
+
+```bash
+curl -fsSL \
+  https://raw.githubusercontent.com/Tracker-Dashboard/tracker-dashboard/main/unraid/install-templates.sh \
+  -o /tmp/install-tracker-dashboard-templates.sh
+cat /tmp/install-tracker-dashboard-templates.sh
+sh /tmp/install-tracker-dashboard-templates.sh
+```
+
+Dans **Docker → Add Container**, sélectionnez et appliquez les templates dans cet ordre :
+
+1. `tracker-dashboard` ;
+2. `tracker-dashboard-browser` ;
+3. `tracker-dashboard-flaresolverr`.
+
+Les deux sidecars utilisent `container:tracker-dashboard` : ils partagent le réseau du conteneur principal. Les ports internes `3001` et `8191` ne sont donc pas exposés sur le réseau local. Le runtime navigateur partage également le même dossier appdata `/app/config`.
+
+## Ordre de démarrage
+
+Dans l'onglet **Docker** :
+
+1. déverrouillez la liste avec le cadenas ;
+2. placez les conteneurs dans l'ordre `tracker-dashboard`, `tracker-dashboard-browser`, `tracker-dashboard-flaresolverr` ;
+3. activez **AutoStart** pour les trois ;
+4. en vue avancée, ajoutez si nécessaire une attente de quelques secondes après `tracker-dashboard`.
+
+Unraid démarre les conteneurs AutoStart dans l'ordre affiché et permet d'ajouter un délai entre eux : [documentation Unraid](https://docs.unraid.net/fr/unraid-os/using-unraid-to/run-docker-containers/managing-and-customizing-containers/).
+
+Après une recréation ou une mise à jour du conteneur principal, recréez les deux sidecars s'ils ne rejoignent plus son espace réseau.
+
+## Vérification
+
+Depuis le terminal Unraid :
+
+```bash
+docker ps --filter name=tracker-dashboard
+docker exec tracker-dashboard curl -fsS http://127.0.0.1:3001/health
+docker exec tracker-dashboard curl -fsS http://127.0.0.1:8191/health
+```
+
+Le runtime navigateur doit répondre `{"ok":true}`. FlareSolverr doit renvoyer une réponse HTTP valide.
+
+## Retours recherchés
+
+Merci d'ouvrir un [retour Unraid](https://github.com/Tracker-Dashboard/tracker-dashboard/issues/new?title=%5BUnraid%5D%20Retour%20sur%20les%20templates) en indiquant :
+
+- la version d'Unraid ;
+- l'architecture et le matériel ;
+- si les trois templates s'installent sans modification ;
+- si l'ordre AutoStart fonctionne après un redémarrage de l'array ;
+- le résultat des commandes de vérification ;
+- toute correction nécessaire dans les chemins, le réseau ou les libellés.
+
+N'incluez jamais d'identifiants de trackers, cookies, secrets TOTP ou tokens dans le retour.

--- a/unraid/install-templates.sh
+++ b/unraid/install-templates.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -eu
+
+base_url="https://raw.githubusercontent.com/Tracker-Dashboard/tracker-dashboard/main/unraid"
+destination="/boot/config/plugins/dockerMan/templates-user"
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo "Ce script doit être exécuté en root depuis le terminal Unraid." >&2
+  exit 1
+fi
+
+mkdir -p "$destination"
+
+for name in tracker-dashboard tracker-dashboard-browser tracker-dashboard-flaresolverr; do
+  target="$destination/my-$name.xml"
+  curl -fsSL "$base_url/$name.xml" -o "$target"
+  echo "Template installé : $target"
+done
+
+echo
+echo "Ouvrez Docker > Add Container, puis installez les trois templates dans cet ordre :"
+echo "1. tracker-dashboard"
+echo "2. tracker-dashboard-browser"
+echo "3. tracker-dashboard-flaresolverr"

--- a/unraid/tracker-dashboard-browser.xml
+++ b/unraid/tracker-dashboard-browser.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Container version="2">
+  <Name>tracker-dashboard-browser</Name>
+  <Repository>ghcr.io/tracker-dashboard/tracker-dashboard-browser:latest</Repository>
+  <Registry>https://github.com/orgs/Tracker-Dashboard/packages/container/package/tracker-dashboard-browser</Registry>
+  <Network>container:tracker-dashboard</Network>
+  <Shell>sh</Shell>
+  <Privileged>false</Privileged>
+  <Support>https://github.com/Tracker-Dashboard/tracker-dashboard/issues</Support>
+  <Project>https://github.com/Tracker-Dashboard/tracker-dashboard</Project>
+  <Overview>Runtime Playwright, Chromium et CloakBrowser de Tracker Dashboard. Le conteneur tracker-dashboard doit être installé et démarré avant celui-ci. Aucun port ne doit être exposé.</Overview>
+  <Category>Tools:</Category>
+  <WebUI/>
+  <TemplateURL>https://raw.githubusercontent.com/Tracker-Dashboard/tracker-dashboard/main/unraid/tracker-dashboard-browser.xml</TemplateURL>
+  <Icon>https://raw.githubusercontent.com/Tracker-Dashboard/tracker-dashboard/main/public/logo.png</Icon>
+  <ExtraParams>--restart=unless-stopped</ExtraParams>
+  <PostArgs/>
+  <Config Name="Appdata partagé" Target="/app/config" Default="/mnt/user/appdata/tracker-dashboard" Mode="rw" Description="Doit être strictement identique au chemin Appdata du conteneur tracker-dashboard." Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/tracker-dashboard</Config>
+  <Config Name="Fuseau horaire" Target="TZ" Default="Europe/Paris" Mode="" Description="Fuseau IANA utilisé par le runtime." Type="Variable" Display="always" Required="true" Mask="false">Europe/Paris</Config>
+</Container>

--- a/unraid/tracker-dashboard-flaresolverr.xml
+++ b/unraid/tracker-dashboard-flaresolverr.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Container version="2">
+  <Name>tracker-dashboard-flaresolverr</Name>
+  <Repository>ghcr.io/flaresolverr/flaresolverr:latest</Repository>
+  <Registry>https://github.com/orgs/FlareSolverr/packages/container/package/flaresolverr</Registry>
+  <Network>container:tracker-dashboard</Network>
+  <Shell>sh</Shell>
+  <Privileged>false</Privileged>
+  <Support>https://github.com/Tracker-Dashboard/tracker-dashboard/issues</Support>
+  <Project>https://github.com/FlareSolverr/FlareSolverr</Project>
+  <Overview>Sidecar FlareSolverr facultatif pour Tracker Dashboard. Il partage le réseau du conteneur principal afin de rester accessible uniquement sur 127.0.0.1:8191.</Overview>
+  <Category>Tools:</Category>
+  <WebUI/>
+  <TemplateURL>https://raw.githubusercontent.com/Tracker-Dashboard/tracker-dashboard/main/unraid/tracker-dashboard-flaresolverr.xml</TemplateURL>
+  <Icon>https://raw.githubusercontent.com/Tracker-Dashboard/tracker-dashboard/main/public/logo.png</Icon>
+  <ExtraParams>--restart=unless-stopped</ExtraParams>
+  <PostArgs/>
+  <Config Name="Adresse d'écoute" Target="HOST" Default="127.0.0.1" Mode="" Description="Conserver 127.0.0.1 : FlareSolverr partage le réseau de Tracker Dashboard." Type="Variable" Display="always-hide" Required="true" Mask="false">127.0.0.1</Config>
+  <Config Name="Niveau de journalisation" Target="LOG_LEVEL" Default="warning" Mode="" Description="Niveau de logs FlareSolverr." Type="Variable" Display="advanced" Required="true" Mask="false">warning</Config>
+  <Config Name="Fuseau horaire" Target="TZ" Default="Europe/Paris" Mode="" Description="Fuseau IANA utilisé par FlareSolverr." Type="Variable" Display="always" Required="true" Mask="false">Europe/Paris</Config>
+</Container>

--- a/unraid/tracker-dashboard.xml
+++ b/unraid/tracker-dashboard.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Container version="2">
+  <Name>tracker-dashboard</Name>
+  <Repository>ghcr.io/tracker-dashboard/tracker-dashboard:latest</Repository>
+  <Registry>https://github.com/orgs/Tracker-Dashboard/packages/container/package/tracker-dashboard</Registry>
+  <Network>bridge</Network>
+  <Shell>sh</Shell>
+  <Privileged>false</Privileged>
+  <Support>https://github.com/Tracker-Dashboard/tracker-dashboard/issues</Support>
+  <Project>https://github.com/Tracker-Dashboard/tracker-dashboard</Project>
+  <Overview>WebUI de suivi des statistiques de trackers BitTorrent. Installez ensuite les templates tracker-dashboard-browser et tracker-dashboard-flaresolverr pour activer toutes les fonctions.</Overview>
+  <Category>Tools:</Category>
+  <WebUI>http://[IP]:[PORT:3000]</WebUI>
+  <TemplateURL>https://raw.githubusercontent.com/Tracker-Dashboard/tracker-dashboard/main/unraid/tracker-dashboard.xml</TemplateURL>
+  <Icon>https://raw.githubusercontent.com/Tracker-Dashboard/tracker-dashboard/main/public/logo.png</Icon>
+  <ExtraParams>--restart=unless-stopped</ExtraParams>
+  <PostArgs/>
+  <Config Name="WebUI" Target="3000" Default="4832" Mode="tcp" Description="Port de la WebUI Tracker Dashboard." Type="Port" Display="always" Required="true" Mask="false">4832</Config>
+  <Config Name="Appdata" Target="/app/config" Default="/mnt/user/appdata/tracker-dashboard" Mode="rw" Description="Configuration, base SQLite, profils navigateur et fichiers de diagnostic." Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/tracker-dashboard</Config>
+  <Config Name="Fuseau horaire" Target="TZ" Default="Europe/Paris" Mode="" Description="Fuseau IANA utilisé par l'application." Type="Variable" Display="always" Required="true" Mask="false">Europe/Paris</Config>
+  <Config Name="Token Prometheus" Target="METRICS_TOKEN" Default="" Mode="" Description="Token facultatif protégeant /metrics. Laissez vide pour désactiver l'export." Type="Variable" Display="advanced" Required="false" Mask="true"/>
+</Container>


### PR DESCRIPTION
## Résumé

- ajoute trois templates DockerMan pour installer Tracker Dashboard, le runtime navigateur et FlareSolverr sous Unraid
- conserve les sidecars sur le réseau privé du conteneur principal, sans exposer les ports `3001` et `8191`
- fournit un installateur de templates et un guide dédié avec l'ordre AutoStart, les contrôles de santé et les précautions de mise à jour
- ajoute un contrôle d'intégration dédié aux XML, aux chemins appdata, au réseau et à la documentation

## Validation

- validation XML des trois templates
- `npm run build`
- `npm run check:integration`
- `npm audit --omit=dev --audit-level=high`
- `git diff --check`