### PR TITLE
Corrige la détection 2FA HD-Forever

### DIFF
--- a/scripts/check-integration.mjs
+++ b/scripts/check-integration.mjs
@@ -32,6 +32,7 @@ const memphis = JSON.parse(fs.readFileSync(path.join(root, 'config', 'trackers',
 const lesaloonv2 = JSON.parse(fs.readFileSync(path.join(root, 'config', 'trackers', 'lesaloonv2.json'), 'utf8'));
 const digitalcore = JSON.parse(fs.readFileSync(path.join(root, 'config', 'trackers', 'digitalcore.json'), 'utf8'));
 const v3x = JSON.parse(fs.readFileSync(path.join(root, 'config', 'trackers', 'v3x.json'), 'utf8'));
+const hdforever = JSON.parse(fs.readFileSync(path.join(root, 'config', 'trackers', 'hdforever.json'), 'utf8'));
 const lesRescapes = JSON.parse(fs.readFileSync(lesRescapesPath, 'utf8'));
 const { applyEnginePreset } = await import('../dist/trackerTemplates.js');
 const errors = [];
@@ -195,6 +196,19 @@ const supportsV3xActivityStats = (
 );
 if (!supportsV3xActivityStats) {
   errors.push('V3X must read all supplied stats from the authenticated /activity page');
+}
+
+const hdfOtpDetectionIsSpecific = (
+  hdforever.login?.otpStep?.field === 'otp_code'
+  && hdforever.login?.otpStep?.action === 'login.php?act=otp'
+  && fetcher.includes('function isOtpStepPage')
+  && fetcher.includes('if (!landedUrl.includes(otpStep.urlContains)) return false')
+  && fetcher.includes('input[name="${otpStep.field}"]')
+  && fetcher.includes('[?&]act=otp')
+  && !fetcher.includes('} else if (cfg.otpStep && landedUrl.includes(cfg.otpStep.urlContains))')
+);
+if (!hdfOtpDetectionIsSpecific) {
+  errors.push('HD-Forever otpStep must require a real OTP marker, not just login.php in the landed URL');
 }
 
 function normalizeRoute(route) {

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -12,6 +12,7 @@ import {
   type TrackerStats,
   type FieldExtractor,
   type Credentials,
+  type LoginConfig,
 } from './types.js';
 import { getProxyConfig, ensureProxyReady } from './proxy.js';
 import { closeAllSshTunnels } from './sshTunnel.js';
@@ -517,6 +518,15 @@ function extractFormAction(html: string): string {
   return m?.[1] ?? '';
 }
 
+function isOtpStepPage(html: string, landedUrl: string, otpStep: NonNullable<LoginConfig['otpStep']>): boolean {
+  if (!landedUrl.includes(otpStep.urlContains)) return false;
+  const $ = cheerio.load(html);
+  if ($(`input[name="${otpStep.field}"]`).length > 0) return true;
+  if (/[?&]act=otp(?:&|$)/i.test(landedUrl)) return true;
+  const action = extractFormAction(html);
+  return action ? /(?:^|[?&])act=otp(?:&|$)/i.test(action) : false;
+}
+
 // Page anti-bot / challenge JS (Cloudflare & co) : signaux frequents quand l'IP du
 // client est filtree -> la vraie page (avec le token CSRF) n'est jamais servie.
 export function isAntiBotPage(html: string): boolean {
@@ -861,7 +871,7 @@ async function doLogin(
       await storeResponseCookies(jar, after2faRes);
       verificationHtml = after2faRes.data;
     }
-  } else if (cfg.otpStep && landedUrl.includes(cfg.otpStep.urlContains)) {
+  } else if (cfg.otpStep && isOtpStepPage(verificationHtml, landedUrl, cfg.otpStep)) {
     // ── 3ter. 2FA via page dediee apres le login ──────────────────────────────
     if (!vars.otp) {
       const dumpPath = writeLoginDebugDump(tracker, landedUrl, verificationHtml, { reason: 'otpStep-no-secret' });
@@ -894,7 +904,7 @@ async function doLogin(
       await storeResponseCookies(jar, afterOtpRes);
       verificationHtml = afterOtpRes.data;
     }
-    if (landedUrl.includes(cfg.otpStep.urlContains)) {
+    if (isOtpStepPage(verificationHtml, landedUrl, cfg.otpStep)) {
       const dumpPath = writeLoginDebugDump(tracker, landedUrl, verificationHtml, {
         reason: 'otpStep-2fa-refusee',
         otp: vars.otp,


### PR DESCRIPTION
## Résumé
- limite `otpStep` aux pages qui exposent réellement le champ OTP ou une action `act=otp`
- évite de traiter une simple URL `login.php` comme une demande 2FA
- conserve le flux TOTP automatique pour les comptes HD-Forever avec 2FA actif
- ajoute un garde d’intégration contre le faux positif sans champ OTP

Fixes #176

## Validation
- `npm run build`
- `npm run check:integration`
- `git diff --check upstream/main...HEAD`