### PR TITLE
Fix CrazySpirits/Memphis and expose V3X in tracker catalog

### DIFF
--- a/config/trackers/crazyspirits.json
+++ b/config/trackers/crazyspirits.json
@@ -5,25 +5,13 @@
   "enabled": true,
   "login": {
     "url": "/account-login.php",
-    "method": "POST",
-    "contentType": "form",
-    "body": {
-      "username": "{{username}}",
-      "password": "{{password}}"
-    },
+    "cookieOnly": true,
     "failurePatterns": [
-      "type=\"password\"",
+      "Veuillez compléter la vérification.",
+      "cf-turnstile",
       "name=\"password\"",
       "account-login.php"
-    ],
-    "preVisitUrls": [
-      "/account-login.php"
-    ],
-    "preStep": {
-      "url": "/account-login.php",
-      "extract": {},
-      "includeHiddenInputs": true
-    }
+    ]
   },
   "fetch": {
     "url": "/",

--- a/config/trackers/memphis.json
+++ b/config/trackers/memphis.json
@@ -10,33 +10,25 @@
     ]
   },
   "fetch": {
-    "url": "/",
+    "url": "/?view=profile",
     "mode": "browser",
     "responseType": "html",
     "fields": {
       "uploadedBytes": {
-        "regex": "<article[^>]*>\\s*<strong[^>]*>\\s*(?<value>[\\d\\s.,]+\\s*(?:[KMGTPE](?:i?B|io|o)|B|o))\\s*</strong>\\s*<span[^>]*>\\s*(?:Envoyé|Envoye|Upload)(?:\\s+total)?\\s*</span>",
+        "regex": "<strong[^>]*>\\s*(?<value>[\\d\\s.,]+\\s*(?:[KMGTPE](?:i?B|io|o)|B|o))\\s*</strong>\\s*<span[^>]*>\\s*Envoyé\\s*</span>",
         "transform": "bytes"
       },
       "downloadedBytes": {
-        "regex": "<article[^>]*>\\s*<strong[^>]*>\\s*(?<value>[\\d\\s.,]+\\s*(?:[KMGTPE](?:i?B|io|o)|B|o))\\s*</strong>\\s*<span[^>]*>\\s*(?:Reçu|Recu|Download|Téléchargé|Telecharge)(?:\\s+total)?\\s*</span>",
+        "regex": "<strong[^>]*>\\s*(?<value>[\\d\\s.,]+\\s*(?:[KMGTPE](?:i?B|io|o)|B|o))\\s*</strong>\\s*<span[^>]*>\\s*Reçu\\s*</span>",
         "transform": "bytes"
       },
       "ratio": {
-        "regex": "<article[^>]*>\\s*<strong[^>]*>\\s*(?<value>(?:[\\d\\s.,]+|inf(?:inite|inity)?|∞))\\s*</strong>\\s*<span[^>]*>\\s*Ratio\\s+indicatif\\s*</span>",
+        "regex": "<strong[^>]*>\\s*(?<value>(?:[\\d\\s.,]+|[Ii]nf(?:inite|inity)?|∞))\\s*</strong>\\s*<span[^>]*>\\s*Ratio\\s+indicatif\\s*</span>",
         "transform": "number"
       },
-      "seedBonus": {
-        "regex": "<article[^>]*>\\s*<strong[^>]*>\\s*(?:Crédits|Credits)\\s*</strong>\\s*<span[^>]*>\\s*(?<value>[\\d\\s.,]+)\\s*</span>",
-        "transform": "string"
-      },
       "seeding": {
-        "regex": "<button[^>]*class=\"[^\"]*account-stat[^\"]*\"[^>]*>[\\s\\S]{0,250}?<strong[^>]*>\\s*En\\s+seed\\s+actuellement\\s*</strong>\\s*<span[^>]*>\\s*(?<value>\\d+)\\s*</span>",
+        "regex": "<strong[^>]*>\\s*(?<value>\\d+)\\s*</strong>\\s*<span[^>]*>\\s*[Aa]ctifs\\s*</span>",
         "transform": "integer"
-      },
-      "seedTime": {
-        "regex": "<article[^>]*>\\s*<strong[^>]*>\\s*Seed\\s+cumulé\\s*</strong>\\s*<span[^>]*>\\s*(?<value>[\\d\\s.,]+\\s*h)\\s*</span>",
-        "transform": "string"
       }
     }
   },

--- a/config/trackers/memphis.json
+++ b/config/trackers/memphis.json
@@ -15,19 +15,27 @@
     "responseType": "html",
     "fields": {
       "uploadedBytes": {
-        "regex": "<strong[^>]*>\\s*(?<value>[\\d\\s.,]+\\s*(?:[KMGTPE](?:i?B|io|o)|B|o))\\s*</strong>\\s*<span[^>]*>\\s*(?:Upload|Envoyé|Envoye)(?:\\s+total)?\\s*</span>",
+        "regex": "<article[^>]*>\\s*<strong[^>]*>\\s*(?<value>[\\d\\s.,]+\\s*(?:[KMGTPE](?:i?B|io|o)|B|o))\\s*</strong>\\s*<span[^>]*>\\s*(?:Envoyé|Envoye|Upload)(?:\\s+total)?\\s*</span>",
         "transform": "bytes"
       },
       "downloadedBytes": {
-        "regex": "<strong[^>]*>\\s*(?<value>[\\d\\s.,]+\\s*(?:[KMGTPE](?:i?B|io|o)|B|o))\\s*</strong>\\s*<span[^>]*>\\s*(?:Download|Téléchargé|Telecharge)(?:\\s+total)?\\s*</span>",
+        "regex": "<article[^>]*>\\s*<strong[^>]*>\\s*(?<value>[\\d\\s.,]+\\s*(?:[KMGTPE](?:i?B|io|o)|B|o))\\s*</strong>\\s*<span[^>]*>\\s*(?:Reçu|Recu|Download|Téléchargé|Telecharge)(?:\\s+total)?\\s*</span>",
         "transform": "bytes"
       },
       "ratio": {
-        "regex": "<strong[^>]*>\\s*(?<value>(?:[\\d\\s.,]+|inf(?:inite|inity)?|∞))\\s*</strong>\\s*<span[^>]*>\\s*Ratio\\s*</span>",
+        "regex": "<article[^>]*>\\s*<strong[^>]*>\\s*(?<value>(?:[\\d\\s.,]+|inf(?:inite|inity)?|∞))\\s*</strong>\\s*<span[^>]*>\\s*Ratio\\s+indicatif\\s*</span>",
         "transform": "number"
       },
       "seedBonus": {
-        "regex": "<strong[^>]*>\\s*(?<value>[\\d\\s.,]+)\\s*</strong>\\s*<span[^>]*>\\s*(?:Bonus|Crédits|Credits)(?:\\s+disponibles)?\\s*</span>",
+        "regex": "<article[^>]*>\\s*<strong[^>]*>\\s*(?:Crédits|Credits)\\s*</strong>\\s*<span[^>]*>\\s*(?<value>[\\d\\s.,]+)\\s*</span>",
+        "transform": "string"
+      },
+      "seeding": {
+        "regex": "<button[^>]*class=\"[^\"]*account-stat[^\"]*\"[^>]*>[\\s\\S]{0,250}?<strong[^>]*>\\s*En\\s+seed\\s+actuellement\\s*</strong>\\s*<span[^>]*>\\s*(?<value>\\d+)\\s*</span>",
+        "transform": "integer"
+      },
+      "seedTime": {
+        "regex": "<article[^>]*>\\s*<strong[^>]*>\\s*Seed\\s+cumulé\\s*</strong>\\s*<span[^>]*>\\s*(?<value>[\\d\\s.,]+\\s*h)\\s*</span>",
         "transform": "string"
       }
     }

--- a/config/trackers/v3x.json
+++ b/config/trackers/v3x.json
@@ -2,7 +2,7 @@
   "id": "v3x",
   "name": "V3X",
   "baseUrl": "https://v3x.club",
-  "enabled": true,
+  "enabled": false,
   "login": {
     "url": "/login",
     "cookieOnly": true,

--- a/scripts/check-integration.mjs
+++ b/scripts/check-integration.mjs
@@ -290,12 +290,25 @@ if (!preservesRateLimitErrors) {
   errors.push('HTTP 429 login responses must stop fallback retries and keep their real error message');
 }
 
-const browserLoginTrackerIds = ['crazyspirits', 'lesrescapesdeygg', 'yggreborn'];
+const browserLoginTrackerIds = ['lesrescapesdeygg', 'yggreborn'];
 for (const trackerId of browserLoginTrackerIds) {
   const tracker = JSON.parse(fs.readFileSync(path.join(root, 'config', 'trackers', `${trackerId}.json`), 'utf8'));
   if (tracker.login?.cookieOnly === true || tracker.fetch?.mode !== 'browser') {
     errors.push(`${tracker.name} must allow automatic browser login`);
   }
+}
+
+const crazyspirits = JSON.parse(
+  fs.readFileSync(path.join(root, 'config', 'trackers', 'crazyspirits.json'), 'utf8'),
+);
+const crazySpiritsUsesTurnstileCookieSession = (
+  crazyspirits.login?.cookieOnly === true
+  && crazyspirits.fetch?.mode === 'browser'
+  && crazyspirits.login?.failurePatterns?.includes('cf-turnstile')
+  && crazyspirits.login?.failurePatterns?.includes('account-login.php')
+);
+if (!crazySpiritsUsesTurnstileCookieSession) {
+  errors.push('CrazySpirits must use a cookie-authenticated browser session when Turnstile is enabled');
 }
 
 const documentsCookieIpBinding = (


### PR DESCRIPTION
## Correctifs

### CrazySpirits
Le dump réel montre un Cloudflare Turnstile obligatoire (`Veuillez compléter la vérification.` + widget `cf-turnstile`).
Le tracker passe donc en `cookieOnly: true` et conserve le fetch navigateur.

### Memphis
Les extracteurs ont été adaptés au HTML réel :
- Upload : `53,6 Gio`
- Download : `0 Gio`
- Ratio : `Inf`
- Crédits : `430`
- En seed actuellement : `1`
- Seed cumulé : `920 h`