### PR TITLE
Restaurer les liens entre torrents et trackers

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4313,11 +4313,22 @@
     return 760 + visibleOptional * 110;
   }
 
-  function betaQbitGroupMatchesTracker(item, stat, host, multiAccount) {
+  function betaQbitGroupMatchesTracker(item, stat, host, multiAccount, siblings = []) {
     if (item.trackerId === stat.id) return true;
-    if (multiAccount) return false;
-    if (trackerHostFromUrl(item.trackerHost) === host) return true;
-    return betaTrackerMatchForHost(item.trackerHost)?.tracker.id === stat.id;
+    const itemHost = trackerHostFromUrl(item.trackerHost);
+    const hostMatches = itemHost === host || betaTrackerMatchForHost(item.trackerHost)?.tracker.id === stat.id;
+    if (!hostMatches) return false;
+    if (!multiAccount) return true;
+
+    const explicitAccount = (betaSettings.accountAnnounceMappings || []).find(mapping => mapping.key && mapping.key === item.announceKey);
+    if (explicitAccount) return explicitAccount.trackerId === stat.id;
+
+    const siblingIds = new Set(siblings.map(sibling => sibling.id));
+    if (item.trackerId && siblingIds.has(item.trackerId)) return false;
+
+    // Tant qu'une passkey n'est pas attribuee a un compte, garder les torrents
+    // visibles sur le premier compte du site plutot que les masquer partout.
+    return stat.id === (siblings[0]?.id || stat.id);
   }
 
   // État des mini-courbes d'évolution de la fiche (conservé entre les re-renders).
@@ -4393,7 +4404,7 @@
     if (multiAccount) {
       const seenKeys = new Set();
       for (const item of (betaOverview?.qbitStats || [])) {
-        if (item.trackerHost !== host || !item.announceKey || seenKeys.has(item.announceKey)) continue;
+        if (trackerHostFromUrl(item.trackerHost) !== host || !item.announceKey || seenKeys.has(item.announceKey)) continue;
         seenKeys.add(item.announceKey);
         const mapping = (betaSettings.accountAnnounceMappings || []).find(m => m.key === item.announceKey);
         siteAnnounceGroups.push({ key: item.announceKey, label: item.announceLabel || item.announceKey, assigned: mapping?.trackerId || item.trackerId || '' });
@@ -4402,7 +4413,7 @@
     // En multi-comptes, on n'affiche que les torrents resolus vers ce compte (sinon
     // tous les comptes du site partageraient le meme hote). En compte unique, on garde
     // le repli par hote pour les annonces non encore reliees.
-    const qbits = (betaOverview?.qbitStats || []).filter(item => betaQbitGroupMatchesTracker(item, stat, host, multiAccount));
+    const qbits = (betaOverview?.qbitStats || []).filter(item => betaQbitGroupMatchesTracker(item, stat, host, multiAccount, siblings));
     const qbitGroupKeys = new Set(qbits.map(item => `${item.clientId || ''}::${item.trackerHost || ''}::${item.announceKey || ''}`));
     const suggestedQbits = (betaOverview?.qbitStats || []).filter(item => {
       const key = `${item.clientId || ''}::${item.trackerHost || ''}::${item.announceKey || ''}`;

--- a/scripts/check-integration.mjs
+++ b/scripts/check-integration.mjs
@@ -154,6 +154,18 @@ if (!cardEditOpensSelectedTracker) {
   errors.push('Card edit buttons must open the selected tracker configuration view');
 }
 
+const torrentTrackerMatchingIsDefensive = (
+  server.includes('function trackerHostMapFor(activeTrackers: TrackerConfig[], settings: BetaSettings): Map<string, string>')
+  && server.includes('if (ids.size === 1) trackerHosts.set(key, [...ids][0]);')
+  && server.includes('activeTrackers.filter(tracker => tracker.enabled !== false)')
+  && html.includes('function betaQbitGroupMatchesTracker(item, stat, host, multiAccount, siblings = [])')
+  && html.includes('const explicitAccount = (betaSettings.accountAnnounceMappings || []).find(mapping => mapping.key && mapping.key === item.announceKey);')
+  && html.includes('return stat.id === (siblings[0]?.id || stat.id);')
+);
+if (!torrentTrackerMatchingIsDefensive) {
+  errors.push('BitTorrent tracker matching must keep unassigned multi-account torrents visible and avoid ambiguous server-side host attribution');
+}
+
 const synchronizesAllBundledTrackers = (
   server.includes('const definition = loadDefaultTrackerDefinition(tracker.baseId ?? tracker.id);')
   && !server.includes('CANONICAL_CONNECTION_TRACKERS')

--- a/src/server.ts
+++ b/src/server.ts
@@ -2014,18 +2014,39 @@ function resolveTorrentTrackerId(
   return betaTrackerIdForAnnounceHost(item.trackerHost, trackerHosts, trackers);
 }
 
-function qbitStatsWithTrackerIds(settings: BetaSettings, activeTrackers: TrackerConfig[]) {
-  const trackerHosts = new Map<string, string>();
-  for (const tracker of activeTrackers) {
+function trackerHostMapFor(activeTrackers: TrackerConfig[], settings: BetaSettings): Map<string, string> {
+  const candidates = new Map<string, Set<string>>();
+  const addCandidate = (key: string, trackerId: string) => {
+    if (!key || key === 'unknown' || !trackerId) return;
+    const ids = candidates.get(key) ?? new Set<string>();
+    ids.add(trackerId);
+    candidates.set(key, ids);
+  };
+
+  for (const tracker of activeTrackers.filter(tracker => tracker.enabled !== false)) {
     const host = trackerHost(tracker.baseUrl);
-    trackerHosts.set(host, tracker.id);
-    trackerHosts.set(hostDomainKey(host), tracker.id);
+    addCandidate(host, tracker.id);
+    addCandidate(hostDomainKey(host), tracker.id);
   }
+
+  const trackerHosts = new Map<string, string>();
+  for (const [key, ids] of candidates.entries()) {
+    if (ids.size === 1) trackerHosts.set(key, [...ids][0]);
+  }
+
+  // Les liaisons manuelles gagnent sur l'heuristique, y compris pour des sites
+  // multi-comptes ou des domaines d'annonce ambigus.
   for (const mapping of settings.announceMappings) {
     const host = trackerHost(mapping.announceHost);
     trackerHosts.set(host, mapping.trackerId);
     trackerHosts.set(hostDomainKey(host), mapping.trackerId);
   }
+
+  return trackerHosts;
+}
+
+function qbitStatsWithTrackerIds(settings: BetaSettings, activeTrackers: TrackerConfig[]) {
+  const trackerHosts = trackerHostMapFor(activeTrackers, settings);
   const accountByKey = new Map(settings.accountAnnounceMappings.map(mapping => [mapping.key, mapping.trackerId]));
   return betaQbitStats.map(item => ({
     ...item,
@@ -2047,17 +2068,7 @@ function qbitSeedingByTrackerId(trackers: TrackerConfig[]): Map<string, { count:
   if (betaQbitStats.length === 0) return result;
   const settings = loadBetaSettings();
   const clientType = new Map(settings.qbitClients.map(client => [client.id, client.type === 'rutorrent' ? 'rutorrent' : 'qbittorrent']));
-  const trackerHosts = new Map<string, string>();
-  for (const tracker of trackers) {
-    const host = trackerHost(tracker.baseUrl);
-    trackerHosts.set(host, tracker.id);
-    trackerHosts.set(hostDomainKey(host), tracker.id);
-  }
-  for (const mapping of settings.announceMappings) {
-    const host = trackerHost(mapping.announceHost);
-    trackerHosts.set(host, mapping.trackerId);
-    trackerHosts.set(hostDomainKey(host), mapping.trackerId);
-  }
+  const trackerHosts = trackerHostMapFor(trackers, settings);
   const accountByKey = new Map(settings.accountAnnounceMappings.map(mapping => [mapping.key, mapping.trackerId]));
   for (const item of betaQbitStats) {
     const trackerId = resolveTorrentTrackerId(item, trackerHosts, accountByKey, trackers);


### PR DESCRIPTION
## Résumé
- évite d'associer automatiquement un hôte BitTorrent ambigu au mauvais tracker quand plusieurs comptes partagent le même domaine
- garde les torrents non attribués visibles sur la fiche du premier compte du site au lieu de les masquer partout
- ajoute une garde d'intégration pour empêcher une régression du matching tracker ↔ torrents

## Validation
- `npm run build`
- `npm run check:integration`
- `npm audit --omit=dev --audit-level=high`
- `git diff --check`