### PR TITLE
Rétablir la liste des torrents sur les fiches

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4313,22 +4313,11 @@
     return 760 + visibleOptional * 110;
   }
 
-  function betaQbitGroupMatchesTracker(item, stat, host, multiAccount, siblings = []) {
+  function betaQbitGroupMatchesTracker(item, stat, host, multiAccount) {
     if (item.trackerId === stat.id) return true;
-    const itemHost = trackerHostFromUrl(item.trackerHost);
-    const hostMatches = itemHost === host || betaTrackerMatchForHost(item.trackerHost)?.tracker.id === stat.id;
-    if (!hostMatches) return false;
-    if (!multiAccount) return true;
-
-    const explicitAccount = (betaSettings.accountAnnounceMappings || []).find(mapping => mapping.key && mapping.key === item.announceKey);
-    if (explicitAccount) return explicitAccount.trackerId === stat.id;
-
-    const siblingIds = new Set(siblings.map(sibling => sibling.id));
-    if (item.trackerId && siblingIds.has(item.trackerId)) return false;
-
-    // Tant qu'une passkey n'est pas attribuee a un compte, garder les torrents
-    // visibles sur le premier compte du site plutot que les masquer partout.
-    return stat.id === (siblings[0]?.id || stat.id);
+    if (multiAccount) return false;
+    if (trackerHostFromUrl(item.trackerHost) === host) return true;
+    return betaTrackerMatchForHost(item.trackerHost)?.tracker.id === stat.id;
   }
 
   // État des mini-courbes d'évolution de la fiche (conservé entre les re-renders).
@@ -4404,7 +4393,7 @@
     if (multiAccount) {
       const seenKeys = new Set();
       for (const item of (betaOverview?.qbitStats || [])) {
-        if (trackerHostFromUrl(item.trackerHost) !== host || !item.announceKey || seenKeys.has(item.announceKey)) continue;
+        if (item.trackerHost !== host || !item.announceKey || seenKeys.has(item.announceKey)) continue;
         seenKeys.add(item.announceKey);
         const mapping = (betaSettings.accountAnnounceMappings || []).find(m => m.key === item.announceKey);
         siteAnnounceGroups.push({ key: item.announceKey, label: item.announceLabel || item.announceKey, assigned: mapping?.trackerId || item.trackerId || '' });
@@ -4413,7 +4402,7 @@
     // En multi-comptes, on n'affiche que les torrents resolus vers ce compte (sinon
     // tous les comptes du site partageraient le meme hote). En compte unique, on garde
     // le repli par hote pour les annonces non encore reliees.
-    const qbits = (betaOverview?.qbitStats || []).filter(item => betaQbitGroupMatchesTracker(item, stat, host, multiAccount, siblings));
+    const qbits = (betaOverview?.qbitStats || []).filter(item => betaQbitGroupMatchesTracker(item, stat, host, multiAccount));
     const qbitGroupKeys = new Set(qbits.map(item => `${item.clientId || ''}::${item.trackerHost || ''}::${item.announceKey || ''}`));
     const suggestedQbits = (betaOverview?.qbitStats || []).filter(item => {
       const key = `${item.clientId || ''}::${item.trackerHost || ''}::${item.announceKey || ''}`;

--- a/scripts/check-integration.mjs
+++ b/scripts/check-integration.mjs
@@ -154,16 +154,16 @@ if (!cardEditOpensSelectedTracker) {
   errors.push('Card edit buttons must open the selected tracker configuration view');
 }
 
-const torrentTrackerMatchingIsDefensive = (
-  server.includes('function trackerHostMapFor(activeTrackers: TrackerConfig[], settings: BetaSettings): Map<string, string>')
-  && server.includes('if (ids.size === 1) trackerHosts.set(key, [...ids][0]);')
-  && server.includes('activeTrackers.filter(tracker => tracker.enabled !== false)')
-  && html.includes('function betaQbitGroupMatchesTracker(item, stat, host, multiAccount, siblings = [])')
-  && html.includes('const explicitAccount = (betaSettings.accountAnnounceMappings || []).find(mapping => mapping.key && mapping.key === item.announceKey);')
-  && html.includes('return stat.id === (siblings[0]?.id || stat.id);')
+const torrentTrackerListingPreservesFallback = (
+  html.includes('function betaQbitGroupMatchesTracker(item, stat, host, multiAccount)')
+  && html.includes('if (multiAccount) return false;')
+  && html.includes('if (trackerHostFromUrl(item.trackerHost) === host) return true;')
+  && html.includes('return betaTrackerMatchForHost(item.trackerHost)?.tracker.id === stat.id;')
+  && server.includes('function qbitStatsWithTrackerIds(settings: BetaSettings, activeTrackers: TrackerConfig[])')
+  && !server.includes('function trackerHostMapFor(activeTrackers: TrackerConfig[], settings: BetaSettings): Map<string, string>')
 );
-if (!torrentTrackerMatchingIsDefensive) {
-  errors.push('BitTorrent tracker matching must keep unassigned multi-account torrents visible and avoid ambiguous server-side host attribution');
+if (!torrentTrackerListingPreservesFallback) {
+  errors.push('Tracker fiches must preserve the BitTorrent torrent listing fallback used before optional columns');
 }
 
 const synchronizesAllBundledTrackers = (

--- a/src/server.ts
+++ b/src/server.ts
@@ -2014,39 +2014,18 @@ function resolveTorrentTrackerId(
   return betaTrackerIdForAnnounceHost(item.trackerHost, trackerHosts, trackers);
 }
 
-function trackerHostMapFor(activeTrackers: TrackerConfig[], settings: BetaSettings): Map<string, string> {
-  const candidates = new Map<string, Set<string>>();
-  const addCandidate = (key: string, trackerId: string) => {
-    if (!key || key === 'unknown' || !trackerId) return;
-    const ids = candidates.get(key) ?? new Set<string>();
-    ids.add(trackerId);
-    candidates.set(key, ids);
-  };
-
-  for (const tracker of activeTrackers.filter(tracker => tracker.enabled !== false)) {
-    const host = trackerHost(tracker.baseUrl);
-    addCandidate(host, tracker.id);
-    addCandidate(hostDomainKey(host), tracker.id);
-  }
-
+function qbitStatsWithTrackerIds(settings: BetaSettings, activeTrackers: TrackerConfig[]) {
   const trackerHosts = new Map<string, string>();
-  for (const [key, ids] of candidates.entries()) {
-    if (ids.size === 1) trackerHosts.set(key, [...ids][0]);
+  for (const tracker of activeTrackers) {
+    const host = trackerHost(tracker.baseUrl);
+    trackerHosts.set(host, tracker.id);
+    trackerHosts.set(hostDomainKey(host), tracker.id);
   }
-
-  // Les liaisons manuelles gagnent sur l'heuristique, y compris pour des sites
-  // multi-comptes ou des domaines d'annonce ambigus.
   for (const mapping of settings.announceMappings) {
     const host = trackerHost(mapping.announceHost);
     trackerHosts.set(host, mapping.trackerId);
     trackerHosts.set(hostDomainKey(host), mapping.trackerId);
   }
-
-  return trackerHosts;
-}
-
-function qbitStatsWithTrackerIds(settings: BetaSettings, activeTrackers: TrackerConfig[]) {
-  const trackerHosts = trackerHostMapFor(activeTrackers, settings);
   const accountByKey = new Map(settings.accountAnnounceMappings.map(mapping => [mapping.key, mapping.trackerId]));
   return betaQbitStats.map(item => ({
     ...item,
@@ -2068,7 +2047,17 @@ function qbitSeedingByTrackerId(trackers: TrackerConfig[]): Map<string, { count:
   if (betaQbitStats.length === 0) return result;
   const settings = loadBetaSettings();
   const clientType = new Map(settings.qbitClients.map(client => [client.id, client.type === 'rutorrent' ? 'rutorrent' : 'qbittorrent']));
-  const trackerHosts = trackerHostMapFor(trackers, settings);
+  const trackerHosts = new Map<string, string>();
+  for (const tracker of trackers) {
+    const host = trackerHost(tracker.baseUrl);
+    trackerHosts.set(host, tracker.id);
+    trackerHosts.set(hostDomainKey(host), tracker.id);
+  }
+  for (const mapping of settings.announceMappings) {
+    const host = trackerHost(mapping.announceHost);
+    trackerHosts.set(host, mapping.trackerId);
+    trackerHosts.set(hostDomainKey(host), mapping.trackerId);
+  }
   const accountByKey = new Map(settings.accountAnnounceMappings.map(mapping => [mapping.key, mapping.trackerId]));
   for (const item of betaQbitStats) {
     const trackerId = resolveTorrentTrackerId(item, trackerHosts, accountByKey, trackers);


### PR DESCRIPTION
## Résumé
- annule la logique de matching ajoutée après le masquage des colonnes, qui pouvait vider la liste des torrents liés
- restaure le comportement de listing connu avant cette régression
- garde l'option afficher/masquer les colonnes et ajoute une garde d'intégration sur le fallback de listing

## Validation
- `npm run build`
- `npm run check:integration`
- `npm audit --omit=dev --audit-level=high`
- `git diff --check`