### PR TITLE
Corriger le relevé des statistiques V3X

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Au premier accès, l'application demande de créer le compte administrateur de l
 
 ## Changements récents
 
+- **V3X** : les statistiques sont désormais relevées depuis la page « Mon activité », y compris le buffer, le temps de seed, les points horaires et le nombre de seeds en cours.
 - **LeSaloon v2 et DigitalCore** : ajout des deux trackers avec lecture navigateur des statistiques et authentification par cookie de session, leurs connexions étant protégées par un défi interactif ou un CAPTCHA.
 - **Points bonus uniformisés** : les séparateurs de milliers et de décimales propres à chaque tracker sont normalisés à l'affichage selon la convention française.
 - **Retrait de Torr9** : sa définition intégrée est supprimée et les anciennes installations la nettoient automatiquement au démarrage.

--- a/config/trackers/v3x.json
+++ b/config/trackers/v3x.json
@@ -17,7 +17,7 @@
     ]
   },
   "fetch": {
-    "url": "/dashboard",
+    "url": "/activity",
     "mode": "browser",
     "responseType": "html",
     "fields": {
@@ -50,7 +50,7 @@
         "transform": "number"
       },
       "seeding": {
-        "regex": "[Ss]eed\\s+en\\s+cours[\\s\\S]{0,200}?(?<value>\\d+)",
+        "regex": "[Ss]eeds?\\s+en\\s+cours[\\s\\S]{0,200}?(?<value>\\d+)",
         "transform": "integer"
       }
     }

--- a/scripts/check-integration.mjs
+++ b/scripts/check-integration.mjs
@@ -31,6 +31,7 @@ const speedapp = JSON.parse(fs.readFileSync(path.join(root, 'config', 'trackers'
 const memphis = JSON.parse(fs.readFileSync(path.join(root, 'config', 'trackers', 'memphis.json'), 'utf8'));
 const lesaloonv2 = JSON.parse(fs.readFileSync(path.join(root, 'config', 'trackers', 'lesaloonv2.json'), 'utf8'));
 const digitalcore = JSON.parse(fs.readFileSync(path.join(root, 'config', 'trackers', 'digitalcore.json'), 'utf8'));
+const v3x = JSON.parse(fs.readFileSync(path.join(root, 'config', 'trackers', 'v3x.json'), 'utf8'));
 const lesRescapes = JSON.parse(fs.readFileSync(lesRescapesPath, 'utf8'));
 const { applyEnginePreset } = await import('../dist/trackerTemplates.js');
 const errors = [];
@@ -95,7 +96,7 @@ const supportsAffectedTrackerLogins = (
   && browserFetcher.includes("(tracker.baseId ?? tracker.id) !== 'tr4ker'")
   && browserFetcher.includes('patterns: string[] = []')
   && fetcher.includes('patterns: string[] = []')
-  && server.includes('if (!creds && !cookieOnlyReady(tracker))')
+  && server.includes('if (!creds && !storedCookieReady(tracker))')
   && server.includes('fetchTrackerBounded(tracker, creds ?? EMPTY_CREDENTIALS)')
 );
 if (!supportsAffectedTrackerLogins) {
@@ -164,6 +165,31 @@ const supportsNewCaptchaTrackers = (
 );
 if (!supportsNewCaptchaTrackers) {
   errors.push('LeSaloon v2 and DigitalCore must use cookie-authenticated browser reads and parse their supplied stats layouts');
+}
+
+const v3xActivityFixture = `
+  <section><span>Upload</span><strong>79.9 Gio</strong></section>
+  <section><span>Download</span><strong>1.00 Gio</strong></section>
+  <section><span>Buffer</span><strong>+78.9 Gio</strong></section>
+  <section><span>Ratio</span><strong>79.89</strong></section>
+  <section><span>Temps de seed</span><strong>25j 21h</strong></section>
+  <section><span>Points</span><strong>52</strong></section>
+  <section><span>Points / h</span><strong>+4</strong></section>
+  <button>Seeds en cours <span>5</span></button>`;
+const supportsV3xActivityStats = (
+  v3x.fetch?.url === '/activity'
+  && v3x.fetch?.mode === 'browser'
+  && extractorValue(v3x, 'uploadedBytes', v3xActivityFixture) === '79.9 Gio'
+  && extractorValue(v3x, 'downloadedBytes', v3xActivityFixture) === '1.00 Gio'
+  && extractorValue(v3x, 'bufferBytes', v3xActivityFixture) === '+78.9 Gio'
+  && extractorValue(v3x, 'ratio', v3xActivityFixture) === '79.89'
+  && extractorValue(v3x, 'seedTime', v3xActivityFixture) === '25j 21h'
+  && extractorValue(v3x, 'points', v3xActivityFixture) === '52'
+  && extractorValue(v3x, 'pointsPerHour', v3xActivityFixture) === '+4'
+  && extractorValue(v3x, 'seeding', v3xActivityFixture) === '5'
+);
+if (!supportsV3xActivityStats) {
+  errors.push('V3X must read all supplied stats from the authenticated /activity page');
 }
 
 function normalizeRoute(route) {

--- a/scripts/check-v3x-auth.mjs
+++ b/scripts/check-v3x-auth.mjs
@@ -6,7 +6,7 @@ const server = fs.readFileSync('src/server.ts', 'utf8');
 assert.equal(v3x.login?.cookieOnly, undefined, 'V3X ne doit pas etre force en cookieOnly');
 assert.equal(v3x.login?.body?.identifier, '{{username}}');
 assert.equal(v3x.login?.body?.password, '{{password}}');
-assert.equal(v3x.fetch?.url, '/dashboard');
+assert.equal(v3x.fetch?.url, '/activity');
 assert.equal(v3x.fetch?.mode, 'browser');
 assert.match(browserFetcher, /tracker\.id === 'v3x'[\s\S]*https:\/\/api\.v3x\.club/);
 assert.match(browserFetcher, /storedCookie && !credentials\.username && !credentials\.password/);


### PR DESCRIPTION
## Résumé

- relève les statistiques V3X depuis la page authentifiée `/activity`
- prend en charge le libellé « Seeds en cours » au pluriel
- ajoute une fixture couvrant upload, download, buffer, ratio, temps de seed, points, points par heure et seeds en cours
- remet le contrat d’intégration du mode cookie en cohérence avec le runtime actuel
- documente le correctif dans les changements récents

## Validation

- `npm run build`
- `npm run check:integration`
- `git diff --check upstream/main...HEAD`