### PR TITLE
Corrige le login API navigateur V3X

### DIFF
--- a/config/trackers/v3x.json
+++ b/config/trackers/v3x.json
@@ -23,31 +23,31 @@
     "responseType": "html",
     "fields": {
       "uploadedBytes": {
-        "regex": "Upload[\\s\\S]{0,80}?</span>\\s*<span[^>]*\\bfont-mono\\b[^>]*>\\s*(?<value>[\\d\\s.,]+\\s*(?:[KMGTPE](?:i?B|io|o)|B|o))",
+        "regex": "[Uu][Pp][Ll][Oo][Aa][Dd][\\s\\S]{0,80}?</span>\\s*<span[^>]*\\bfont-mono\\b[^>]*>\\s*(?<value>[\\d\\s.,]+\\s*(?:[KMGTPE](?:i?B|io|o)|B|o))",
         "transform": "bytes"
       },
       "downloadedBytes": {
-        "regex": "Download[\\s\\S]{0,80}?</span>\\s*<span[^>]*\\bfont-mono\\b[^>]*>\\s*(?<value>[\\d\\s.,]+\\s*(?:[KMGTPE](?:i?B|io|o)|B|o))",
+        "regex": "[Dd][Oo][Ww][Nn][Ll][Oo][Aa][Dd][\\s\\S]{0,80}?</span>\\s*<span[^>]*\\bfont-mono\\b[^>]*>\\s*(?<value>[\\d\\s.,]+\\s*(?:[KMGTPE](?:i?B|io|o)|B|o))",
         "transform": "bytes"
       },
       "bufferBytes": {
-        "regex": "Buffer[\\s\\S]{0,80}?</span>\\s*<span[^>]*\\bfont-mono\\b[^>]*>\\s*(?<value>[+\\-−]?[\\d\\s.,]+\\s*(?:[KMGTPE](?:i?B|io|o)|B|o))",
+        "regex": "[Bb][Uu][Ff][Ff][Ee][Rr][\\s\\S]{0,80}?</span>\\s*<span[^>]*\\bfont-mono\\b[^>]*>\\s*(?<value>[+\\-−]?[\\d\\s.,]+\\s*(?:[KMGTPE](?:i?B|io|o)|B|o))",
         "transform": "bytes"
       },
       "ratio": {
-        "regex": "Ratio[\\s\\S]{0,80}?</span>\\s*<span[^>]*\\bfont-mono\\b[^>]*>\\s*(?<value>(?:[\\d\\s.,]+|inf(?:inite|inity)?|∞))",
+        "regex": "[Rr][Aa][Tt][Ii][Oo][\\s\\S]{0,80}?</span>\\s*<span[^>]*\\bfont-mono\\b[^>]*>\\s*(?<value>(?:[\\d\\s.,]+|inf(?:inite|inity)?|∞))",
         "transform": "number"
       },
       "seedTime": {
-        "regex": "Temps\\s+de\\s+seed[\\s\\S]{0,80}?</span>\\s*<span[^>]*\\bfont-mono\\b[^>]*>\\s*(?<value>\\d+\\s*j(?:\\s*\\d+\\s*h)?(?:\\s*\\d+\\s*m)?)",
+        "regex": "[Tt][Ee][Mm][Pp][Ss]\\s+[Dd][Ee]\\s+[Ss][Ee][Ee][Dd][\\s\\S]{0,80}?</span>\\s*<span[^>]*\\bfont-mono\\b[^>]*>\\s*(?<value>\\d+\\s*j(?:\\s*\\d+\\s*h)?(?:\\s*\\d+\\s*m)?)",
         "transform": "string"
       },
       "points": {
-        "regex": "Points(?!\\s*/\\s*h)[\\s\\S]{0,80}?</span>\\s*<span[^>]*\\bfont-mono\\b[^>]*>\\s*(?<value>[\\d\\s.,]+)",
+        "regex": "[Pp][Oo][Ii][Nn][Tt][Ss](?!\\s*/\\s*[Hh])[\\s\\S]{0,80}?</span>\\s*<span[^>]*\\bfont-mono\\b[^>]*>\\s*(?<value>[\\d\\s.,]+)",
         "transform": "string"
       },
       "pointsPerHour": {
-        "regex": "Points\\s*/\\s*h[\\s\\S]{0,80}?</span>\\s*<span[^>]*\\bfont-mono\\b[^>]*>\\s*(?<value>[+\\-]?[\\d\\s.,]+)",
+        "regex": "[Pp][Oo][Ii][Nn][Tt][Ss]\\s*/\\s*[Hh][\\s\\S]{0,80}?</span>\\s*<span[^>]*\\bfont-mono\\b[^>]*>\\s*(?<value>[+\\-]?[\\d\\s.,]+)",
         "transform": "number"
       },
       "seeding": {

--- a/scripts/check-integration.mjs
+++ b/scripts/check-integration.mjs
@@ -182,6 +182,15 @@ const v3xActivityFixture = `
   ${v3xStatCard('Points', '52')}
   ${v3xStatCard('Points / h', '+4')}
   <button class="px-4 py-2 text-sm"><span><svg width="14"><path d="M2 20"></path></svg></span>Seeds en cours<span class="px-1.5 py-0.5 text-[10px]">5</span></button>`;
+const v3xUppercaseActivityFixture = `
+  ${v3xStatCard('UPLOAD', '84.8 Gio')}
+  ${v3xStatCard('DOWNLOAD', '1.00 Gio')}
+  ${v3xStatCard('BUFFER', '+83.8 Gio')}
+  ${v3xStatCard('RATIO', '84.76')}
+  ${v3xStatCard('TEMPS DE SEED', '48j 3h')}
+  ${v3xStatCard('POINTS', '74')}
+  ${v3xStatCard('POINTS / H', '+5')}
+  <button class="px-4 py-2 text-sm"><span><svg width="14"><path d="M2 20"></path></svg></span>Seeds en cours<span class="px-1.5 py-0.5 text-[10px]">5</span></button>`;
 const supportsV3xActivityStats = (
   v3x.fetch?.url === '/activity'
   && v3x.fetch?.mode === 'browser'
@@ -193,6 +202,13 @@ const supportsV3xActivityStats = (
   && extractorValue(v3x, 'points', v3xActivityFixture) === '52'
   && extractorValue(v3x, 'pointsPerHour', v3xActivityFixture) === '+4'
   && extractorValue(v3x, 'seeding', v3xActivityFixture) === '5'
+  && extractorValue(v3x, 'uploadedBytes', v3xUppercaseActivityFixture) === '84.8 Gio'
+  && extractorValue(v3x, 'downloadedBytes', v3xUppercaseActivityFixture) === '1.00 Gio'
+  && extractorValue(v3x, 'bufferBytes', v3xUppercaseActivityFixture) === '+83.8 Gio'
+  && extractorValue(v3x, 'ratio', v3xUppercaseActivityFixture) === '84.76'
+  && extractorValue(v3x, 'seedTime', v3xUppercaseActivityFixture) === '48j 3h'
+  && extractorValue(v3x, 'points', v3xUppercaseActivityFixture) === '74'
+  && extractorValue(v3x, 'pointsPerHour', v3xUppercaseActivityFixture) === '+5'
 );
 if (!supportsV3xActivityStats) {
   errors.push('V3X must read all supplied stats from the authenticated /activity page');

--- a/scripts/check-v3x-auth.mjs
+++ b/scripts/check-v3x-auth.mjs
@@ -16,6 +16,11 @@ assert.match(browserFetcher, /document\.querySelector\('input\[name="login"\]'\)
 assert.match(browserFetcher, /document\.querySelector\('input\[name="password"\]'\)/);
 assert.match(browserFetcher, /document\.querySelector\('button\[type="submit"\]'\)/);
 assert.match(browserFetcher, /Login V3X echoue/);
+assert.match(browserFetcher, /function submitV3xApiLogin/);
+assert.match(browserFetcher, /https:\/\/api\.v3x\.club\/auth\/login/);
+assert.match(browserFetcher, /JSON\.stringify\(\{ login: username, password, remember: true \}\)/);
+assert.match(browserFetcher, /session API acceptee mais activite non authentifiee/);
+assert.match(fs.readFileSync('src/fetcher.ts', 'utf8'), /if \(tracker\.id === 'v3x'\) return null/);
 assert.match(server, /function storedCookieReady\(tracker: TrackerConfig\)/);
 assert.doesNotMatch(server, /cookieOnlyReady\(tracker\)/);
 console.log('V3X auth OK: username/password normal + cookie fallback + api.v3x.club cookie scope.');

--- a/src/browserFetcher.ts
+++ b/src/browserFetcher.ts
@@ -300,12 +300,12 @@ async function waitForTrackerContent(tracker: TrackerConfig, page: Page): Promis
           );
           if (hasLoginForm) return false;
           const text = document.body?.innerText ?? '';
-          return text.includes('Upload')
-            && text.includes('Download')
-            && text.includes('Buffer')
-            && text.includes('Ratio')
-            && text.includes('Temps de seed')
-            && text.includes('Points / h')
+          return /Upload/i.test(text)
+            && /Download/i.test(text)
+            && /Buffer/i.test(text)
+            && /Ratio/i.test(text)
+            && /Temps de seed/i.test(text)
+            && /Points\s*\/\s*h/i.test(text)
             && text.includes('Seeds en cours');
         },
         null,
@@ -451,6 +451,75 @@ function extractV3xLoginError(html: string): string | null {
   return null;
 }
 
+async function submitV3xApiLogin(
+  tracker: TrackerConfig,
+  credentials: { username: string; password: string },
+  page: Page,
+): Promise<void> {
+  const result = await page.evaluate(
+    async ({ username, password }) => {
+      try {
+        const response = await fetch('https://api.v3x.club/auth/login', {
+          method: 'POST',
+          credentials: 'include',
+          headers: {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ login: username, password, remember: true }),
+        });
+        let data: Record<string, unknown> | null = null;
+        try {
+          data = await response.json();
+        } catch {
+          data = null;
+        }
+        return {
+          ok: response.ok,
+          status: response.status,
+          error: typeof data?.error === 'string' ? data.error : '',
+          details: typeof data?.details === 'string' ? data.details : '',
+          hasUser: Boolean(data?.id || data?.username),
+        };
+      } catch (err) {
+        return {
+          ok: false,
+          status: 0,
+          error: err instanceof Error ? err.message : String(err),
+          details: '',
+          hasUser: false,
+        };
+      }
+    },
+    credentials,
+  );
+
+  if (!result.ok || !result.hasUser) {
+    const currentUrl = page.url();
+    const html = await safeContent(page);
+    const dump = writeBrowserDump(tracker, currentUrl, html, 'login-refused');
+    const suffix = dump ? ` - dump: ${dump}` : '';
+    const detail = result.error || result.details
+      ? ` : ${[result.error, result.details].filter(Boolean).join(' - ')}`
+      : ` : API login status ${result.status}`;
+    throw new Error(`Login V3X echoue${detail}${suffix}`);
+  }
+
+  await page.goto(resolveUrl(tracker.baseUrl, tracker.fetch.url), { waitUntil: 'commit', timeout: 45_000 });
+  await page.waitForLoadState('domcontentloaded', { timeout: 30_000 }).catch(() => {});
+  await page.waitForLoadState('networkidle', { timeout: 10_000 }).catch(() => {});
+  await waitForLiveView(page);
+  if (!(await waitForTrackerContent(tracker, page))) {
+    const currentUrl = page.url();
+    const html = await safeContent(page);
+    const dump = writeBrowserDump(tracker, currentUrl, html, 'login-refused');
+    const suffix = dump ? ` - dump: ${dump}` : '';
+    const loginError = extractV3xLoginError(html);
+    const detail = loginError ? ` : ${loginError}` : ' : session API acceptee mais activite non authentifiee';
+    throw new Error(`Login V3X echoue${detail}${suffix}`);
+  }
+}
+
 async function waitForAntiBotChallenge(page: Page): Promise<void> {
   for (let i = 0; i < 20; i += 1) {
     if (!looksAntiBot(await safeContent(page))) return;
@@ -533,6 +602,11 @@ async function ensureLoggedIn(
   await waitForLiveView(page);
   await page.waitForLoadState('networkidle', { timeout: 10_000 }).catch(() => {});
   await page.locator('input').first().waitFor({ timeout: 10_000 }).catch(() => {});
+
+  if (tracker.id === 'v3x') {
+    await submitV3xApiLogin(tracker, credentials, page);
+    return;
+  }
 
   for (const [name, template] of Object.entries(tracker.login.body)) {
     const value = interpolate(template, {

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -1140,6 +1140,10 @@ export async function fetchTracker(
   const attemptHttpViaCurl = async (): Promise<TrackerStats | null> => {
     if (!fastFetchEnabled()) { console.log(`  [${tracker.name}] curl: fast-fetch désactivé`); return null; }
     const cfg = tracker.login;
+    // V3X accepte le login via son API Next.js, mais /activity reste rendu cote
+    // client. Le login+fetch curl ne peut donc pas valider les stats et ajoute
+    // seulement une tentative bruyante avant le vrai chemin navigateur.
+    if (tracker.id === 'v3x') return null;
     // 2FA via page dediee : non reproduit ici, on laisse la voie axios
     // (doLogin) gerer ce cas.
     if (cfg.otpStep) return null;


### PR DESCRIPTION
## Résumé
- utilise l’endpoint réel `https://api.v3x.club/auth/login` depuis le contexte navigateur V3X
- conserve le formulaire `login` / `password` et le fallback cookie `v3x_sid`
- évite la tentative login+fetch curl complète pour V3X, car `/activity` est rendu côté client
- accepte les libellés `/activity` en majuscules observés en production

## Validation
- `npm run build`
- `npm run check:integration`
- `git diff --check upstream/main...HEAD`
- test navigateur réel : API login V3X `200`, cookie `v3x_sid` posé, `/activity` accessible sans formulaire de login