### PR TITLE
Ajoute TRAWL en secours anti-bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Au premier accès, l'application demande de créer le compte administrateur de l
 - **Plusieurs comptes par tracker** : duplication d'un tracker, noms d'affichage personnalisables, regroupement sous le site et attribution des torrents par passkey entre comptes.
 - **Clients BitTorrent et cross-seed** : comparaison aux torrents locaux, rafraîchissement automatique par client, plusieurs instances cross-seed et plusieurs clients associés à une même instance.
 - **Seeding comparé** : compteurs annoncés par le site et détectés dans les clients BitTorrent affichés côte à côte.
-- **Protection anti-bot renforcée** : sessions navigateur plus fiables, cookies par tracker et repli automatique via FlareSolverr lorsqu'un challenge bloque la lecture normale.
+- **Protection anti-bot renforcée** : sessions navigateur plus fiables, cookies par tracker, repli automatique via FlareSolverr puis secours TRAWL lorsqu'un challenge bloque la lecture normale.
 - **Ajout de trackers simplifié** : presets UNIT3D, Gazelle, TorrentLeech, MyAnonamouse et API JSON, modes guidé/expert et catalogue enrichi, notamment avec IPTorrents et DarkPeers.
 - **Interface modernisée** : navigation latérale, vues cartes/lignes, taille des cartes partagée entre appareils, thèmes clair/sombre/système et fiches trackers enrichies.
 - **Graphiques et calendrier** : activation facultative, courbes UP/DL/ratio, comparaisons multi-trackers et historique des rafraîchissements OK/KO.
@@ -163,7 +163,7 @@ Avec le type **SSH**, le dashboard ouvre un tunnel SSH (SOCKS5 local adossé au 
 
 ### Unraid — templates bêta
 
-Des templates Unraid sont disponibles pour installer séparément l'application, le runtime navigateur et FlareSolverr sans Docker Compose. Consultez le [guide Unraid](unraid/README.md). Nous recherchons activement des retours avant une éventuelle publication dans Community Applications.
+Des templates Unraid sont disponibles pour installer séparément l'application, le runtime navigateur, FlareSolverr et TRAWL sans Docker Compose. Consultez le [guide Unraid](unraid/README.md). Nous recherchons activement des retours avant une éventuelle publication dans Community Applications.
 
 Le navigateur (Playwright/Chromium/CloakBrowser) est externalisé dans l'image `ghcr.io/tracker-dashboard/tracker-dashboard-browser:latest`. L'image principale reste allégée.
 
@@ -201,11 +201,11 @@ Si le runtime navigateur est absent, les trackers en `mode: browser` affichent u
 
 Les lectures en mode navigateur utilisent **Chromium** (Playwright) par défaut. Une option (panneau Proxies → Moteur navigateur) bascule sur **[CloakBrowser](https://github.com/CloakHQ/CloakBrowser)**, un Chromium modifié pour présenter une empreinte de vrai navigateur (TLS, fingerprint) et franchir davantage de protections anti-bot. S'il est indisponible, l'app repart automatiquement sur Chromium.
 
-### Repli Cloudflare (FlareSolverr)
+### Repli Cloudflare (FlareSolverr puis TRAWL)
 
-Tracker Dashboard peut utiliser **[FlareSolverr](https://github.com/FlareSolverr/FlareSolverr)** en dernier recours lorsqu'un tracker renvoie explicitement un challenge Cloudflare ou anti-bot. Le sidecar reçoit uniquement l'URL, les cookies et le proxy du tracker concerné, résout le challenge dans une session temporaire, renvoie le HTML puis détruit cette session. Les erreurs de credentials, de réseau ou d'extraction ne déclenchent pas ce navigateur supplémentaire. Un tracker connu pour nécessiter FlareSolverr, comme YGGReborn, peut déclarer ce repli en priorité après les lectures HTTP légères.
+Tracker Dashboard peut utiliser **[FlareSolverr](https://github.com/FlareSolverr/FlareSolverr)** en dernier recours lorsqu'un tracker renvoie explicitement un challenge Cloudflare ou anti-bot. Si FlareSolverr échoue ou reste injoignable, l'application tente ensuite **[TRAWL](https://github.com/germondai/trawl)** via son API compatible FlareSolverr. Les sidecars reçoivent uniquement l'URL, les cookies et le proxy du tracker concerné, résolvent le challenge dans une session temporaire, renvoient le HTML puis détruisent cette session. Les erreurs de credentials, de réseau ou d'extraction ne déclenchent pas ces navigateurs supplémentaires. Un tracker connu pour nécessiter ce repli, comme YGGReborn, peut le déclarer en priorité après les lectures HTTP légères.
 
-Le fichier `docker-compose.yml` fourni inclut déjà ce sidecar. Pour une stack existante, ajoutez :
+Le fichier `docker-compose.yml` fourni inclut déjà FlareSolverr et TRAWL. Pour une stack existante, ajoutez d'abord FlareSolverr :
 
 ```yaml
 services:
@@ -221,7 +221,22 @@ services:
       TZ: Europe/Paris
 ```
 
-Le partage du réseau du conteneur principal est important : FlareSolverr est alors joignable en interne sur `http://127.0.0.1:8191` et réutilise aussi les tunnels SOCKS locaux des proxies SSH. Aucun port FlareSolverr n'est exposé sur l'hôte. Une URL différente peut être fournie avec `FLARESOLVERR_URL`.
+Ajoutez ensuite TRAWL comme secours. L'image `baseline` est retenue pour sa compatibilité avec les vieux CPU, les anciens kernels et les NAS Synology ; ce n'est pas une promesse de consommation CPU/RAM plus basse que FlareSolverr.
+
+```yaml
+services:
+  tracker-dashboard-trawl:
+    image: ghcr.io/germondai/trawl:baseline
+    container_name: tracker-dashboard-trawl
+    restart: unless-stopped
+    network_mode: "container:tracker-dashboard"
+    environment:
+      PORT: 8192
+      LOG_LEVEL: warning
+      TZ: Europe/Paris
+```
+
+Le partage du réseau du conteneur principal est important : FlareSolverr est alors joignable en interne sur `http://127.0.0.1:8191`, TRAWL sur `http://127.0.0.1:8192`, et les deux réutilisent aussi les tunnels SOCKS locaux des proxies SSH. Aucun port anti-bot n'est exposé sur l'hôte. Une URL différente peut être fournie avec `FLARESOLVERR_URL` ou `TRAWL_URL`.
 
 ## Lecture rapide (curl-impersonate)
 
@@ -295,5 +310,6 @@ Le ratio peut être calculé depuis upload/download s'il n'est pas exposé ; ide
 - [Autovisit](https://github.com/Gusdezup/Autovisit) — idée de la prise en charge du 2FA (TOTP).
 - [CloakBrowser](https://github.com/CloakHQ/CloakBrowser) — moteur Chromium furtif proposé en option.
 - [FlareSolverr](https://github.com/FlareSolverr/FlareSolverr) — résolution de challenges Cloudflare via un sidecar interne optionnel.
+- [TRAWL](https://github.com/germondai/trawl) — secours anti-bot compatible FlareSolverr lorsque le premier repli échoue.
 - [cross-seed](https://github.com/cross-seed/cross-seed) — détection des torrents injectés et logo officiel (licence Apache-2.0).
 - Et tous les contributeurs qui partagent des définitions de trackers.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,3 +25,13 @@ services:
       # Evite de journaliser les corps de requete, qui contiennent les cookies de session.
       LOG_LEVEL: warning
       TZ: Europe/Paris
+
+  tracker-dashboard-trawl:
+    image: ghcr.io/germondai/trawl:baseline
+    container_name: tracker-dashboard-trawl
+    restart: unless-stopped
+    network_mode: "service:tracker-dashboard"
+    environment:
+      PORT: 8192
+      LOG_LEVEL: warning
+      TZ: Europe/Paris

--- a/public/index.html
+++ b/public/index.html
@@ -2075,12 +2075,13 @@
     </div>
     <div class="proxy-info" style="margin-top:14px; max-width:760px">
       <div style="display:flex; align-items:center; gap:10px; flex-wrap:wrap">
-        <b>Repli Cloudflare (FlareSolverr)</b>
+        <b>Repli Cloudflare (FlareSolverr puis TRAWL)</b>
         <span id="flaresolverr-badge" class="definition-badge definition-badge-muted">…</span>
+        <span id="trawl-badge" class="definition-badge definition-badge-muted">…</span>
         <button class="btn-test" style="padding:4px 10px" onclick="loadFlareSolverrStatus()" type="button">Vérifier</button>
       </div>
       <div id="flaresolverr-detail" class="beta-note" style="margin-top:8px"></div>
-      <p class="beta-note" style="margin-top:8px">Dernier recours automatique pour les challenges Cloudflare/anti-bot explicites. CloakBrowser reste le moteur normal ; les erreurs de credentials ou de regex ne déclenchent pas FlareSolverr.</p>
+      <p class="beta-note" style="margin-top:8px">Dernier recours automatique pour les challenges Cloudflare/anti-bot explicites : FlareSolverr est essayé d'abord, puis TRAWL si FlareSolverr échoue. CloakBrowser reste le moteur normal ; les erreurs de credentials ou de regex ne déclenchent pas ces sidecars.</p>
     </div>
     <div class="proxy-form" style="align-items:flex-start; margin-top:14px">
       <label class="toggle-switch" style="grid-column:span 5" title="Lecture rapide via curl-impersonate">
@@ -7054,7 +7055,7 @@
   --restart unless-stopped \\
   --network container:tracker-dashboard \\
   -e HOST=127.0.0.1 \\
-  -e LOG_LEVEL=info \\
+  -e LOG_LEVEL=warning \\
   -e TZ=Europe/Paris \\
   ghcr.io/flaresolverr/flaresolverr:latest`;
 
@@ -7066,7 +7067,27 @@
     network_mode: "container:tracker-dashboard"
     environment:
       HOST: 127.0.0.1
-      LOG_LEVEL: info
+      LOG_LEVEL: warning
+      TZ: Europe/Paris`;
+
+  const TRAWL_INSTALL_COMMAND = `docker run -d \\
+  --name tracker-dashboard-trawl \\
+  --restart unless-stopped \\
+  --network container:tracker-dashboard \\
+  -e PORT=8192 \\
+  -e LOG_LEVEL=warning \\
+  -e TZ=Europe/Paris \\
+  ghcr.io/germondai/trawl:baseline`;
+
+  const TRAWL_COMPOSE_SNIPPET = `services:
+  tracker-dashboard-trawl:
+    image: ghcr.io/germondai/trawl:baseline
+    container_name: tracker-dashboard-trawl
+    restart: unless-stopped
+    network_mode: "container:tracker-dashboard"
+    environment:
+      PORT: 8192
+      LOG_LEVEL: warning
       TZ: Europe/Paris`;
 
   // Etat du runtime navigateur externe + versions.
@@ -7114,19 +7135,28 @@
 
   async function loadFlareSolverrStatus() {
     const badge = document.getElementById('flaresolverr-badge');
+    const trawlBadge = document.getElementById('trawl-badge');
     const detail = document.getElementById('flaresolverr-detail');
-    if (!badge || !detail) return;
+    if (!badge || !trawlBadge || !detail) return;
     badge.textContent = 'Vérification…';
+    trawlBadge.textContent = 'Vérification…';
     badge.className = 'definition-badge definition-badge-muted';
+    trawlBadge.className = 'definition-badge definition-badge-muted';
     badge.style.color = '';
+    trawlBadge.style.color = '';
     try {
-      const response = await fetch('/api/flaresolverr/status');
-      const data = await response.json();
-      const status = data.status || {};
+      const [flareResponse, trawlResponse] = await Promise.all([
+        fetch('/api/flaresolverr/status'),
+        fetch('/api/trawl/status'),
+      ]);
+      const flareData = await flareResponse.json();
+      const trawlData = await trawlResponse.json();
+      const status = flareData.status || {};
+      const trawlStatus = trawlData.status || {};
       if (status.available) {
         badge.textContent = 'FlareSolverr — disponible';
         badge.className = 'definition-badge';
-        detail.innerHTML = `Version <b>${escapeHtml(status.version || '?')}</b><br><span style="color:var(--muted)">${escapeHtml(status.url || '')}</span>`;
+        detail.innerHTML = `FlareSolverr <b>${escapeHtml(status.version || '?')}</b><br><span style="color:var(--muted)">${escapeHtml(status.url || '')}</span>`;
       } else {
         badge.textContent = 'FlareSolverr — absent';
         badge.className = 'definition-badge definition-badge-muted';
@@ -7141,8 +7171,27 @@
             <button class="btn-test" style="padding:4px 10px;margin-top:6px" onclick="copyFlareSolverrInstall(this, 'run')" type="button">Copier la commande</button>
           </details>`;
       }
+      if (trawlStatus.available) {
+        trawlBadge.textContent = 'TRAWL — disponible';
+        trawlBadge.className = 'definition-badge';
+        detail.innerHTML += `<div style="margin-top:8px">TRAWL <b>${escapeHtml(trawlStatus.version || 'baseline')}</b><br><span style="color:var(--muted)">${escapeHtml(trawlStatus.url || '')}</span></div>`;
+      } else {
+        trawlBadge.textContent = 'TRAWL — absent';
+        trawlBadge.className = 'definition-badge definition-badge-muted';
+        trawlBadge.style.color = 'var(--red)';
+        detail.innerHTML += `<div style="margin-top:12px">Le sidecar TRAWL de secours est absent ou injoignable${trawlStatus.error ? ' : ' + escapeHtml(trawlStatus.error) : ''}.
+          <div style="margin-top:10px"><b>Stack Compose / Dockge / Portainer</b></div>
+          <pre style="white-space:pre-wrap;margin-top:8px"><code>${escapeHtml(TRAWL_COMPOSE_SNIPPET)}</code></pre>
+          <button class="btn-test" style="padding:4px 10px;margin-top:6px" onclick="copyTrawlInstall(this, 'compose')" type="button">Copier le compose</button>
+          <details style="margin-top:10px">
+            <summary style="cursor:pointer">Commande Docker équivalente</summary>
+            <pre style="white-space:pre-wrap;margin-top:8px"><code>${escapeHtml(TRAWL_INSTALL_COMMAND)}</code></pre>
+            <button class="btn-test" style="padding:4px 10px;margin-top:6px" onclick="copyTrawlInstall(this, 'run')" type="button">Copier la commande</button>
+          </details></div>`;
+      }
     } catch (error) {
       badge.textContent = 'Inconnu';
+      trawlBadge.textContent = 'Inconnu';
       detail.textContent = 'Statut indisponible : ' + error.message;
     }
   }
@@ -7178,6 +7227,17 @@
       setTimeout(() => { button.textContent = previous; }, 1500);
     } catch (error) {
       console.warn('copyFlareSolverrInstall:', error.message);
+    }
+  }
+
+  async function copyTrawlInstall(button, mode) {
+    try {
+      await navigator.clipboard.writeText(mode === 'compose' ? TRAWL_COMPOSE_SNIPPET : TRAWL_INSTALL_COMMAND);
+      const previous = button.textContent;
+      button.textContent = 'Copié';
+      setTimeout(() => { button.textContent = previous; }, 1500);
+    } catch (error) {
+      console.warn('copyTrawlInstall:', error.message);
     }
   }
 

--- a/scripts/check-flaresolverr.mjs
+++ b/scripts/check-flaresolverr.mjs
@@ -1,5 +1,5 @@
 import http from 'node:http';
-import { fetchWithFlareSolverr, getFlareSolverrStatus, isFlareSolverrCandidate } from '../dist/flareSolverr.js';
+import { fetchWithFlareSolverr, getFlareSolverrStatus, getTrawlStatus, isFlareSolverrCandidate } from '../dist/flareSolverr.js';
 
 const calls = [];
 const server = http.createServer(async (request, response) => {
@@ -101,6 +101,73 @@ try {
   if (!status.available || status.version !== 'test') {
     throw new Error('FlareSolverr status endpoint was not detected');
   }
+  const trawlStatus = await getTrawlStatus(baseUrl);
+  if (!trawlStatus.available || trawlStatus.provider !== 'trawl') {
+    throw new Error('TRAWL health endpoint was not detected');
+  }
+
+  const failingFlare = http.createServer(async (request, response) => {
+    response.setHeader('Content-Type', 'application/json');
+    if (request.method === 'GET') {
+      response.end(JSON.stringify({ version: 'failing-flare' }));
+      return;
+    }
+    response.end(JSON.stringify({ status: 'error', message: 'primary solver failed' }));
+  });
+  const trawlCalls = [];
+  const trawlServer = http.createServer(async (request, response) => {
+    if (request.method === 'GET') {
+      response.setHeader('Content-Type', 'application/json');
+      response.end(JSON.stringify({ ok: true, version: 'trawl-test' }));
+      return;
+    }
+    let raw = '';
+    for await (const chunk of request) raw += chunk;
+    const payload = JSON.parse(raw);
+    trawlCalls.push(payload);
+    response.setHeader('Content-Type', 'application/json');
+    if (payload.cmd === 'sessions.create') {
+      response.end(JSON.stringify({ status: 'ok', session: payload.session }));
+      return;
+    }
+    if (payload.cmd === 'sessions.destroy') {
+      response.end(JSON.stringify({ status: 'ok' }));
+      return;
+    }
+    response.end(JSON.stringify({
+      status: 'ok',
+      solution: {
+        status: 200,
+        url: payload.url,
+        response: '<div>TRAWL fallback</div><span>Upload</span>',
+        cookies: [],
+      },
+    }));
+  });
+  await new Promise(resolve => failingFlare.listen(0, '127.0.0.1', resolve));
+  await new Promise(resolve => trawlServer.listen(0, '127.0.0.1', resolve));
+  try {
+    const failingAddress = failingFlare.address();
+    const trawlAddress = trawlServer.address();
+    process.env.FLARESOLVERR_URL = `http://127.0.0.1:${failingAddress.port}`;
+    process.env.TRAWL_URL = `http://127.0.0.1:${trawlAddress.port}`;
+    const fallbackResult = await fetchWithFlareSolverr(tracker, { username: 'user', password: 'unused' }, {
+      cookieRaw: 'remember_token=session',
+      timeoutMs: 5_000,
+    });
+    if (fallbackResult.provider !== 'trawl' || !fallbackResult.html.includes('TRAWL fallback')) {
+      throw new Error('TRAWL must be tried when FlareSolverr fails');
+    }
+    if (!trawlCalls.some(call => call.cmd === 'request.get')) {
+      throw new Error('TRAWL fallback did not receive the tracker request');
+    }
+  } finally {
+    delete process.env.FLARESOLVERR_URL;
+    delete process.env.TRAWL_URL;
+    await new Promise(resolve => failingFlare.close(resolve));
+    await new Promise(resolve => trawlServer.close(resolve));
+  }
+
   if (!isFlareSolverrCandidate(new Error('Challenge anti-bot/Cloudflare affiche'))
     || isFlareSolverrCandidate(new Error('Identifiants invalides'))
     || isFlareSolverrCandidate(new Error('Aucune donnee extraite'))) {

--- a/scripts/check-integration.mjs
+++ b/scripts/check-integration.mjs
@@ -270,15 +270,21 @@ if (!yggUsesFlareSolverrFallback) {
 const shipsFlareSolverrSidecar = (
   compose.includes('tracker-dashboard-flaresolverr:')
   && compose.includes('ghcr.io/flaresolverr/flaresolverr:latest')
+  && compose.includes('tracker-dashboard-trawl:')
+  && compose.includes('ghcr.io/germondai/trawl:baseline')
+  && compose.includes('PORT: 8192')
   && compose.includes('LOG_LEVEL: warning')
   && compose.includes('network_mode: "service:tracker-dashboard"')
   && compose.includes('HOST: 127.0.0.1')
   && html.includes('/api/flaresolverr/status')
+  && html.includes('/api/trawl/status')
   && server.includes("app.get('/api/flaresolverr/status'")
-  && readme.includes('### Repli Cloudflare (FlareSolverr)')
+  && server.includes("app.get('/api/trawl/status'")
+  && readme.includes('### Repli Cloudflare (FlareSolverr puis TRAWL)')
+  && readme.includes('ghcr.io/germondai/trawl:baseline')
 );
 if (!shipsFlareSolverrSidecar) {
-  errors.push('FlareSolverr sidecar wiring must remain available in Compose, WebUI and README');
+  errors.push('FlareSolverr and TRAWL anti-bot sidecar wiring must remain available in Compose, WebUI and README');
 }
 
 const shipsCrossSeedIntegration = (

--- a/scripts/check-unraid-templates.mjs
+++ b/scripts/check-unraid-templates.mjs
@@ -9,6 +9,7 @@ const templateNames = [
   'tracker-dashboard',
   'tracker-dashboard-browser',
   'tracker-dashboard-flaresolverr',
+  'tracker-dashboard-trawl',
 ];
 
 const parsed = new Map();
@@ -30,7 +31,7 @@ assert.equal(main('Container > Network').text(), 'bridge');
 assert.equal(main('Config[Type="Port"][Target="3000"]').text(), '4832');
 assert.equal(main('Config[Type="Path"][Target="/app/config"]').text(), '/mnt/user/appdata/tracker-dashboard');
 
-for (const name of ['tracker-dashboard-browser', 'tracker-dashboard-flaresolverr']) {
+for (const name of ['tracker-dashboard-browser', 'tracker-dashboard-flaresolverr', 'tracker-dashboard-trawl']) {
   const $ = parsed.get(name);
   assert.equal($('Container > Network').text(), 'container:tracker-dashboard');
   assert.equal($('Config[Type="Port"]').length, 0, `${name} ne doit exposer aucun port`);
@@ -42,6 +43,10 @@ assert.equal(browser('Config[Type="Path"][Target="/app/config"]').text(), '/mnt/
 const flare = parsed.get('tracker-dashboard-flaresolverr');
 assert.equal(flare('Config[Type="Variable"][Target="HOST"]').text(), '127.0.0.1');
 
+const trawl = parsed.get('tracker-dashboard-trawl');
+assert.equal(trawl('Container > Repository').text(), 'ghcr.io/germondai/trawl:baseline');
+assert.equal(trawl('Config[Type="Variable"][Target="PORT"]').text(), '8192');
+
 const guide = fs.readFileSync(path.join(unraidDir, 'README.md'), 'utf8');
 const installer = fs.readFileSync(path.join(unraidDir, 'install-templates.sh'), 'utf8');
 assert.match(guide, /phase bêta/i);
@@ -49,4 +54,4 @@ assert.match(guide, /Retours recherchés/);
 assert.match(guide, /N'incluez jamais d'identifiants/);
 for (const name of templateNames) assert.match(installer, new RegExp(name));
 
-console.log('Unraid template checks OK: three DockerMan templates, private sidecars, installer and feedback guide.');
+console.log('Unraid template checks OK: DockerMan templates, private sidecars, installer and feedback guide.');

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -1057,16 +1057,17 @@ export async function fetchTracker(
   const attemptFlareSolverr = async (): Promise<TrackerStats | null> => {
     try {
       const solved = await fetchWithFlareSolverr(tracker, creds);
+      const provider = solved.provider === 'trawl' ? 'TRAWL' : 'FlareSolverr';
       const failed = hasBrowserAuthFailure(tracker, solved.url, solved.html);
       if (failed) {
-        console.log(`  [${tracker.name}] FlareSolverr: page non authentifiee (${failed}), repli navigateur`);
+        console.log(`  [${tracker.name}] ${provider}: page non authentifiee (${failed}), repli navigateur`);
         return null;
       }
       const stats = buildStatsFromHtml(solved.url, solved.html, solved.extraHtml);
-      console.log(`  [${tracker.name}] Lecture via FlareSolverr OK`);
+      console.log(`  [${tracker.name}] Lecture via ${provider} OK`);
       return stats;
     } catch (error) {
-      console.log(`  [${tracker.name}] FlareSolverr indisponible/echec, repli navigateur - ${error instanceof Error ? error.message : String(error)}`);
+      console.log(`  [${tracker.name}] Repli anti-bot indisponible/echec, repli navigateur - ${error instanceof Error ? error.message : String(error)}`);
       return null;
     }
   };

--- a/src/flareSolverr.ts
+++ b/src/flareSolverr.ts
@@ -5,6 +5,7 @@ import { getSshLocalEndpoint } from './sshTunnel.js';
 import { type TrackerConfig } from './types.js';
 
 const DEFAULT_FLARESOLVERR_URL = 'http://127.0.0.1:8191';
+const DEFAULT_TRAWL_URL = 'http://127.0.0.1:8192';
 
 interface FlareCookie {
   name: string;
@@ -30,11 +31,13 @@ export interface FlareSolverrFetchResult {
   html: string;
   url: string;
   extraHtml?: string;
+  provider?: 'flaresolverr' | 'trawl';
 }
 
 export interface FlareSolverrStatus {
   available: boolean;
   url: string;
+  provider?: 'flaresolverr' | 'trawl';
   version?: string;
   userAgent?: string;
   error?: string;
@@ -54,6 +57,10 @@ export function isFlareSolverrCandidate(error: unknown): boolean {
 
 function serviceUrl(override?: string): string {
   return (override || process.env.FLARESOLVERR_URL || DEFAULT_FLARESOLVERR_URL).replace(/\/+$/, '');
+}
+
+function trawlUrl(override?: string): string {
+  return (override || process.env.TRAWL_URL || DEFAULT_TRAWL_URL).replace(/\/+$/, '');
 }
 
 function resolveUrl(baseUrl: string, relativePath: string): string {
@@ -143,7 +150,26 @@ export async function fetchWithFlareSolverr(
   credentials: { username: string; password: string },
   overrides: FlareSolverrOverrides = {},
 ): Promise<FlareSolverrFetchResult> {
-  const baseUrl = serviceUrl(overrides.baseUrl);
+  return fetchWithSolver(serviceUrl(overrides.baseUrl), 'flaresolverr', tracker, credentials, overrides)
+    .catch(async (primaryError) => {
+      if (overrides.baseUrl) throw primaryError;
+      try {
+        return await fetchWithSolver(trawlUrl(), 'trawl', tracker, credentials, overrides);
+      } catch (secondaryError) {
+        const primaryMessage = primaryError instanceof Error ? primaryError.message : String(primaryError);
+        const secondaryMessage = secondaryError instanceof Error ? secondaryError.message : String(secondaryError);
+        throw new Error(`FlareSolverr indisponible/echec (${primaryMessage}); TRAWL indisponible/echec (${secondaryMessage})`);
+      }
+    });
+}
+
+async function fetchWithSolver(
+  baseUrl: string,
+  provider: 'flaresolverr' | 'trawl',
+  tracker: TrackerConfig,
+  credentials: { username: string; password: string },
+  overrides: FlareSolverrOverrides = {},
+): Promise<FlareSolverrFetchResult> {
   const requestedTimeout = overrides.timeoutMs ?? Number.parseInt(process.env.FLARESOLVERR_TIMEOUT_MS || '90000', 10);
   const timeoutMs = Number.isFinite(requestedTimeout)
     ? Math.max(5_000, Math.min(180_000, requestedTimeout))
@@ -192,23 +218,26 @@ export async function fetchWithFlareSolverr(
       html: primary.response ?? '',
       url: primary.url || primaryUrl,
       extraHtml,
+      provider,
     };
   } finally {
     await callFlareSolverr(baseUrl, { cmd: 'sessions.destroy', session: activeSession }, 15_000).catch(() => {});
   }
 }
 
-export async function getFlareSolverrStatus(baseUrlOverride?: string): Promise<FlareSolverrStatus> {
-  const url = serviceUrl(baseUrlOverride);
+async function getSolverStatus(url: string, provider: 'flaresolverr' | 'trawl'): Promise<FlareSolverrStatus> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), 5_000);
   try {
-    const response = await fetch(`${url}/`, { signal: controller.signal });
+    const response = provider === 'trawl'
+      ? await fetch(`${url}/health`, { signal: controller.signal })
+      : await fetch(`${url}/`, { signal: controller.signal });
     const data = await response.json().catch(() => ({})) as Record<string, unknown>;
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
     return {
       available: true,
       url,
+      provider,
       version: typeof data.version === 'string' ? data.version : undefined,
       userAgent: typeof data.userAgent === 'string' ? data.userAgent : undefined,
     };
@@ -217,4 +246,12 @@ export async function getFlareSolverrStatus(baseUrlOverride?: string): Promise<F
   } finally {
     clearTimeout(timer);
   }
+}
+
+export async function getFlareSolverrStatus(baseUrlOverride?: string): Promise<FlareSolverrStatus> {
+  return getSolverStatus(serviceUrl(baseUrlOverride), 'flaresolverr');
+}
+
+export async function getTrawlStatus(baseUrlOverride?: string): Promise<FlareSolverrStatus> {
+  return getSolverStatus(trawlUrl(baseUrlOverride), 'trawl');
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'url';
 import axios from 'axios';
 import { fetchTracker, invalidateAllSessions, invalidateSession } from './fetcher.js';
 import { resetBrowserProfile, closeBrowserSession, fetchRawHtmlWithBrowser, getBrowserRuntimeStatus } from './browserBackend.js';
-import { getFlareSolverrStatus } from './flareSolverr.js';
+import { getFlareSolverrStatus, getTrawlStatus } from './flareSolverr.js';
 import {
   cleanCrossSeedBaseUrl,
   detectCrossSeedInstanceIds,
@@ -3369,6 +3369,10 @@ export async function start(): Promise<void> {
 
   app.get('/api/flaresolverr/status', async (_req, res) => {
     res.json({ ok: true, status: await getFlareSolverrStatus() });
+  });
+
+  app.get('/api/trawl/status', async (_req, res) => {
+    res.json({ ok: true, status: await getTrawlStatus() });
   });
 
   app.post('/api/settings/browser-engine', (req, res) => {

--- a/unraid/README.md
+++ b/unraid/README.md
@@ -1,10 +1,11 @@
 # Templates Unraid — bêta
 
-Ce dossier fournit trois templates DockerMan pour installer Tracker Dashboard sur Unraid sans Docker Compose :
+Ce dossier fournit quatre templates DockerMan pour installer Tracker Dashboard sur Unraid sans Docker Compose :
 
 1. `tracker-dashboard` — application et WebUI ;
 2. `tracker-dashboard-browser` — runtime Playwright/Chromium/CloakBrowser requis par les trackers en mode navigateur ;
-3. `tracker-dashboard-flaresolverr` — repli anti-bot facultatif.
+3. `tracker-dashboard-flaresolverr` — repli anti-bot facultatif principal ;
+4. `tracker-dashboard-trawl` — repli anti-bot secondaire si FlareSolverr échoue.
 
 > [!IMPORTANT]
 > Ces templates sont en phase bêta. Nous recherchons des retours d'utilisateurs Unraid avant de proposer une publication dans Community Applications.
@@ -25,17 +26,18 @@ Dans **Docker → Add Container**, sélectionnez et appliquez les templates dans
 
 1. `tracker-dashboard` ;
 2. `tracker-dashboard-browser` ;
-3. `tracker-dashboard-flaresolverr`.
+3. `tracker-dashboard-flaresolverr` ;
+4. `tracker-dashboard-trawl`.
 
-Les deux sidecars utilisent `container:tracker-dashboard` : ils partagent le réseau du conteneur principal. Les ports internes `3001` et `8191` ne sont donc pas exposés sur le réseau local. Le runtime navigateur partage également le même dossier appdata `/app/config`.
+Les trois sidecars utilisent `container:tracker-dashboard` : ils partagent le réseau du conteneur principal. Les ports internes `3001`, `8191` et `8192` ne sont donc pas exposés sur le réseau local. Le runtime navigateur partage également le même dossier appdata `/app/config`.
 
 ## Ordre de démarrage
 
 Dans l'onglet **Docker** :
 
 1. déverrouillez la liste avec le cadenas ;
-2. placez les conteneurs dans l'ordre `tracker-dashboard`, `tracker-dashboard-browser`, `tracker-dashboard-flaresolverr` ;
-3. activez **AutoStart** pour les trois ;
+2. placez les conteneurs dans l'ordre `tracker-dashboard`, `tracker-dashboard-browser`, `tracker-dashboard-flaresolverr`, `tracker-dashboard-trawl` ;
+3. activez **AutoStart** pour les quatre ;
 4. en vue avancée, ajoutez si nécessaire une attente de quelques secondes après `tracker-dashboard`.
 
 Unraid démarre les conteneurs AutoStart dans l'ordre affiché et permet d'ajouter un délai entre eux : [documentation Unraid](https://docs.unraid.net/fr/unraid-os/using-unraid-to/run-docker-containers/managing-and-customizing-containers/).
@@ -50,9 +52,10 @@ Depuis le terminal Unraid :
 docker ps --filter name=tracker-dashboard
 docker exec tracker-dashboard curl -fsS http://127.0.0.1:3001/health
 docker exec tracker-dashboard curl -fsS http://127.0.0.1:8191/health
+docker exec tracker-dashboard curl -fsS http://127.0.0.1:8192/health
 ```
 
-Le runtime navigateur doit répondre `{"ok":true}`. FlareSolverr doit renvoyer une réponse HTTP valide.
+Le runtime navigateur doit répondre `{"ok":true}`. FlareSolverr et TRAWL doivent renvoyer une réponse HTTP valide.
 
 ## Retours recherchés
 
@@ -60,7 +63,7 @@ Merci d'ouvrir un [retour Unraid](https://github.com/Tracker-Dashboard/tracker-d
 
 - la version d'Unraid ;
 - l'architecture et le matériel ;
-- si les trois templates s'installent sans modification ;
+- si les quatre templates s'installent sans modification ;
 - si l'ordre AutoStart fonctionne après un redémarrage de l'array ;
 - le résultat des commandes de vérification ;
 - toute correction nécessaire dans les chemins, le réseau ou les libellés.

--- a/unraid/install-templates.sh
+++ b/unraid/install-templates.sh
@@ -11,7 +11,7 @@ fi
 
 mkdir -p "$destination"
 
-for name in tracker-dashboard tracker-dashboard-browser tracker-dashboard-flaresolverr; do
+for name in tracker-dashboard tracker-dashboard-browser tracker-dashboard-flaresolverr tracker-dashboard-trawl; do
   target="$destination/my-$name.xml"
   curl -fsSL "$base_url/$name.xml" -o "$target"
   echo "Template installé : $target"
@@ -22,3 +22,4 @@ echo "Ouvrez Docker > Add Container, puis installez les trois templates dans cet
 echo "1. tracker-dashboard"
 echo "2. tracker-dashboard-browser"
 echo "3. tracker-dashboard-flaresolverr"
+echo "4. tracker-dashboard-trawl"

--- a/unraid/tracker-dashboard-trawl.xml
+++ b/unraid/tracker-dashboard-trawl.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Container version="2">
+  <Name>tracker-dashboard-trawl</Name>
+  <Repository>ghcr.io/germondai/trawl:baseline</Repository>
+  <Registry>https://github.com/germondai/trawl/pkgs/container/trawl</Registry>
+  <Network>container:tracker-dashboard</Network>
+  <Shell>sh</Shell>
+  <Privileged>false</Privileged>
+  <Support>https://github.com/Tracker-Dashboard/tracker-dashboard/issues</Support>
+  <Project>https://github.com/germondai/trawl</Project>
+  <Overview>Sidecar TRAWL facultatif pour Tracker Dashboard. Il sert de repli anti-bot apres FlareSolverr et utilise l'image baseline pour les vieux CPU et NAS Synology.</Overview>
+  <Category>Tools:</Category>
+  <WebUI/>
+  <TemplateURL>https://raw.githubusercontent.com/Tracker-Dashboard/tracker-dashboard/main/unraid/tracker-dashboard-trawl.xml</TemplateURL>
+  <Icon>https://raw.githubusercontent.com/Tracker-Dashboard/tracker-dashboard/main/public/logo.png</Icon>
+  <ExtraParams>--restart=unless-stopped</ExtraParams>
+  <PostArgs/>
+  <Config Name="Port interne" Target="PORT" Default="8192" Mode="" Description="Conserver 8192 : FlareSolverr utilise deja 8191 dans le reseau partage de Tracker Dashboard." Type="Variable" Display="always-hide" Required="true" Mask="false">8192</Config>
+  <Config Name="Niveau de journalisation" Target="LOG_LEVEL" Default="warning" Mode="" Description="Niveau de logs TRAWL." Type="Variable" Display="advanced" Required="true" Mask="false">warning</Config>
+  <Config Name="Fuseau horaire" Target="TZ" Default="Europe/Paris" Mode="" Description="Fuseau IANA utilise par TRAWL." Type="Variable" Display="always" Required="true" Mask="false">Europe/Paris</Config>
+</Container>

--- a/unraid/tracker-dashboard.xml
+++ b/unraid/tracker-dashboard.xml
@@ -8,7 +8,7 @@
   <Privileged>false</Privileged>
   <Support>https://github.com/Tracker-Dashboard/tracker-dashboard/issues</Support>
   <Project>https://github.com/Tracker-Dashboard/tracker-dashboard</Project>
-  <Overview>WebUI de suivi des statistiques de trackers BitTorrent. Installez ensuite les templates tracker-dashboard-browser et tracker-dashboard-flaresolverr pour activer toutes les fonctions.</Overview>
+  <Overview>WebUI de suivi des statistiques de trackers BitTorrent. Installez ensuite les templates tracker-dashboard-browser, tracker-dashboard-flaresolverr et tracker-dashboard-trawl pour activer toutes les fonctions.</Overview>
   <Category>Tools:</Category>
   <WebUI>http://[IP]:[PORT:3000]</WebUI>
   <TemplateURL>https://raw.githubusercontent.com/Tracker-Dashboard/tracker-dashboard/main/unraid/tracker-dashboard.xml</TemplateURL>


### PR DESCRIPTION
﻿## Résumé
- ajoute TRAWL `ghcr.io/germondai/trawl:baseline` comme secours anti-bot après FlareSolverr
- expose le statut TRAWL dans la WebUI et ajoute le template Unraid dédié
- documente le chaînage FlareSolverr puis TRAWL, avec `baseline` recommandé pour vieux CPU/Synology sans promettre une consommation plus basse

## Validation
- `npm ci`
- `npm run build`
- `npm run check:integration`
- `git diff --check`
- smoke test local du serveur compilé sur `/` et route protégée `/api/flaresolverr/status`
