### PR TITLE
Ajoute Memphis, Oldtoons et PussyTorrents

### DIFF
--- a/config/trackers/memphis.json
+++ b/config/trackers/memphis.json
@@ -1,0 +1,35 @@
+{
+  "id": "memphis",
+  "name": "Memphis",
+  "baseUrl": "https://memphis.fit",
+  "enabled": true,
+  "login": {
+    "cookieOnly": true
+  },
+  "fetch": {
+    "url": "/",
+    "mode": "browser",
+    "responseType": "html",
+    "fields": {
+      "uploadedBytes": {
+        "regex": "id=\"user-stats\"[\\s\\S]{0,4000}?<strong[^>]*>\\s*(?<value>[\\d\\s.,]+\\s*(?:[KMGTPE](?:i?B|io|o)|B|o))\\s*</strong>\\s*<span[^>]*>\\s*(?:Upload|Envoyé|Envoye)(?: total)?\\s*</span>",
+        "transform": "bytes"
+      },
+      "downloadedBytes": {
+        "regex": "id=\"user-stats\"[\\s\\S]{0,4000}?<strong[^>]*>\\s*(?<value>[\\d\\s.,]+\\s*(?:[KMGTPE](?:i?B|io|o)|B|o))\\s*</strong>\\s*<span[^>]*>\\s*(?:Download|Téléchargé|Telecharge)(?: total)?\\s*</span>",
+        "transform": "bytes"
+      },
+      "ratio": {
+        "regex": "id=\"user-stats\"[\\s\\S]{0,4000}?<strong[^>]*>\\s*(?<value>(?:[\\d\\s.,]+|inf(?:inite|inity)?|∞))\\s*</strong>\\s*<span[^>]*>\\s*Ratio\\s*</span>",
+        "transform": "number"
+      },
+      "seedBonus": {
+        "regex": "id=\"user-stats\"[\\s\\S]{0,4000}?<strong[^>]*>\\s*(?<value>[\\d\\s.,]+)\\s*</strong>\\s*<span[^>]*>\\s*(?:Bonus|Crédits|Credits)(?: disponibles)?\\s*</span>",
+        "transform": "string"
+      }
+    }
+  },
+  "dashboard": {
+    "byteUnit": "binary"
+  }
+}

--- a/config/trackers/oldtoons.json
+++ b/config/trackers/oldtoons.json
@@ -1,0 +1,12 @@
+{
+  "id": "oldtoons",
+  "name": "Oldtoons",
+  "baseUrl": "https://oldtoons.world",
+  "enabled": true,
+  "engine": "unit3d",
+  "login": {
+    "url": "login",
+    "method": "POST",
+    "contentType": "form"
+  }
+}

--- a/config/trackers/pussytorrents.json
+++ b/config/trackers/pussytorrents.json
@@ -1,0 +1,36 @@
+{
+  "id": "pussytorrents",
+  "name": "PussyTorrents",
+  "baseUrl": "https://pussytorrents.org",
+  "enabled": true,
+  "login": {
+    "cookieOnly": true,
+    "failurePatterns": [
+      "type=\"password\"",
+      "name=\"password\"",
+      "/user/account/login"
+    ]
+  },
+  "fetch": {
+    "url": "/",
+    "mode": "browser",
+    "responseType": "html",
+    "fields": {
+      "uploadedBytes": {
+        "regex": "title=\"Uploaded\"[^>]*class=\"uploaded\"[^>]*>[\\s\\S]{0,80}?</span>\\s*(?<value>[\\d\\s.,]+\\s*(?:[KMGTPE](?:i?B|io|o)|B|o))",
+        "transform": "bytes"
+      },
+      "downloadedBytes": {
+        "regex": "title=\"Downloaded\"[^>]*class=\"downloaded\"[^>]*>[\\s\\S]{0,80}?</span>\\s*(?<value>[\\d\\s.,]+\\s*(?:[KMGTPE](?:i?B|io|o)|B|o))",
+        "transform": "bytes"
+      },
+      "ratio": {
+        "regex": ">Ratio:\\s*</span>\\s*(?<value>(?:[\\d\\s.,]+|inf(?:inite|inity)?|∞))",
+        "transform": "number"
+      }
+    }
+  },
+  "dashboard": {
+    "byteUnit": "decimal"
+  }
+}


### PR DESCRIPTION
## Résumé

- ajoute Memphis en mode navigateur avec authentification par cookies et extraction des statistiques dynamiques
- ajoute Oldtoons avec le moteur UNIT3D
- ajoute PussyTorrents en mode navigateur avec extraction de l’upload, du téléchargement et du ratio

## Validation

- `npm run build`
- `npm run check:integration`
- validation JSON des 39 définitions de trackers et contrôle de l’unicité des identifiants et URLs
- vérification hors ligne des sélecteurs Oldtoons et PussyTorrents à partir de pages authentifiées sauvegardées