### PR TITLE
Restaurer les torrents liés aux fiches trackers

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4202,6 +4202,13 @@
     return `<th class="sortable" onclick="setBetaTorrentSort('${key}')">${label} ${betaTorrentSortIndicator(key)}</th>`;
   }
 
+  function betaQbitGroupMatchesTracker(item, stat, host, multiAccount) {
+    if (item.trackerId === stat.id) return true;
+    if (multiAccount) return false;
+    if (trackerHostFromUrl(item.trackerHost) === host) return true;
+    return betaTrackerMatchForHost(item.trackerHost)?.tracker.id === stat.id;
+  }
+
   // État des mini-courbes d'évolution de la fiche (conservé entre les re-renders).
   let ficheChartPeriod = '7'; // '7' | '30' | 'all'
   let ficheBufferOn = false;
@@ -4284,8 +4291,12 @@
     // En multi-comptes, on n'affiche que les torrents resolus vers ce compte (sinon
     // tous les comptes du site partageraient le meme hote). En compte unique, on garde
     // le repli par hote pour les annonces non encore reliees.
-    const qbits = (betaOverview?.qbitStats || []).filter(item => item.trackerId === stat.id || (!multiAccount && item.trackerHost === host));
-    const suggestedQbits = (betaOverview?.qbitStats || []).filter(item => !item.trackerId && betaTrackerMatchForHost(item.trackerHost)?.tracker.id === stat.id);
+    const qbits = (betaOverview?.qbitStats || []).filter(item => betaQbitGroupMatchesTracker(item, stat, host, multiAccount));
+    const qbitGroupKeys = new Set(qbits.map(item => `${item.clientId || ''}::${item.trackerHost || ''}::${item.announceKey || ''}`));
+    const suggestedQbits = (betaOverview?.qbitStats || []).filter(item => {
+      const key = `${item.clientId || ''}::${item.trackerHost || ''}::${item.announceKey || ''}`;
+      return !qbitGroupKeys.has(key) && !item.trackerId && betaTrackerMatchForHost(item.trackerHost)?.tracker.id === stat.id;
+    });
     const torrents = qbits.flatMap(item => (item.torrents || []).map(torrent => ({ ...torrent, clientLabel: item.clientLabel, clientBaseUrl: item.clientBaseUrl })));
     const sortedTorrents = betaSortedTorrents(torrents);
     const crossSeedTorrentCount = torrents.filter(torrent => (torrent.crossSeedInstanceIds || []).length > 0).length;

--- a/src/server.ts
+++ b/src/server.ts
@@ -2354,6 +2354,10 @@ function parseXmlRpcScalars(xml: string): string[] {
   return values;
 }
 
+function xmlRpcHasFault(xml: string): boolean {
+  return /<fault>/i.test(xml);
+}
+
 async function fetchRutorrentClient(client: BetaQbitClient): Promise<QbitTrackerAggregate[]> {
   const baseUrl = cleanClientBaseUrl(client.baseUrl);
   const crossSeedInstances = loadBetaSettings().crossSeedInstances;
@@ -2380,6 +2384,7 @@ async function fetchRutorrentClient(client: BetaQbitClient): Promise<QbitTracker
       'd.creation_date=',
       'd.timestamp.finished=',
     ]);
+    if (xmlRpcHasFault(xml)) throw new Error(responsePreview(xml));
   } catch (err: unknown) {
     betaWarn(`${betaClientLogName(client)}: d.multicall2 avec dates KO - ${err instanceof Error ? err.message : String(err)}; repli sans dates/seedtime`);
     fieldCount = 9;


### PR DESCRIPTION
## Résumé
- restaure le fallback d'affichage des groupes BitTorrent qui matchent un tracker par host ou heuristique
- évite de dupliquer ces groupes dans la liste d'import proposée
- corrige le fallback ruTorrent/rTorrent quand les champs de dates renvoient une réponse XML-RPC `fault`, afin de ne pas perdre tous les torrents

## Validation
- `npm run build`
- `npm run check:integration`
- `npm audit --omit=dev --audit-level=high`
- `git diff --check`