### PR TITLE
Fix CrazySpirits/Memphis and add V3X

### DIFF
--- a/config/trackers/crazyspirits.json
+++ b/config/trackers/crazyspirits.json
@@ -4,7 +4,7 @@
   "baseUrl": "https://crazyspirits.com",
   "enabled": true,
   "login": {
-    "url": "account-login.php",
+    "url": "/account-login.php",
     "method": "POST",
     "contentType": "form",
     "body": {
@@ -15,17 +15,36 @@
       "type=\"password\"",
       "name=\"password\"",
       "account-login.php"
-    ]
+    ],
+    "preVisitUrls": [
+      "/account-login.php"
+    ],
+    "preStep": {
+      "url": "/account-login.php",
+      "extract": {},
+      "includeHiddenInputs": true
+    }
   },
   "fetch": {
     "url": "/",
     "mode": "browser",
     "responseType": "html",
     "fields": {
-      "downloadedBytes": { "regex": "/dl\\.png\"[\\s\\S]{0,160}?<font[^>]*>\\s*(?<value>[\\d.,]+\\s*[KMGTPE]?i?B)", "transform": "bytes" },
-      "uploadedBytes":   { "regex": "/up\\.png\"[\\s\\S]{0,160}?<font[^>]*>\\s*(?<value>[\\d.,]+\\s*[KMGTPE]?i?B)", "transform": "bytes" },
-      "seedBonus":       { "regex": "Crazy Bonus\\s*<a[^>]*>\\s*(?<value>[\\d\\s.,]+)",                              "transform": "string" }
+      "downloadedBytes": {
+        "regex": "/dl\\.png\"[\\s\\S]{0,160}?<font[^>]*>\\s*(?<value>[\\d.,]+\\s*[KMGTPE]?i?B)",
+        "transform": "bytes"
+      },
+      "uploadedBytes": {
+        "regex": "/up\\.png\"[\\s\\S]{0,160}?<font[^>]*>\\s*(?<value>[\\d.,]+\\s*[KMGTPE]?i?B)",
+        "transform": "bytes"
+      },
+      "seedBonus": {
+        "regex": "Crazy Bonus\\s*<a[^>]*>\\s*(?<value>[\\d\\s.,]+)",
+        "transform": "string"
+      }
     }
   },
-  "dashboard": { "byteUnit": "binary" }
+  "dashboard": {
+    "byteUnit": "binary"
+  }
 }

--- a/config/trackers/memphis.json
+++ b/config/trackers/memphis.json
@@ -15,19 +15,19 @@
     "responseType": "html",
     "fields": {
       "uploadedBytes": {
-        "regex": "id=\"user-stats\"[\\s\\S]{0,4000}?<strong[^>]*>\\s*(?<value>[\\d\\s.,]+\\s*(?:[KMGTPE](?:i?B|io|o)|B|o))\\s*</strong>\\s*<span[^>]*>\\s*(?:Upload|Envoyé|Envoye)(?: total)?\\s*</span>",
+        "regex": "<strong[^>]*>\\s*(?<value>[\\d\\s.,]+\\s*(?:[KMGTPE](?:i?B|io|o)|B|o))\\s*</strong>\\s*<span[^>]*>\\s*(?:Upload|Envoyé|Envoye)(?:\\s+total)?\\s*</span>",
         "transform": "bytes"
       },
       "downloadedBytes": {
-        "regex": "id=\"user-stats\"[\\s\\S]{0,4000}?<strong[^>]*>\\s*(?<value>[\\d\\s.,]+\\s*(?:[KMGTPE](?:i?B|io|o)|B|o))\\s*</strong>\\s*<span[^>]*>\\s*(?:Download|Téléchargé|Telecharge)(?: total)?\\s*</span>",
+        "regex": "<strong[^>]*>\\s*(?<value>[\\d\\s.,]+\\s*(?:[KMGTPE](?:i?B|io|o)|B|o))\\s*</strong>\\s*<span[^>]*>\\s*(?:Download|Téléchargé|Telecharge)(?:\\s+total)?\\s*</span>",
         "transform": "bytes"
       },
       "ratio": {
-        "regex": "id=\"user-stats\"[\\s\\S]{0,4000}?<strong[^>]*>\\s*(?<value>(?:[\\d\\s.,]+|inf(?:inite|inity)?|∞))\\s*</strong>\\s*<span[^>]*>\\s*Ratio\\s*</span>",
+        "regex": "<strong[^>]*>\\s*(?<value>(?:[\\d\\s.,]+|inf(?:inite|inity)?|∞))\\s*</strong>\\s*<span[^>]*>\\s*Ratio\\s*</span>",
         "transform": "number"
       },
       "seedBonus": {
-        "regex": "id=\"user-stats\"[\\s\\S]{0,4000}?<strong[^>]*>\\s*(?<value>[\\d\\s.,]+)\\s*</strong>\\s*<span[^>]*>\\s*(?:Bonus|Crédits|Credits)(?: disponibles)?\\s*</span>",
+        "regex": "<strong[^>]*>\\s*(?<value>[\\d\\s.,]+)\\s*</strong>\\s*<span[^>]*>\\s*(?:Bonus|Crédits|Credits)(?:\\s+disponibles)?\\s*</span>",
         "transform": "string"
       }
     }

--- a/config/trackers/v3x.json
+++ b/config/trackers/v3x.json
@@ -1,0 +1,57 @@
+{
+  "id": "v3x",
+  "name": "V3X",
+  "baseUrl": "https://v3x.club",
+  "enabled": true,
+  "login": {
+    "url": "/login",
+    "cookieOnly": true,
+    "failurePatterns": [
+      "href=\"/login\"",
+      ">Connexion<",
+      "Se connecter"
+    ]
+  },
+  "fetch": {
+    "url": "/activity",
+    "mode": "browser",
+    "responseType": "html",
+    "fields": {
+      "uploadedBytes": {
+        "regex": "Upload[\\s\\S]{0,300}?(?<value>[\\d\\s.,]+\\s*(?:[KMGTPE](?:i?B|io|o)|B|o))",
+        "transform": "bytes"
+      },
+      "downloadedBytes": {
+        "regex": "Download[\\s\\S]{0,300}?(?<value>[\\d\\s.,]+\\s*(?:[KMGTPE](?:i?B|io|o)|B|o))",
+        "transform": "bytes"
+      },
+      "bufferBytes": {
+        "regex": "Buffer[\\s\\S]{0,300}?(?<value>[+\\-]?[\\d\\s.,]+\\s*(?:[KMGTPE](?:i?B|io|o)|B|o))",
+        "transform": "bytes"
+      },
+      "ratio": {
+        "regex": "Ratio[\\s\\S]{0,200}?(?<value>(?:[\\d\\s.,]+|inf(?:inite|inity)?|∞))",
+        "transform": "number"
+      },
+      "seedTime": {
+        "regex": "Temps\\s+de\\s+seed[\\s\\S]{0,250}?(?<value>\\d+\\s*j(?:\\s*\\d+\\s*h)?(?:\\s*\\d+\\s*m)?)",
+        "transform": "string"
+      },
+      "points": {
+        "regex": "Points(?!\\s*/\\s*h)[\\s\\S]{0,200}?(?<value>[\\d\\s.,]+)",
+        "transform": "string"
+      },
+      "pointsPerHour": {
+        "regex": "Points\\s*/\\s*h[\\s\\S]{0,200}?(?<value>[+\\-]?[\\d\\s.,]+)",
+        "transform": "number"
+      },
+      "seeding": {
+        "regex": "[Ss]eed\\s+en\\s+cours[\\s\\S]{0,200}?(?<value>\\d+)",
+        "transform": "integer"
+      }
+    }
+  },
+  "dashboard": {
+    "byteUnit": "binary"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -4570,6 +4570,7 @@
         <div class="beta-detail-stat"><span>Ratio</span><strong>${hasStatValue(ratio) ? formatRatio(ratio) : '-'}</strong></div>
         <div class="beta-detail-stat"><span>Buffer</span><strong>${Array.isArray(buffer) ? buffer.join(' ') : buffer}</strong></div>
         <div class="beta-detail-stat"><span>Seed</span><strong>${formatCount(stat.fields.seeding ?? stat.fields.seedTimeDays ?? stat.fields.seedTime)}</strong></div>
+        ${hasStatValue(stat.fields.pointsPerHour) ? `<div class="beta-detail-stat"><span>Points / h</span><strong>${formatCount(stat.fields.pointsPerHour)}</strong></div>` : ''}
         <div class="beta-detail-stat"><span>Torrents liés</span><strong>${torrents.length}</strong></div>
         <div class="beta-detail-stat"><span>Torrents Cross-Seed</span><strong>${crossSeedTorrentCount}</strong></div>
       </div>


### PR DESCRIPTION
## Changements

### CrazySpirits
- initialise explicitement la page de connexion avant le POST ;
- recupere et reutilise les champs hidden du formulaire ;
- conserve le mode navigateur pour le fetch des statistiques.

### Memphis
- supprime la dependance fragile a `#user-stats` ;
- extrait UP/DL/ratio/bonus directement autour de leurs libelles.

### V3X
- ajoute le tracker `https://v3x.club` ;
- session par cookie + fetch navigateur de `/activity` ;
- recupere Upload, Download, Buffer, Ratio, Temps de seed, Points, Points/h et Seed en cours ;
- affiche Points/h dans la fiche detaillee lorsqu'il est disponible.
