### PR TITLE
Fix V3X visibility in integrated tracker menu

### DIFF
--- a/scripts/check-v3x-catalog.mjs
+++ b/scripts/check-v3x-catalog.mjs
@@ -6,7 +6,14 @@ import { pathToFileURL } from 'node:url';
 
 const root = process.cwd();
 const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'tracker-dashboard-v3x-catalog-'));
+const serverSource = fs.readFileSync(path.join(root, 'src', 'server.ts'), 'utf8');
 let sqlite;
+
+assert.match(
+  serverSource,
+  /const enabled = definition\.id === 'v3x' && !v3xHasStoredAuth[\s\S]*?\? false[\s\S]*?: Boolean\(configuredTracker && configuredTracker\.enabled !== false\)/,
+  'L API tracker-definitions doit forcer V3X disponible tant qu aucune authentification V3X n est stockee',
+);
 
 try {
   fs.mkdirSync(path.join(temp, 'config', 'trackers'), { recursive: true });

--- a/src/server.ts
+++ b/src/server.ts
@@ -2916,15 +2916,36 @@ export async function start(): Promise<void> {
     importLegacyTrackersIfNeeded();
     trackers = normalizeTrackerConfigs();
     const configured = new Map(trackers.map(tracker => [tracker.id, tracker]));
+    const credentialSummaries = new Map(
+      listTrackerCredentialSummaries().map(credential => [credential.trackerId, credential]),
+    );
     const definitions = listAllTrackerSummaries()
       .map(definition => {
         const configuredTracker = configured.get(definition.id);
+        // V3X a ete publie initialement avec enabled=true. Certaines installations
+        // conservent donc une ancienne ligne SQLite active, meme apres mise a jour de
+        // la definition embarquee. Le menu "Ajouter un tracker > Tracker integre"
+        // se base sur CE enabled API : tant que cette ligne vaut true, V3X disparait.
+        //
+        // Pour V3X, l'etat "actif" n'est donc considere reel que si le compte a
+        // effectivement une authentification stockee. Sans mot de passe/cookie/TOTP,
+        // il doit toujours rester disponible dans le catalogue.
+        const credential = credentialSummaries.get(definition.id);
+        const v3xHasStoredAuth = definition.id === 'v3x' && Boolean(
+          credential?.hasPassword
+          || hasTrackerCookie('v3x')
+          || hasTrackerTotpSecret('v3x')
+        );
+        const enabled = definition.id === 'v3x' && !v3xHasStoredAuth
+          ? false
+          : Boolean(configuredTracker && configuredTracker.enabled !== false);
+
         // Prerequis affiches dans l'UI (badges) : resolus sur la config effective
         // (preset moteur applique), car ex. le mode browser de Gazelle vient du preset.
         const effective = configuredTracker ?? loadEffectiveTrackerDefinition(definition.id);
         return {
           ...definition,
-          enabled: Boolean(configuredTracker && configuredTracker.enabled !== false),
+          enabled,
           configured: Boolean(configuredTracker),
           isDefault: isDefaultTracker(definition.id),
           isCustom: !isDefaultTracker(definition.id),


### PR DESCRIPTION
## Correctif

Corrige directement la réponse de `/api/tracker-definitions`, qui est la source du menu :

**Configuration → Ajouter un tracker → Tracker intégré**

V3X est désormais renvoyé avec `enabled: false` tant qu'aucune authentification V3X n'est réellement enregistrée :

- aucun mot de passe ;
- aucun cookie ;
- aucun TOTP.

Cela neutralise définitivement les anciennes lignes SQLite `v3x enabled=true` créées lors de la première publication du tracker.

Lorsqu'un compte V3X est réellement configuré, son état actif normal est conservé.

## Non-régression

Le check V3X vérifie désormais également que l'API applique explicitement cette règle, et le frontend continue à alimenter le menu intégré avec `definitions.filter(def => !def.enabled)`.