### PR TITLE
Préciser la configuration du cookie V3X

### DIFF
--- a/config/trackers/v3x.json
+++ b/config/trackers/v3x.json
@@ -14,7 +14,8 @@
     "failurePatterns": [
       "Nom d'utilisateur ou email",
       "Mot de passe oublié"
-    ]
+    ],
+    "cookieInstructions": "V3X nécessite un cookie de session valide. Connecte-toi sur v3x.club avec la même IP de sortie que ce tracker, puis copie le cookie sous la forme v3x_sid=VALEUR. Ne partage jamais cette valeur : elle donne accès à ta session. Renouvelle-la si le message « session navigateur non authentifiée » apparaît."
   },
   "fetch": {
     "url": "/activity",

--- a/public/index.html
+++ b/public/index.html
@@ -6649,12 +6649,16 @@
     const isEnabled = Boolean(definition.enabled);
     const safeId = escapeHtml(definition.id);
     const cookieOnly = Boolean(credential.cookieOnly || definition.requiresCookie);
+    const cookieInstructions = definition.cookieInstructions
+      ? `<p class="beta-note" style="margin:0 0 7px"><b>Pour ce tracker :</b> ${escapeHtml(definition.cookieInstructions)}</p>`
+      : '';
     const statusBadge = cookieOnly
       ? `<span class="credential-badge ${credential.hasCookie ? 'credential-ok' : 'credential-missing'}">${credential.hasCookie ? 'Cookie OK' : 'Cookie requis'}</span>`
       : `<span class="credential-badge ${credential.hasPassword ? 'credential-ok' : 'credential-missing'}">${credential.hasPassword ? 'Configuré' : 'Manquant'}</span>`;
     // Bloc cookie de session : champ principal pour un tracker cookie-only (les
     // identifiants sont masqués, inutiles), sinon rangé dans Options avancées.
     const cookieFieldHtml = `
+                      ${cookieInstructions}
                       <div class="advanced-cookie-row">
                         <textarea class="tracker-input" id="credential-cookie-${safeId}" autocomplete="off" rows="3" spellcheck="false" style="flex:1; resize:vertical; font-family:monospace; font-size:11px; white-space:pre"
                           placeholder="${credential.hasCookie ? '•••••••• (enregistré — colle pour remplacer, vide pour effacer)' : 'Colle ici un fichier cookies.txt (Netscape), un export JSON Cookie-Editor, ou nom=valeur; nom2=valeur2'}"
@@ -6690,6 +6694,11 @@
                 <div class="definition-actions">
                   <button class="btn-test" style="padding:6px 10px" onclick="resetCredential('${safeId}')">Réinitialiser</button>
                 </div>
+                ${!cookieOnly && cookieInstructions ? `
+                <div class="tracker-field" style="grid-column:1/-1">
+                  <label>Cookie de session <span style="color:var(--muted)">— recommandé pour ${escapeHtml(definition.name)}${credential.hasCookie ? ' · <b style="color:var(--green)">défini</b>' : ''}</span></label>
+                  ${cookieFieldHtml}
+                </div>` : ''}
                 <div class="definition-actions">
                   <button class="btn-test" style="padding:6px 10px" onclick="setTrackerEnabled('${safeId}', ${isEnabled ? 'false' : 'true'})">${isEnabled ? 'Retirer' : 'Ajouter'}</button>
                 </div>
@@ -6706,7 +6715,7 @@
                 <details class="definition-advanced" style="grid-column:1/-1">
                   <summary>Options avancées${credential.hasCookie ? ' · <b style="color:var(--green)">cookie défini</b>' : ''}${credential.hasTotp ? ' · <b style="color:var(--green)">2FA défini</b>' : ''}</summary>
                   <div class="definition-advanced-body">
-                    ${cookieOnly ? `
+                    ${cookieOnly || cookieInstructions ? `
                     <div class="advanced-field advanced-cookie-field">
                       <p class="beta-note" style="margin-top:0"><b>Important :</b> exporte tous les cookies avec la même IP de sortie que celle utilisée par ce tracker dans Tracker Dashboard (même proxy, ou même connexion directe). Vérifie notamment que <code>cf_clearance</code> est présent pour les sites protégés par Cloudflare ; les sessions liées à l’IP et les cookies anti-bot seront sinon refusés.</p>
                     </div>` : `

--- a/src/server.ts
+++ b/src/server.ts
@@ -421,6 +421,9 @@ function sanitizeTrackerConfigInput(
     failurePatterns,
   };
   if (cookieOnly) loginOut.cookieOnly = true;
+  if (String(login.cookieInstructions ?? '').trim()) {
+    loginOut.cookieInstructions = String(login.cookieInstructions).trim().slice(0, 1_000);
+  }
   if (String(login.postUrl ?? '').trim()) loginOut.postUrl = String(login.postUrl).trim();
   if (String(login.otpField ?? '').trim()) loginOut.otpField = String(login.otpField).trim();
   if (String(login.csrfHeader ?? '').trim()) loginOut.csrfHeader = String(login.csrfHeader).trim();
@@ -2970,6 +2973,7 @@ export async function start(): Promise<void> {
           baseId: configuredTracker?.baseId ?? definition.baseId,
           requiresCookie: Boolean(effective?.login?.cookieOnly),
           requiresBrowser: effective?.fetch?.mode === 'browser',
+          cookieInstructions: effective?.login?.cookieInstructions,
         };
       })
       .sort((a, b) => a.name.localeCompare(b.name, 'fr', { sensitivity: 'base' }));

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,6 +100,8 @@ export interface LoginConfig {
    * les sites qui plafonnent/bloquent les logins automatises (ex: MyAnonamouse).
    */
   cookieOnly?: boolean;
+  /** Consigne affichée dans la configuration pour récupérer le bon cookie de session. */
+  cookieInstructions?: string;
 }
 
 export interface FieldExtractor {


### PR DESCRIPTION
## Résumé

- affiche le champ cookie directement dans la configuration de V3X
- précise le format `v3x_sid=VALEUR` et la nécessité de conserver la même IP de sortie
- avertit que le cookie est secret et doit être renouvelé lorsque la session navigateur expire
- conserve le parcours par identifiant et mot de passe avec le cookie comme repli

## Validation

- `npm run build`
- `npm run check:integration`
- `git diff --check`