### PR TITLE
Uniformiser l’affichage des points bonus

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Au premier accès, l'application demande de créer le compte administrateur de l
 
 ## Changements récents
 
+- **Points bonus uniformisés** : les séparateurs de milliers et de décimales propres à chaque tracker sont normalisés à l'affichage selon la convention française.
 - **Retrait de Torr9** : sa définition intégrée est supprimée et les anciennes installations la nettoient automatiquement au démarrage.
 - **Retrait de Nexum** : le tracker a fermé définitivement. Sa définition intégrée est supprimée et les anciennes installations la nettoient automatiquement au démarrage.
 - **Image principale allégée** : Playwright, Chromium et CloakBrowser sont regroupés dans le service parallèle `tracker-dashboard-browser`, avec état, versions et alertes de mise à jour dans la WebUI.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
-    "check:integration": "node scripts/check-integration.mjs && node scripts/check-unread-messages.mjs && node scripts/check-extra-fetch.mjs && node scripts/check-flaresolverr.mjs && node scripts/check-cross-seed.mjs && node --experimental-sqlite scripts/check-retired-trackers.mjs && node --experimental-sqlite scripts/check-timezone.mjs && node scripts/check-unraid-templates.mjs",
+    "check:integration": "node scripts/check-integration.mjs && node scripts/check-points-format.mjs && node scripts/check-unread-messages.mjs && node scripts/check-extra-fetch.mjs && node scripts/check-flaresolverr.mjs && node scripts/check-cross-seed.mjs && node --experimental-sqlite scripts/check-retired-trackers.mjs && node --experimental-sqlite scripts/check-timezone.mjs && node scripts/check-unraid-templates.mjs",
     "start": "node --experimental-sqlite dist/index.js",
     "start:browser": "node --experimental-sqlite dist/browserRuntime.js"
   },

--- a/public/index.html
+++ b/public/index.html
@@ -2895,6 +2895,62 @@
     return hasStatValue(value) ? value : '-';
   }
 
+  // Les trackers n'utilisent pas tous la meme convention pour les points :
+  // espaces ou virgules pour les milliers, virgule ou point pour les decimales.
+  // On ne modifie pas la valeur stockee ; seule sa presentation est uniformisee.
+  function parseLocalizedPoints(value) {
+    if (!hasStatValue(value)) return null;
+    if (typeof value === 'number') {
+      return Number.isFinite(value) ? { number: value, decimals: null } : null;
+    }
+    const raw = String(value)
+      .replace(/&nbsp;|&#160;|&#xa0;/gi, ' ')
+      .replace(/[\u00a0\u202f]/g, ' ')
+      .trim();
+    if (!/^[+-]?[\d\s.,]+$/.test(raw)) return null;
+
+    const compact = raw.replace(/\s/g, '');
+    const separators = [...compact.matchAll(/[.,]/g)];
+    let decimalSeparator = '';
+    let decimals = 0;
+    if (separators.length) {
+      const lastIndex = separators[separators.length - 1].index;
+      const last = compact[lastIndex];
+      const digitsAfter = compact.length - lastIndex - 1;
+      const sameSeparator = separators.every(match => match[0] === last);
+      const groupedThousands = sameSeparator
+        && digitsAfter === 3
+        && compact.split(last).slice(1).every(group => group.length === 3);
+      if (!groupedThousands) {
+        decimalSeparator = last;
+        decimals = digitsAfter;
+      }
+    }
+
+    let normalized = compact;
+    if (decimalSeparator) {
+      const decimalIndex = compact.lastIndexOf(decimalSeparator);
+      normalized = compact.slice(0, decimalIndex).replace(/[.,]/g, '')
+        + '.' + compact.slice(decimalIndex + 1).replace(/[.,]/g, '');
+    } else {
+      normalized = compact.replace(/[.,]/g, '');
+    }
+    const number = Number(normalized);
+    return Number.isFinite(number) ? { number, decimals } : null;
+  }
+
+  function formatPoints(value) {
+    const parsed = parseLocalizedPoints(value);
+    if (!parsed) return hasStatValue(value) ? value : '-';
+    const fractionDigits = parsed.decimals === null
+      ? Math.min(20, String(value).split('.')[1]?.length || 0)
+      : Math.min(20, parsed.decimals);
+    return new Intl.NumberFormat('fr-FR', {
+      minimumFractionDigits: fractionDigits,
+      maximumFractionDigits: fractionDigits,
+    }).format(parsed.number).replace(/\u202f/g, ' ');
+  }
+
   function statByteUnit(stat) {
     return stat?.byteUnit === 'decimal' ? 'decimal' : 'binary';
   }
@@ -4108,7 +4164,7 @@
     if (key === 'ratio') return Number(computedRatio(fields) || 0);
     if (key === 'buffer') return Number(fields.bufferBytes ?? fields.buffer ?? 0);
     if (key === 'seed') return Number(fields.seeding ?? fields.seedTimeDays ?? fields.seedTime ?? 0);
-    if (key === 'bonus') return Number(fields.seedBonus ?? fields.points ?? 0);
+    if (key === 'bonus') return parseLocalizedPoints(fields.seedBonus ?? fields.points)?.number ?? 0;
     return String(stat.name || stat.id || '').toLowerCase();
   }
 
@@ -4173,7 +4229,7 @@
                 <td class="num"><span class="${ratioClass(ratio)}">${hasStatValue(ratio) ? formatRatio(ratio) : '-'}</span></td>
                 <td class="num"><span class="${bufferClass(formatBuffer(fields, byteUnit))}">${buffer}</span></td>
                 <td class="num">${formatCount(fields.seeding ?? fields.seedTimeDays ?? fields.seedTime)}</td>
-                <td class="num">${formatCount(bonusRaw)}</td>
+                <td class="num">${formatPoints(bonusRaw)}</td>
                 <td>
                   <div class="beta-table-actions">
                     <button class="beta-icon-btn" onclick="openTrackerFiche('${escapeHtml(stat.id)}')" type="button">Fiche</button>
@@ -6133,7 +6189,7 @@
         return 0;
       }
       case 'seeding':  return toNum(hasStatValue(f.seeding) ? f.seeding : stat.qbitSeeding);
-      case 'bonus':    return toNum(hasStatValue(f.seedBonus) ? f.seedBonus : f.points);
+      case 'bonus':    return parseLocalizedPoints(hasStatValue(f.seedBonus) ? f.seedBonus : f.points)?.number ?? -1;
       case 'status':   return stat.status === 'error' ? 1 : 0; // erreurs regroupees
       default:         return 0;
     }
@@ -6310,7 +6366,7 @@
     const buffer = formatBuffer(f, byteUnit);
 
     const ratiolessCell1 = hasStatValue(f.points)
-      ? statCell('Points', [formatCount(f.points), 'pts'], '', '')
+      ? statCell('Points', [formatPoints(f.points), 'pts'], '', '')
       : (hasStatValue(f.seedTime)
           ? statCell('Seed 24h', formatCount(f.seedTime), '', '')
           : statCell('Points', '-', '', ''));
@@ -6321,7 +6377,7 @@
           : statCell('Taux', '-', '', ''));
     const bonusOrRequired = hasStatValue(f.requiredRatio)
       ? statCell('Req. ratio', formatRatio(f.requiredRatio), '', '')
-      : statCell('Bonus', formatCount(f.seedBonus), '', '');
+      : statCell('Bonus', formatPoints(f.seedBonus), '', '');
     const bottomCells = ratioless
       ? `${ratiolessCell1}${ratiolessCell2}`
       : `${hasStatValue(f.seedTimeDays)
@@ -6428,7 +6484,7 @@
       ? '<span class="cell-muted">—</span>'
       : (hasStatValue(f.requiredRatio)
           ? `${formatRatio(f.requiredRatio)} <span class="stat-source" title="Ratio requis">req.</span>`
-          : formatCount(bonusRaw));
+          : formatPoints(bonusRaw));
 
     const statusCell = hasProblem
       ? `<td class="cell-status" onclick="toggleIncidentEditor('${id}')">${rowStatusBadges(stat)}<span class="chevron">›</span></td>`

--- a/scripts/check-points-format.mjs
+++ b/scripts/check-points-format.mjs
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import vm from 'node:vm';
+
+const html = fs.readFileSync(new URL('../public/index.html', import.meta.url), 'utf8');
+
+function functionSource(name) {
+  const start = html.indexOf(`  function ${name}(`);
+  assert.notEqual(start, -1, `Fonction ${name} introuvable`);
+  const bodyStart = html.indexOf('{', start);
+  let depth = 0;
+  for (let index = bodyStart; index < html.length; index += 1) {
+    if (html[index] === '{') depth += 1;
+    if (html[index] === '}') depth -= 1;
+    if (depth === 0) return html.slice(start, index + 1);
+  }
+  throw new Error(`Corps de ${name} incomplet`);
+}
+
+const context = { Intl };
+vm.createContext(context);
+vm.runInContext([
+  functionSource('hasStatValue'),
+  functionSource('parseLocalizedPoints'),
+  functionSource('formatPoints'),
+].join('\n'), context);
+
+const examples = new Map([
+  ['12 345 678', '12 345 678'],
+  ['12,345,678', '12 345 678'],
+  ['123456,78', '123 456,78'],
+  ['123456.78', '123 456,78'],
+]);
+
+for (const [input, expected] of examples) {
+  assert.equal(context.formatPoints(input), expected, input);
+}
+assert.equal(context.parseLocalizedPoints('12,345,678').number, 12345678);
+assert.equal(context.parseLocalizedPoints('123456,78').number, 123456.78);
+
+console.log('Points format checks OK: thousands and decimals use the French convention.');


### PR DESCRIPTION
## Modifications

- reconnaît les séparateurs de milliers et de décimales utilisés par les différents trackers
- affiche les points bonus selon la convention française, avec des espaces pour les milliers et une virgule pour les décimales
- applique la même normalisation aux cartes, aux vues en lignes, au tableau compact et aux tris
- conserve les valeurs sources sans les modifier
- documente le comportement dans le README

## Validation

- `git diff --check`
- `npm run build`
- `npm run check:integration`
- contrôle dédié des formats `12 345 678`, `12,345,678`, `123456,78` et `123456.78`