### PR TITLE
Fix bundled tracker refresh and Memphis SPA stats

### DIFF
--- a/config/trackers/memphis.json
+++ b/config/trackers/memphis.json
@@ -27,7 +27,7 @@
         "transform": "number"
       },
       "seeding": {
-        "regex": "<strong[^>]*>\\s*(?<value>\\d+)\\s*</strong>\\s*<span[^>]*>\\s*[Aa]ctifs\\s*</span>",
+        "regex": "(?:En\\s+seed\\s+actuellement\\s*</strong>\\s*<span[^>]*>|Mon\\s+empreinte\\s+de\\s+disponibilité[\\s\\S]{0,1200}?<strong[^>]*>)\\s*(?<value>\\d+)",
         "transform": "integer"
       }
     }

--- a/scripts/check-integration.mjs
+++ b/scripts/check-integration.mjs
@@ -102,6 +102,29 @@ if (!supportsAffectedTrackerLogins) {
   errors.push('SpeedApp email login, Memphis cookie-only refresh and duplicated TR4KER browser readiness must remain supported');
 }
 
+const memphisRuntimeWaitsForSpaStats = (
+  memphis.fetch?.url === '/?view=profile'
+  && memphis.fetch?.mode === 'browser'
+  && browserFetcher.includes("tracker.id === 'memphis'")
+  && browserFetcher.includes("document.querySelector('#account-health-panel')")
+  && browserFetcher.includes('/Ratio\\s+indicatif/i.test(text)')
+  && memphis.fetch?.fields?.uploadedBytes
+  && memphis.fetch?.fields?.downloadedBytes
+  && memphis.fetch?.fields?.ratio
+  && memphis.fetch?.fields?.seeding
+);
+if (!memphisRuntimeWaitsForSpaStats) {
+  errors.push('Memphis must wait for SPA profile stats before extracting ratio, traffic and seeding');
+}
+
+const refreshesBundledTrackerDefinitions = (
+  db.includes('fs.copyFileSync(source, target);')
+  && !db.includes('if (fs.existsSync(target)) continue;')
+);
+if (!refreshesBundledTrackerDefinitions) {
+  errors.push('Bundled tracker definitions must refresh existing volume copies after image updates');
+}
+
 const extractorValue = (tracker, field, fixture) => {
   const extractor = tracker.fetch?.fields?.[field];
   return extractor?.regex

--- a/src/browserFetcher.ts
+++ b/src/browserFetcher.ts
@@ -316,6 +316,28 @@ async function waitForTrackerContent(tracker: TrackerConfig, page: Page): Promis
       return false;
     }
   }
+  if (tracker.id === 'memphis') {
+    try {
+      await page.waitForFunction(
+        () => {
+          // Memphis est une SPA : le HTML initial contient les coquilles des vues,
+          // puis les statistiques du compte sont injectées après le chargement.
+          // textContent est volontairement utilisé pour détecter aussi un panneau
+          // profil encore masqué par la navigation SPA.
+          const panel = document.querySelector('#account-health-panel');
+          const text = panel?.textContent ?? document.body?.textContent ?? '';
+          return /Ratio\s+indicatif/i.test(text)
+            && /Envoyé/i.test(text)
+            && /Reçu/i.test(text);
+        },
+        null,
+        { timeout: 30_000 },
+      );
+      return true;
+    } catch {
+      return false;
+    }
+  }
   if ((tracker.baseId ?? tracker.id) !== 'tr4ker') return false;
   try {
     await page.waitForFunction(

--- a/src/db.ts
+++ b/src/db.ts
@@ -391,9 +391,15 @@ export function syncDefaultTrackerDefinitions(): void {
   const files = fs.readdirSync(DEFAULT_TRACKERS_DIR)
     .filter(file => file.endsWith('.json') && !file.endsWith('.example.json'));
   for (const file of files) {
+    const source = path.join(DEFAULT_TRACKERS_DIR, file);
     const target = path.join(trackersDir, file);
-    if (fs.existsSync(target)) continue;
-    fs.copyFileSync(path.join(DEFAULT_TRACKERS_DIR, file), target);
+
+    // Les définitions intégrées livrées dans l'image font autorité et doivent être
+    // rafraîchies à chaque démarrage. Sans cela, une ancienne copie persistée sur le
+    // volume reste figée indéfiniment (ex: V3X ajouté ensuite avec enabled=false).
+    // Les trackers personnels ne sont pas concernés : seuls les noms de fichiers
+    // présents dans DEFAULT_TRACKERS_DIR sont synchronisés ici.
+    fs.copyFileSync(source, target);
   }
 }
 


### PR DESCRIPTION
## Correctifs

### V3X / définitions intégrées

Les définitions intégrées copiées sur le volume n'étaient jamais rafraîchies lorsqu'un fichier existait déjà.

Conséquence : une installation ayant reçu une ancienne version de `v3x.json` conservait cette version après un pull/recreate et V3X pouvait rester absent de « Ajouter un tracker ».

Les fichiers provenant de `default-trackers/` sont désormais resynchronisés automatiquement vers `config/trackers/` à chaque démarrage. Les trackers personnalisés ne sont pas touchés.

### Memphis

Memphis charge les statistiques du profil de façon asynchrone dans sa SPA. Le navigateur pouvait capturer `page.content()` avant l'injection des statistiques, donnant « Aucune donnée extraite » malgré des regex valides.

Le fetch navigateur attend désormais explicitement les données du panneau profil (`Ratio indicatif`, `Envoyé`, `Reçu`) avant la capture HTML.

L'extraction du nombre en seed accepte les deux présentations observées :
- `En seed actuellement` → `1`
- `Mon empreinte de disponibilité` → `1 actifs`

## Validation

- JSON valide
- `git diff --check`
- fixtures Memphis pour les deux layouts
- contrat d'intégration ajouté pour empêcher la régression