### PR TITLE
Fix V3X username/password and cookie authentication

### DIFF
--- a/config/trackers/v3x.json
+++ b/config/trackers/v3x.json
@@ -5,15 +5,19 @@
   "enabled": false,
   "login": {
     "url": "/login",
-    "cookieOnly": true,
+    "method": "POST",
+    "contentType": "form",
+    "body": {
+      "identifier": "{{username}}",
+      "password": "{{password}}"
+    },
     "failurePatterns": [
-      "href=\"/login\"",
-      ">Connexion<",
-      "Se connecter"
+      "Nom d'utilisateur ou email",
+      "Mot de passe oublié"
     ]
   },
   "fetch": {
-    "url": "/activity",
+    "url": "/dashboard",
     "mode": "browser",
     "responseType": "html",
     "fields": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
-    "check:integration": "node scripts/check-integration.mjs && node scripts/check-points-format.mjs && node scripts/check-unread-messages.mjs && node scripts/check-extra-fetch.mjs && node scripts/check-flaresolverr.mjs && node scripts/check-cross-seed.mjs && node --experimental-sqlite scripts/check-v3x-catalog.mjs && node --experimental-sqlite scripts/check-retired-trackers.mjs && node --experimental-sqlite scripts/check-timezone.mjs && node scripts/check-unraid-templates.mjs",
+    "check:integration": "node scripts/check-v3x-auth.mjs && node scripts/check-integration.mjs && node scripts/check-points-format.mjs && node scripts/check-unread-messages.mjs && node scripts/check-extra-fetch.mjs && node scripts/check-flaresolverr.mjs && node scripts/check-cross-seed.mjs && node --experimental-sqlite scripts/check-v3x-catalog.mjs && node --experimental-sqlite scripts/check-retired-trackers.mjs && node --experimental-sqlite scripts/check-timezone.mjs && node scripts/check-unraid-templates.mjs",
     "start": "node --experimental-sqlite dist/index.js",
     "start:browser": "node --experimental-sqlite dist/browserRuntime.js"
   },

--- a/scripts/check-v3x-auth.mjs
+++ b/scripts/check-v3x-auth.mjs
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+const v3x = JSON.parse(fs.readFileSync('config/trackers/v3x.json', 'utf8'));
+const browserFetcher = fs.readFileSync('src/browserFetcher.ts', 'utf8');
+const server = fs.readFileSync('src/server.ts', 'utf8');
+assert.equal(v3x.login?.cookieOnly, undefined, 'V3X ne doit pas etre force en cookieOnly');
+assert.equal(v3x.login?.body?.identifier, '{{username}}');
+assert.equal(v3x.login?.body?.password, '{{password}}');
+assert.equal(v3x.fetch?.url, '/dashboard');
+assert.equal(v3x.fetch?.mode, 'browser');
+assert.match(browserFetcher, /tracker\.id === 'v3x'[\s\S]*https:\/\/api\.v3x\.club/);
+assert.match(browserFetcher, /storedCookie && !credentials\.username && !credentials\.password/);
+assert.match(server, /function storedCookieReady\(tracker: TrackerConfig\)/);
+assert.doesNotMatch(server, /cookieOnlyReady\(tracker\)/);
+console.log('V3X auth OK: username/password normal + cookie fallback + api.v3x.club cookie scope.');

--- a/src/browserFetcher.ts
+++ b/src/browserFetcher.ts
@@ -57,16 +57,19 @@ async function injectStoredCookies(tracker: TrackerConfig, context: BrowserConte
     console.warn(`[Cookies] ${tracker.id} : aucun cookie reconnu dans la valeur fournie (format invalide ?)`);
     return;
   }
-  // Injection via `url` : Playwright en deduit domaine/chemin -> robuste.
-  const url = tracker.baseUrl;
-  const cookies = parsed.map(c => ({
+  // Injection via `url` : Playwright en deduit domaine/chemin.
+  // V3X utilise `v3x_sid` sur api.v3x.club alors que l'interface vit sur v3x.club.
+  const cookieUrls = tracker.id === 'v3x'
+    ? [tracker.baseUrl, 'https://api.v3x.club']
+    : [tracker.baseUrl];
+  const cookies = parsed.flatMap(c => cookieUrls.map(url => ({
     name: c.name,
     value: c.value,
     url,
     ...(c.secure !== undefined ? { secure: c.secure } : {}),
     ...(c.httpOnly !== undefined ? { httpOnly: c.httpOnly } : {}),
     ...(c.expires !== undefined ? { expires: c.expires } : {}),
-  }));
+  })));
   try {
     await context.addCookies(cookies);
     console.log(`[Cookies] ${tracker.id} : ${cookies.length} cookie(s) injecte(s) (${parsed.map(c => c.name).join(', ')})`);
@@ -458,6 +461,16 @@ async function ensureLoggedIn(
     }
     const matched = tracker.login.failurePatterns.find(p => html.includes(p));
     throw new Error(`Session non authentifiee : page de login detectee (motif "${matched ?? '?'}") malgre le cookie injecte. Causes frequentes : session liee a l'IP (sortir par la meme IP via proxy/SSH), cookie incomplet, ou expire${suffix}`);
+  }
+
+  // Mode dual cookie + credentials : si un cookie a ete fourni sans identifiants,
+  // on ne tente pas un formulaire vide si cette session est refusee/expiree.
+  const storedCookie = overrides ? (overrides.cookie ?? '') : getTrackerCookie(tracker.id);
+  if (storedCookie && !credentials.username && !credentials.password) {
+    const currentUrl = page.url();
+    const dump = writeBrowserDump(tracker, currentUrl, html, 'cookie-session');
+    const suffix = dump ? ` - dump: ${dump}` : '';
+    throw new Error(`Cookie de session refuse ou expire ; renseigner username/password ou remplacer le cookie${suffix}`);
   }
 
   const loginUrl = resolveUrl(tracker.baseUrl, tracker.login.url);

--- a/src/server.ts
+++ b/src/server.ts
@@ -940,11 +940,11 @@ function hydrateFromSnapshots(trackers: TrackerConfig[]): TrackerConfig[] {
   return stale;
 }
 
-// Un tracker en cookie-only n'a pas forcement de mot de passe enregistre : sa
-// "credential" est le cookie de session. Sans ce cas, un tracker purement cookie
-// (cookie present, aucun mot de passe) serait rejete a tort en "Credentials manquants".
-function cookieOnlyReady(tracker: TrackerConfig): boolean {
-  return Boolean(tracker.login?.cookieOnly) && hasTrackerCookie(tracker.id);
+// Un cookie de session valide peut authentifier un tracker meme lorsque le tracker
+// accepte aussi username/password. Cela permet un vrai mode dual : credentials OU
+// cookie manuel, sans forcer `cookieOnly: true` dans la definition.
+function storedCookieReady(tracker: TrackerConfig): boolean {
+  return hasTrackerCookie(tracker.id);
 }
 
 const EMPTY_CREDENTIALS = { username: '', password: '' };
@@ -972,7 +972,7 @@ async function refresh(trackers: TrackerConfig[]): Promise<TrackerStats[]> {
     const enabledTrackers = trackers.filter(t => t.enabled !== false);
     const results = await mapWithConcurrency(enabledTrackers, REFRESH_CONCURRENCY, async tracker => {
       const creds = credentials[tracker.id];
-      if (!creds && !cookieOnlyReady(tracker)) {
+      if (!creds && !storedCookieReady(tracker)) {
         const stat: TrackerStats = {
           id:          tracker.id,
           name:        tracker.name,
@@ -1035,7 +1035,7 @@ async function refreshOneTracker(
   }
 
   const creds = loadCredentialsFromDb()[tracker.id];
-  if (!creds && !cookieOnlyReady(tracker)) {
+  if (!creds && !storedCookieReady(tracker)) {
     const stat: TrackerStats = {
       id:          tracker.id,
       name:        tracker.name,
@@ -1087,7 +1087,7 @@ async function refreshScheduledTracker(
   }
 
   const creds = loadCredentialsFromDb()[tracker.id];
-  if (!creds && !cookieOnlyReady(tracker)) {
+  if (!creds && !storedCookieReady(tracker)) {
     console.warn(`  [${tracker.name}] Refresh planifie ignore : credentials manquants`);
     return;
   }


### PR DESCRIPTION
## Correctif V3X

V3X n'est plus force en `cookieOnly`.

Le chemin normal devient username/email + mot de passe via le runtime navigateur. Le cookie manuel reste un fallback facultatif.

Le cookie V3X est injecte sur `v3x.club` et `api.v3x.club`, car `v3x_sid` est utilise par l'API.

Le backend accepte aussi un cookie stocke comme authentification pour un tracker qui supporte user/password. Si le cookie est expire et qu'aucun credential n'est present, le navigateur ne soumet plus un formulaire vide.

La lecture V3X utilise `/dashboard`, route authentifiee observee sur le site actuel.

Validation : check V3X dedie, JSON valide, `git diff --check`, aucune installation de dependances.
