### PR TITLE
Afficher les dates et seedtime des torrents

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2700,6 +2700,18 @@
     }).format(new Date(iso));
   }
 
+  function formatDurationSeconds(value) {
+    const seconds = Number(value);
+    if (!Number.isFinite(seconds) || seconds < 0) return '-';
+    const days = Math.floor(seconds / 86400);
+    const hours = Math.floor((seconds % 86400) / 3600);
+    const minutes = Math.floor((seconds % 3600) / 60);
+    if (days > 0) return `${days} j ${hours} h`;
+    if (hours > 0) return `${hours} h ${minutes} min`;
+    if (minutes > 0) return `${minutes} min`;
+    return `${Math.floor(seconds)} s`;
+  }
+
   // ─── Rendu des cartes ──────────────────────────────────────────────────────
 
   function statCell(label, value, unit, colorClass) {
@@ -4144,6 +4156,8 @@
   function betaTorrentSortValue(torrent, key) {
     switch (key) {
       case 'state': return torrentStateLabel(torrent.state).toLowerCase();
+      case 'added': return Date.parse(torrent.addedAt || '') || 0;
+      case 'seedtime': return toNum(torrent.seedTimeSeconds);
       case 'size': return toNum(torrent.sizeBytes);
       case 'progress': return toNum(torrent.progress);
       case 'uploaded': return toNum(torrent.uploadedBytes);
@@ -4402,19 +4416,21 @@
       <div style="margin-top:12px">
         <h3>Torrents liés dans les clients BitTorrent</h3>
         <table class="beta-mini-table">
-          <thead><tr><th>Client</th><th>Torrent</th>${betaTorrentTh('state', 'État')}${betaTorrentTh('size', 'Taille')}${betaTorrentTh('progress', 'Progression')}${betaTorrentTh('uploaded', 'UP')}${betaTorrentTh('downloaded', 'DL')}${betaTorrentTh('ratio', 'Ratio')}</tr></thead>
+          <thead><tr><th>Client</th><th>Torrent</th>${betaTorrentTh('state', 'État')}${betaTorrentTh('added', 'Ajouté le')}${betaTorrentTh('seedtime', 'Seedtime')}${betaTorrentTh('size', 'Taille')}${betaTorrentTh('progress', 'Progression')}${betaTorrentTh('uploaded', 'UP')}${betaTorrentTh('downloaded', 'DL')}${betaTorrentTh('ratio', 'Ratio')}</tr></thead>
           <tbody>${sortedTorrents.map(torrent => `
             <tr>
               <td>${torrent.clientBaseUrl ? `<a href="${escapeHtml(torrent.clientBaseUrl)}" target="_blank" rel="noreferrer noopener" title="Ouvrir ${escapeHtml(torrent.clientLabel)} dans un nouvel onglet">${escapeHtml(torrent.clientLabel)}</a>` : escapeHtml(torrent.clientLabel)}</td>
               <td title="${escapeHtml(torrent.hash)}">${escapeHtml(torrent.name || torrent.hash || '-')}${crossSeedMarks(torrent.crossSeedInstanceIds, { linked: true })}</td>
               <td>${escapeHtml(torrentStateLabel(torrent.state))}</td>
+              <td>${torrent.addedAt ? formatDateTime(torrent.addedAt) : '-'}</td>
+              <td>${formatDurationSeconds(torrent.seedTimeSeconds)}</td>
               <td>${bytesText(torrent.sizeBytes)}</td>
               <td>${Math.round((Number(torrent.progress) || 0) * 100)}%</td>
               <td>${bytesText(torrent.uploadedBytes)}</td>
               <td>${bytesText(torrent.downloadedBytes)}</td>
               <td>${torrent.ratio === null ? '-' : formatRatio(torrent.ratio)}</td>
             </tr>
-          `).join('') || '<tr><td colspan="8" class="cell-muted">Aucun torrent lié. Vérifier les associations BitTorrent.</td></tr>'}</tbody>
+          `).join('') || '<tr><td colspan="10" class="cell-muted">Aucun torrent lié. Vérifier les associations BitTorrent.</td></tr>'}</tbody>
         </table>
       </div>
       ${suggestedTorrents.length ? `

--- a/src/server.ts
+++ b/src/server.ts
@@ -297,6 +297,8 @@ interface QbitTrackerAggregate {
     uploadedBytes: number;
     downloadedBytes: number;
     ratio: number | null;
+    addedAt: string | null;
+    seedTimeSeconds: number | null;
     category: string;
     tags: string[];
     crossSeedInstanceIds: string[];
@@ -2108,6 +2110,17 @@ function cleanClientBaseUrl(value: string): string {
   }
 }
 
+function unixSecondsToIso(value: unknown): string | null {
+  const seconds = Number(value);
+  if (!Number.isFinite(seconds) || seconds <= 0) return null;
+  return new Date(seconds * 1000).toISOString();
+}
+
+function finiteSeconds(value: unknown): number | null {
+  const seconds = Number(value);
+  return Number.isFinite(seconds) && seconds >= 0 ? seconds : null;
+}
+
 function qbitHttpError(endpoint: string, status: number, data: unknown, authState: 'none' | 'attempted' | 'authenticated'): Error {
   const preview = responsePreview(data);
   const authHint = authState === 'authenticated'
@@ -2285,6 +2298,8 @@ async function fetchQbitClient(client: BetaQbitClient): Promise<QbitTrackerAggre
       uploadedBytes: Number.isFinite(up) ? up : 0,
       downloadedBytes: Number.isFinite(down) ? down : 0,
       ratio: Number.isFinite(Number(torrent.ratio)) ? Number(torrent.ratio) : null,
+      addedAt: unixSecondsToIso(torrent.added_on),
+      seedTimeSeconds: finiteSeconds(torrent.seeding_time),
       category,
       tags,
       crossSeedInstanceIds: detectCrossSeedInstanceIds(crossSeedInstances, client.id, category, tags),
@@ -2344,7 +2359,7 @@ async function fetchRutorrentClient(client: BetaQbitClient): Promise<QbitTracker
   const crossSeedInstances = loadBetaSettings().crossSeedInstances;
   betaLog(`${betaClientLogName(client)}: scan ruTorrent/rTorrent sur ${baseUrl}`);
   await rtorrentRpc(client, 'download_list', ['main']);
-  const xml = await rtorrentRpc(client, 'd.multicall2', [
+  const baseFields = [
     '',
     'main',
     'd.hash=',
@@ -2356,14 +2371,27 @@ async function fetchRutorrentClient(client: BetaQbitClient): Promise<QbitTracker
     'd.ratio=',
     'd.complete=',
     'd.custom1=',
-  ]);
+  ];
+  let fieldCount = 11;
+  let xml: string;
+  try {
+    xml = await rtorrentRpc(client, 'd.multicall2', [
+      ...baseFields,
+      'd.creation_date=',
+      'd.timestamp.finished=',
+    ]);
+  } catch (err: unknown) {
+    betaWarn(`${betaClientLogName(client)}: d.multicall2 avec dates KO - ${err instanceof Error ? err.message : String(err)}; repli sans dates/seedtime`);
+    fieldCount = 9;
+    xml = await rtorrentRpc(client, 'd.multicall2', baseFields);
+  }
   const scalars = parseXmlRpcScalars(xml);
-  betaLog(`${betaClientLogName(client)}: d.multicall2 a retourne ${scalars.length} valeur(s), ${Math.floor(scalars.length / 9)} torrent(s) potentiel(s)`);
+  betaLog(`${betaClientLogName(client)}: d.multicall2 a retourne ${scalars.length} valeur(s), ${Math.floor(scalars.length / fieldCount)} torrent(s) potentiel(s)`);
   const groups = new Map<string, QbitTrackerAggregate>();
   let trackerDetailCalls = 0;
   let unknownSkipped = 0;
-  for (let i = 0; i + 8 < scalars.length; i += 9) {
-    const [hash, name, stateRaw, sizeRaw, upRaw, downRaw, ratioRaw, completeRaw, labelRaw] = scalars.slice(i, i + 9);
+  for (let i = 0; i + fieldCount - 1 < scalars.length; i += fieldCount) {
+    const [hash, name, stateRaw, sizeRaw, upRaw, downRaw, ratioRaw, completeRaw, labelRaw, creationRaw, finishedRaw] = scalars.slice(i, i + fieldCount);
     let announce = '';
     try {
       trackerDetailCalls += 1;
@@ -2381,6 +2409,10 @@ async function fetchRutorrentClient(client: BetaQbitClient): Promise<QbitTracker
     const up = Number(upRaw) || 0;
     const down = Number(downRaw) || 0;
     const complete = completeRaw === '1';
+    const finishedSeconds = Number(finishedRaw) || 0;
+    const seedTimeSeconds = complete && finishedSeconds > 0
+      ? Math.max(0, Math.floor(Date.now() / 1000) - finishedSeconds)
+      : null;
     const existing = groups.get(groupKey) ?? {
       clientId: client.id,
       clientLabel: client.label,
@@ -2412,6 +2444,8 @@ async function fetchRutorrentClient(client: BetaQbitClient): Promise<QbitTracker
       uploadedBytes: up,
       downloadedBytes: down,
       ratio: Number.isFinite(Number(ratioRaw)) ? Number(ratioRaw) / 1000 : null,
+      addedAt: unixSecondsToIso(creationRaw),
+      seedTimeSeconds,
       category: labelRaw || '',
       tags: labelRaw ? [labelRaw] : [],
       crossSeedInstanceIds: detectCrossSeedInstanceIds(crossSeedInstances, client.id, labelRaw, labelRaw ? [labelRaw] : []),


### PR DESCRIPTION
## Résumé
- remonte la date d'ajout et le seedtime client pour chaque torrent lié
- affiche les colonnes `Ajouté le` et `Seedtime` dans les fiches trackers, avec tri cliquable
- garde un repli compatible pour ruTorrent/rTorrent quand les champs de dates ne sont pas disponibles

## Validation
- `npm run build`
- `npm run check:integration`
- `npm audit --omit=dev --audit-level=high`
- `git diff --check`