### PR TITLE
Fiabiliser la publication des images après fusion

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,6 +1,7 @@
 name: Build & Publish Docker Image
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -9,6 +10,11 @@ on:
   pull_request:
     branches:
       - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
 
 env:
   REGISTRY: ghcr.io
@@ -16,6 +22,7 @@ env:
 
 jobs:
   build-and-push:
+    if: github.event_name != 'pull_request' || github.event.action != 'closed' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -24,6 +31,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.4.0
+        with:
+          ref: ${{ (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.action == 'closed')) && 'main' || github.ref }}
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v4
@@ -38,8 +47,10 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            # latest sur chaque push sur main
-            type=raw,value=latest,enable={{is_default_branch}}
+            # latest sur push main, relance manuelle ou PR fusionnee. Le dernier cas
+            # couvre les fusions automatiques au GITHUB_TOKEN qui ne recreent pas
+            # toujours un evenement push exploitable par Actions.
+            type=raw,value=latest,enable=${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true) }}
             # tag semver si push d'un tag v*
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -57,7 +68,7 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true) }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
@@ -70,6 +81,7 @@ jobs:
 
   build-and-push-browser:
     name: Runtime navigateur (tracker-dashboard-browser)
+    if: github.event_name != 'pull_request' || github.event.action != 'closed' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -78,6 +90,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.4.0
+        with:
+          ref: ${{ (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.action == 'closed')) && 'main' || github.ref }}
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v4
@@ -92,7 +106,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/tracker-dashboard/tracker-dashboard-browser
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true) }}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha,prefix=sha-
@@ -109,7 +123,7 @@ jobs:
           context: .
           file: ./Dockerfile.browser
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true) }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |


### PR DESCRIPTION
## Résumé

- ajoute un déclenchement manuel au workflow de publication Docker
- publie aussi les images lorsqu’une pull request interne est fermée après fusion
- conserve les builds sans publication pour les pull requests ouvertes
- force le checkout de `main` pour les publications post-fusion et manuelles

## Validation

- chargement YAML réussi
- `git diff --check`
- vérification des conditions de publication pour `push`, `workflow_dispatch` et `pull_request.closed` fusionnée