### PR TITLE
Ajoute LeSaloon v2 et DigitalCore

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Au premier accès, l'application demande de créer le compte administrateur de l
 
 ## Changements récents
 
+- **LeSaloon v2 et DigitalCore** : ajout des deux trackers avec lecture navigateur des statistiques et authentification par cookie de session, leurs connexions étant protégées par un défi interactif ou un CAPTCHA.
 - **Points bonus uniformisés** : les séparateurs de milliers et de décimales propres à chaque tracker sont normalisés à l'affichage selon la convention française.
 - **Retrait de Torr9** : sa définition intégrée est supprimée et les anciennes installations la nettoient automatiquement au démarrage.
 - **Retrait de Nexum** : le tracker a fermé définitivement. Sa définition intégrée est supprimée et les anciennes installations la nettoient automatiquement au démarrage.

--- a/config/trackers/digitalcore.json
+++ b/config/trackers/digitalcore.json
@@ -1,0 +1,48 @@
+{
+  "id": "digitalcore",
+  "name": "DigitalCore",
+  "baseUrl": "https://digitalcore.club",
+  "enabled": true,
+  "login": {
+    "url": "login?redirect=/",
+    "method": "POST",
+    "contentType": "form",
+    "body": {},
+    "failurePatterns": [
+      "Welcome back",
+      ">Captcha<",
+      "placeholder=\"Username\""
+    ],
+    "cookieOnly": true
+  },
+  "fetch": {
+    "url": "/",
+    "mode": "browser",
+    "responseType": "html",
+    "fields": {
+      "ratio": {
+        "regex": ">Ratio:?[\\s\\S]{0,120}?>\\s*(?<value>(?:[\\d\\s.,]+|inf(?:inite|inity)?|∞|100\\+))\\s*<",
+        "transform": "number"
+      },
+      "uploadedBytes": {
+        "regex": ">UL:?[\\s\\S]{0,120}?>\\s*(?<value>[\\d\\s.,]+\\s*(?:[KMGTPE](?:i?B|io|o)|B|o))\\s*<",
+        "transform": "bytes"
+      },
+      "downloadedBytes": {
+        "regex": ">DL:?[\\s\\S]{0,120}?>\\s*(?<value>[\\d\\s.,]+\\s*(?:[KMGTPE](?:i?B|io|o)|B|o))\\s*<",
+        "transform": "bytes"
+      },
+      "bufferBytes": {
+        "regex": ">Buffer:?[\\s\\S]{0,120}?>\\s*(?<value>[\\d\\s.,]+\\s*(?:[KMGTPE](?:i?B|io|o)|B|o))\\s*<",
+        "transform": "bytes"
+      },
+      "seedBonus": {
+        "regex": ">Points:?[\\s\\S]{0,120}?>\\s*(?<value>[\\d\\s.,\\u202f]+)\\s*<",
+        "transform": "string"
+      }
+    }
+  },
+  "dashboard": {
+    "byteUnit": "binary"
+  }
+}

--- a/config/trackers/lesaloonv2.json
+++ b/config/trackers/lesaloonv2.json
@@ -1,0 +1,49 @@
+{
+  "id": "lesaloonv2",
+  "name": "LeSaloon v2",
+  "baseUrl": "https://lesaloonv2-0.net",
+  "enabled": true,
+  "login": {
+    "url": "yupy_login.php",
+    "method": "POST",
+    "contentType": "form",
+    "body": {},
+    "failurePatterns": [
+      "yupy_login.php",
+      "N'oubliez pas d'utiliser votre ADRESSE COURRIEL",
+      "CLIQUER SUR LE BOUTON DU BAS"
+    ],
+    "cookieOnly": true
+  },
+  "fetch": {
+    "url": "index.php",
+    "mode": "browser",
+    "antiBotFallback": "flaresolverr",
+    "responseType": "html",
+    "fields": {
+      "memberClass": {
+        "regex": ">Rang<[\\s\\S]{0,220}?<span[^>]*>\\s*(?:<strong[^>]*>)?\\s*(?<value>[^<]+)",
+        "transform": "string"
+      },
+      "uploadedBytes": {
+        "regex": ">Upload<[\\s\\S]{0,180}?<font[^>]*>\\s*(?<value>[\\d\\s.,]+\\s*(?:[KMGTPE](?:i?B|io|o)|B|o))",
+        "transform": "bytes"
+      },
+      "downloadedBytes": {
+        "regex": ">Download<[\\s\\S]{0,180}?<font[^>]*>\\s*(?<value>[\\d\\s.,]+\\s*(?:[KMGTPE](?:i?B|io|o)|B|o))",
+        "transform": "bytes"
+      },
+      "ratio": {
+        "regex": ">Ratio<[\\s\\S]{0,180}?<font[^>]*>\\s*(?<value>[\\d\\s.,]+)",
+        "transform": "number"
+      },
+      "seedBonus": {
+        "regex": "module=seedbonus[^>]*>[\\s\\S]{0,180}?<font[^>]*>\\s*(?<value>[\\d\\s.,]+)",
+        "transform": "string"
+      }
+    }
+  },
+  "dashboard": {
+    "byteUnit": "binary"
+  }
+}

--- a/scripts/check-integration.mjs
+++ b/scripts/check-integration.mjs
@@ -29,6 +29,8 @@ const redacted = JSON.parse(fs.readFileSync(redactedPath, 'utf8'));
 const tr4ker = JSON.parse(fs.readFileSync(tr4kerPath, 'utf8'));
 const speedapp = JSON.parse(fs.readFileSync(path.join(root, 'config', 'trackers', 'speedapp.json'), 'utf8'));
 const memphis = JSON.parse(fs.readFileSync(path.join(root, 'config', 'trackers', 'memphis.json'), 'utf8'));
+const lesaloonv2 = JSON.parse(fs.readFileSync(path.join(root, 'config', 'trackers', 'lesaloonv2.json'), 'utf8'));
+const digitalcore = JSON.parse(fs.readFileSync(path.join(root, 'config', 'trackers', 'digitalcore.json'), 'utf8'));
 const lesRescapes = JSON.parse(fs.readFileSync(lesRescapesPath, 'utf8'));
 const { applyEnginePreset } = await import('../dist/trackerTemplates.js');
 const errors = [];
@@ -98,6 +100,47 @@ const supportsAffectedTrackerLogins = (
 );
 if (!supportsAffectedTrackerLogins) {
   errors.push('SpeedApp email login, Memphis cookie-only refresh and duplicated TR4KER browser readiness must remain supported');
+}
+
+const extractorValue = (tracker, field, fixture) => {
+  const extractor = tracker.fetch?.fields?.[field];
+  return extractor?.regex
+    ? new RegExp(extractor.regex, 's').exec(fixture)?.groups?.value?.trim()
+    : undefined;
+};
+
+const lesaloonFixture = `
+  <font>Rang</font><font>[</font><span><strong>Membre VIP</strong></span><font>]</font>
+  <font>Upload</font><font>[</font><font color="green">82.17 TB</font>
+  <font>Download</font><font>[</font><font color="green">0.00 KB</font>
+  <font>Ratio</font><font>[</font><font color="green">1000</font>
+  <a href="index.php?page=modules&module=seedbonus"><font>Pièces d'or</font><font>[</font><font color="green">6,184,620.11</font></a>`;
+const digitalcoreFixture = `
+  <span>Ratio:</span><strong>100+</strong><span>UL:</span><strong>55.99 GiB</strong>
+  <span>DL:</span><strong>0 KiB</strong><span>Buffer:</span><strong>55.99 GiB</strong>
+  <dt>Points:</dt><dd>22 761,50</dd>`;
+const supportsNewCaptchaTrackers = (
+  lesaloonv2.login?.cookieOnly === true
+  && lesaloonv2.fetch?.mode === 'browser'
+  && lesaloonv2.fetch?.antiBotFallback === 'flaresolverr'
+  && extractorValue(lesaloonv2, 'memberClass', lesaloonFixture) === 'Membre VIP'
+  && extractorValue(lesaloonv2, 'uploadedBytes', lesaloonFixture) === '82.17 TB'
+  && extractorValue(lesaloonv2, 'downloadedBytes', lesaloonFixture) === '0.00 KB'
+  && extractorValue(lesaloonv2, 'ratio', lesaloonFixture) === '1000'
+  && extractorValue(lesaloonv2, 'seedBonus', lesaloonFixture) === '6,184,620.11'
+  && digitalcore.login?.cookieOnly === true
+  && digitalcore.fetch?.mode === 'browser'
+  && digitalcore.fetch?.url === '/'
+  && browserFetcher.includes("(tracker.baseId ?? tracker.id) === 'digitalcore'")
+  && browserFetcher.includes("(tracker.baseId ?? tracker.id) === 'lesaloonv2'")
+  && extractorValue(digitalcore, 'ratio', digitalcoreFixture) === '100+'
+  && extractorValue(digitalcore, 'uploadedBytes', digitalcoreFixture) === '55.99 GiB'
+  && extractorValue(digitalcore, 'downloadedBytes', digitalcoreFixture) === '0 KiB'
+  && extractorValue(digitalcore, 'bufferBytes', digitalcoreFixture) === '55.99 GiB'
+  && extractorValue(digitalcore, 'seedBonus', digitalcoreFixture) === '22 761,50'
+);
+if (!supportsNewCaptchaTrackers) {
+  errors.push('LeSaloon v2 and DigitalCore must use cookie-authenticated browser reads and parse their supplied stats layouts');
 }
 
 function normalizeRoute(route) {

--- a/src/browserFetcher.ts
+++ b/src/browserFetcher.ts
@@ -209,6 +209,36 @@ async function waitForTurnstile(page: Page): Promise<void> {
  * une coquille "non connecte" avant hydratation (cas TR4KER).
  */
 async function waitForTrackerContent(tracker: TrackerConfig, page: Page): Promise<boolean> {
+  if ((tracker.baseId ?? tracker.id) === 'digitalcore') {
+    try {
+      await page.waitForFunction(
+        () => {
+          const text = document.body?.innerText ?? '';
+          return text.includes('Ratio:') && text.includes('UL:') && text.includes('DL:') && text.includes('Buffer:');
+        },
+        null,
+        { timeout: 30_000 },
+      );
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  if ((tracker.baseId ?? tracker.id) === 'lesaloonv2') {
+    try {
+      await page.waitForFunction(
+        () => {
+          const text = document.body?.innerText ?? '';
+          return text.includes('Rang') && text.includes('Upload') && text.includes('Download') && text.includes("Pièces d'or");
+        },
+        null,
+        { timeout: 20_000 },
+      );
+      return true;
+    } catch {
+      return false;
+    }
+  }
   if (tracker.id === 'lesrescapesdeygg') {
     try {
       await page.waitForFunction(


### PR DESCRIPTION
## Résumé

- ajoute les définitions intégrées de LeSaloon v2 et DigitalCore
- lit leurs statistiques avec le runtime navigateur et des cookies de session adaptés aux défis interactifs
- ajoute un repli FlareSolverr pour le challenge Cloudflare observé sur LeSaloon v2
- attend l’hydratation des statistiques avant l’extraction et couvre les formats fournis par des tests de non-régression
- documente les deux nouveaux trackers dans le README

## Validation

- `npm run build`
- `npm run check:integration`
- `npm audit --omit=dev --audit-level=high`
- `git diff --check`
- vérification live limitée aux pages publiques via le proxy autorisé : challenge Cloudflare confirmé pour LeSaloon v2, route de connexion et CAPTCHA confirmés pour DigitalCore