### PR TITLE
Corriger le démarrage des trackers avec navigateur

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,9 @@ Des templates Unraid sont disponibles pour installer séparément l'application,
 
 Le navigateur (Playwright/Chromium/CloakBrowser) est externalisé dans l'image `ghcr.io/tracker-dashboard/tracker-dashboard-browser:latest`. L'image principale reste allégée.
 
-Si vous gérez Tracker Dashboard avec Compose, ajoutez une petite stack parallèle pour le runtime navigateur :
+Le fichier `docker-compose.yml` fourni inclut déjà ce runtime. Au démarrage, l'application attend sa disponibilité pendant 30 secondes maximum avant de rafraîchir les trackers en `mode: browser`. Ce délai peut être ajusté avec `BROWSER_RUNTIME_BOOT_WAIT_MS` sur le service principal.
+
+Pour une stack Compose existante qui ne contient pas encore le runtime, ajoutez ce service :
 
 ```yaml
 services:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,19 @@ services:
     volumes:
       - ./config:/app/config
 
+  tracker-dashboard-browser:
+    image: ghcr.io/tracker-dashboard/tracker-dashboard-browser:latest
+    container_name: tracker-dashboard-browser
+    restart: unless-stopped
+    network_mode: "service:tracker-dashboard"
+    volumes_from:
+      - tracker-dashboard
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:3001/health').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+
   tracker-dashboard-flaresolverr:
     image: ghcr.io/flaresolverr/flaresolverr:latest
     container_name: tracker-dashboard-flaresolverr

--- a/src/server.ts
+++ b/src/server.ts
@@ -911,6 +911,24 @@ async function fetchTrackerBounded(
 
 // Fenetre de fraicheur au boot : en dessous, on ressert la base sans re-scraper.
 const BOOT_FRESH_HOURS = Math.max(0, Number(process.env.BOOT_FRESH_HOURS) || 24);
+const browserBootWaitValue = Number(process.env.BROWSER_RUNTIME_BOOT_WAIT_MS ?? 30_000);
+const BROWSER_RUNTIME_BOOT_WAIT_MS = Number.isFinite(browserBootWaitValue)
+  ? Math.max(0, browserBootWaitValue)
+  : 30_000;
+
+async function waitForBrowserRuntimeAtBoot(): Promise<boolean> {
+  const deadline = Date.now() + BROWSER_RUNTIME_BOOT_WAIT_MS;
+  let firstAttempt = true;
+  while (firstAttempt || Date.now() < deadline) {
+    firstAttempt = false;
+    const status = await getBrowserRuntimeStatus();
+    if (status.available) return true;
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) break;
+    await new Promise(resolve => setTimeout(resolve, Math.min(1_000, remaining)));
+  }
+  return false;
+}
 
 /**
  * Au demarrage : remplit cachedStats avec le dernier snapshot OK de chaque tracker
@@ -3659,7 +3677,19 @@ export async function start(): Promise<void> {
     console.log(`Boot: ${servedFromCache} tracker(s) servis depuis la base (< ${BOOT_FRESH_HOURS}h), aucun scraping au demarrage`);
   } else {
     console.log(`Boot: ${servedFromCache} tracker(s) servis depuis la base, ${staleTrackers.length} obsolete(s)/absent(s) a rafraichir`);
-    await refresh(staleTrackers);
+    const browserTrackers = staleTrackers.filter(tracker => tracker.fetch.mode === 'browser');
+    const otherTrackers = staleTrackers.filter(tracker => tracker.fetch.mode !== 'browser');
+    if (otherTrackers.length > 0) await refresh(otherTrackers);
+    if (browserTrackers.length > 0) {
+      console.log(`Boot: attente du runtime navigateur pour ${browserTrackers.length} tracker(s) (maximum ${BROWSER_RUNTIME_BOOT_WAIT_MS} ms)`);
+      const runtimeReady = await waitForBrowserRuntimeAtBoot();
+      if (runtimeReady) {
+        console.log('Boot: runtime navigateur disponible, rafraichissement des trackers navigateur');
+      } else {
+        console.warn('Boot: runtime navigateur toujours indisponible apres le delai, tentative de rafraichissement maintenue');
+      }
+      await refresh(browserTrackers);
+    }
   }
 
   // Recuperation des logos au demarrage (non bloquant). NON force : on ne telecharge


### PR DESCRIPTION
## Résumé

- inclut `tracker-dashboard-browser` dans le Compose officiel avec un contrôle de santé
- attend jusqu’à 30 secondes la disponibilité du runtime avant le premier rafraîchissement des trackers navigateur
- laisse les trackers HTTP démarrer immédiatement et conserve une tentative après expiration du délai
- documente le délai configurable `BROWSER_RUNTIME_BOOT_WAIT_MS`

## Validation

- `npm run build`
- `npm run check:integration`
- `docker compose config`
- `git diff --check`