### PR TITLE
Fix V3X missing from integrated tracker catalog

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
-    "check:integration": "node scripts/check-integration.mjs && node scripts/check-points-format.mjs && node scripts/check-unread-messages.mjs && node scripts/check-extra-fetch.mjs && node scripts/check-flaresolverr.mjs && node scripts/check-cross-seed.mjs && node --experimental-sqlite scripts/check-retired-trackers.mjs && node --experimental-sqlite scripts/check-timezone.mjs && node scripts/check-unraid-templates.mjs",
+    "check:integration": "node scripts/check-integration.mjs && node scripts/check-points-format.mjs && node scripts/check-unread-messages.mjs && node scripts/check-extra-fetch.mjs && node scripts/check-flaresolverr.mjs && node scripts/check-cross-seed.mjs && node --experimental-sqlite scripts/check-v3x-catalog.mjs && node --experimental-sqlite scripts/check-retired-trackers.mjs && node --experimental-sqlite scripts/check-timezone.mjs && node scripts/check-unraid-templates.mjs",
     "start": "node --experimental-sqlite dist/index.js",
     "start:browser": "node --experimental-sqlite dist/browserRuntime.js"
   },

--- a/scripts/check-v3x-catalog.mjs
+++ b/scripts/check-v3x-catalog.mjs
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const root = process.cwd();
+const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'tracker-dashboard-v3x-catalog-'));
+let sqlite;
+
+try {
+  fs.mkdirSync(path.join(temp, 'config', 'trackers'), { recursive: true });
+  fs.mkdirSync(path.join(temp, 'default-trackers'), { recursive: true });
+
+  // Definition actuellement correcte, embarquee dans l'image.
+  const bundledV3x = {
+    id: 'v3x',
+    name: 'V3X',
+    baseUrl: 'https://v3x.club',
+    enabled: false,
+    login: { url: '/login', cookieOnly: true, failurePatterns: ['href="/login"'] },
+    fetch: { url: '/activity', mode: 'browser', responseType: 'html', fields: {
+      ratio: { regex: 'Ratio(?<value>[0-9.]+)', transform: 'number' },
+    } },
+    dashboard: { byteUnit: 'binary' },
+  };
+  fs.writeFileSync(
+    path.join(temp, 'default-trackers', 'v3x.json'),
+    JSON.stringify(bundledV3x),
+  );
+
+  // Reproduction exacte de l'installation cassee : une ancienne ligne SQLite
+  // issue de la premiere version de V3X est restee enabled=true.
+  const oldV3x = { ...bundledV3x, enabled: true };
+  fs.writeFileSync(
+    path.join(temp, 'config', 'trackers', 'v3x.json'),
+    JSON.stringify(oldV3x),
+  );
+
+  process.chdir(temp);
+  const nonce = Date.now();
+  const db = await import(`${pathToFileURL(path.join(root, 'dist', 'db.js')).href}?v3x-db=${nonce}`);
+  const migrations = await import(`${pathToFileURL(path.join(root, 'dist', 'catalogMigrations.js')).href}?v3x-migration=${nonce}`);
+
+  db.saveTrackerConfig(oldV3x);
+  // Simule les installations qui avaient DEJA passe l'ancienne migration generale.
+  db.setJsonSetting('migration_disable_uncredentialed_default_trackers_v1', { done: true });
+
+  migrations.migrateV3xCatalogAvailability();
+
+  let stored = db.loadRawTrackerConfigsFromDb().find(config => config.id === 'v3x');
+  assert.ok(stored, 'V3X doit rester present en base');
+  assert.equal(
+    stored.enabled,
+    false,
+    'Une ancienne ligne V3X active sans credentials doit revenir dans Ajouter un tracker',
+  );
+  assert.equal(
+    db.getJsonSetting('migration_v3x_catalog_availability_v1', { done: false }).done,
+    true,
+    'La migration V3X doit etre marquee comme terminee',
+  );
+
+  // Garde de securite : si l'utilisateur a reellement configure V3X, ne jamais
+  // le desactiver lors de cette migration.
+  db.saveTrackerConfig({ ...stored, enabled: true });
+  db.setTrackerCookie('v3x', 'session=fixture');
+  db.setJsonSetting('migration_v3x_catalog_availability_v1', { done: false });
+  migrations.migrateV3xCatalogAvailability();
+
+  stored = db.loadRawTrackerConfigsFromDb().find(config => config.id === 'v3x');
+  assert.equal(
+    stored.enabled,
+    true,
+    'Un V3X configure avec un cookie doit rester actif',
+  );
+
+  sqlite = db.getDb();
+  console.log('V3X catalog migration OK: stale SQLite state is repaired without disabling configured accounts.');
+} finally {
+  sqlite?.close();
+  process.chdir(root);
+  fs.rmSync(temp, { recursive: true, force: true });
+}

--- a/src/catalogMigrations.ts
+++ b/src/catalogMigrations.ts
@@ -1,0 +1,65 @@
+import {
+  getJsonSetting,
+  hasTrackerCookie,
+  hasTrackerTotpSecret,
+  importLegacyTrackersIfNeeded,
+  listTrackerCredentialSummaries,
+  loadDefaultTrackerDefinition,
+  loadRawTrackerConfigsFromDb,
+  saveTrackerConfig,
+  setJsonSetting,
+} from './db.js';
+
+const V3X_CATALOG_MIGRATION_KEY = 'migration_v3x_catalog_availability_v1';
+
+/**
+ * Corrige les installations qui ont recu V3X pendant la courte periode ou sa
+ * definition integree etait livree avec enabled=true.
+ *
+ * Le menu « Ajouter un tracker > Tracker integre » se base sur l'etat SQLite,
+ * pas directement sur le JSON embarque. Une ancienne ligne v3x enabled=true
+ * restait donc active meme apres le passage du fichier v3x.json a enabled=false.
+ *
+ * Cette migration est volontairement ciblee et executee une seule fois :
+ * - pas de ligne V3X en base -> rien a corriger ;
+ * - V3X deja desactive -> rien a corriger ;
+ * - V3X avec credentials/cookie/TOTP -> on respecte l'activation utilisateur ;
+ * - V3X actif sans aucune configuration -> on le remet dans le catalogue.
+ */
+export function migrateV3xCatalogAvailability(): void {
+  const state = getJsonSetting(V3X_CATALOG_MIGRATION_KEY, { done: false });
+  if (state.done) return;
+
+  // Important : reproduit l'ordre de boot reel. Si une ancienne config JSON du
+  // volume doit encore etre importee dans SQLite, elle l'est AVANT la correction.
+  importLegacyTrackersIfNeeded();
+
+  const bundled = loadDefaultTrackerDefinition('v3x');
+  if (!bundled || bundled.enabled !== false) {
+    // Ne pas marquer la migration terminee si l'image courante ne contient pas
+    // encore la definition V3X attendue.
+    return;
+  }
+
+  const existing = loadRawTrackerConfigsFromDb().find(config => config.id === 'v3x');
+  if (!existing) {
+    // Sans ligne SQLite, /api/tracker-definitions considere deja V3X non actif
+    // et l'affiche dans « Ajouter un tracker ».
+    setJsonSetting(V3X_CATALOG_MIGRATION_KEY, { done: true });
+    return;
+  }
+
+  const credential = listTrackerCredentialSummaries().find(item => item.trackerId === 'v3x');
+  const configured = Boolean(
+    credential?.hasPassword
+    || hasTrackerCookie('v3x')
+    || hasTrackerTotpSecret('v3x')
+  );
+
+  if (existing.enabled !== false && !configured) {
+    saveTrackerConfig({ ...existing, enabled: false });
+    console.log('[Migration] V3X remis dans Ajouter un tracker > Tracker integre');
+  }
+
+  setJsonSetting(V3X_CATALOG_MIGRATION_KEY, { done: true });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { start } from './server.js';
+import { migrateV3xCatalogAvailability } from './catalogMigrations.js';
 
 function timestampLogs(): void {
   const stamp = () => new Date().toLocaleString('fr-FR', {
@@ -18,4 +19,5 @@ function timestampLogs(): void {
 }
 
 timestampLogs();
+migrateV3xCatalogAvailability();
 start().catch(console.error);


### PR DESCRIPTION
## Probleme

V3X a initialement ete livre avec `enabled: true`, puis corrige en `enabled: false`.

Le menu **Configuration > Ajouter un tracker > Tracker integre** filtre les definitions avec `!def.enabled`, mais `/api/tracker-definitions` derive `enabled` depuis la configuration SQLite existante. Les installations ayant conserve une ancienne ligne `v3x` active restent donc masquees, meme si le JSON embarque et le fichier du volume sont maintenant `enabled: false`.

La migration generale `migration_disable_uncredentialed_default_trackers_v1` ne corrige pas ces installations lorsqu'elle avait deja ete executee avant l'ajout de V3X.

## Correctif

- ajoute une migration unique et ciblee `migration_v3x_catalog_availability_v1` ;
- execute l'import legacy avant la correction afin de couvrir les anciennes installations ;
- remet `v3x` en `enabled: false` uniquement si une ligne SQLite active existe sans mot de passe, cookie ni TOTP ;
- conserve V3X actif s'il a reellement ete configure ;
- execute la migration avant `start()` pour que le menu et le premier refresh voient immediatement le bon etat.

## Test de non-regression

`check-v3x-catalog.mjs` reproduit explicitement :

1. une ancienne ligne SQLite `v3x enabled=true` ;
2. l'ancienne migration generale deja marquee comme terminee ;
3. la definition embarquee actuelle `enabled=false` ;
4. verification que V3X repasse en `enabled=false` ;
5. verification qu'un V3X avec cookie reste actif.