### PR TITLE
Corriger la largeur du champ cookie V3X

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1709,6 +1709,12 @@
       color: var(--muted);
       font-size: 11px;
     }
+    .tracker-cookie-field {
+      grid-template-columns: minmax(0, 1fr);
+      align-items: start;
+      white-space: normal;
+    }
+    .tracker-cookie-field .advanced-cookie-row { width: 100%; }
     .tracker-credential-status {
       display: flex;
       align-items: center;
@@ -6675,7 +6681,7 @@
                 <span class="definition-badge ${isEnabled ? '' : 'definition-badge-muted'}">${isEnabled ? 'Actif' : 'Disponible'}</span>
                 ${statusBadge}
                 ${cookieOnly ? `
-                <div class="tracker-field" style="grid-column: span 2">
+                <div class="tracker-field tracker-cookie-field" style="grid-column: span 2">
                   <label>Cookie de session <span style="color:var(--muted)">— seul mode de connexion de ce site${credential.hasCookie ? ' · <b style="color:var(--green)">défini</b>' : ''}</span></label>
                   ${cookieFieldHtml}
                 </div>
@@ -6695,7 +6701,7 @@
                   <button class="btn-test" style="padding:6px 10px" onclick="resetCredential('${safeId}')">Réinitialiser</button>
                 </div>
                 ${!cookieOnly && cookieInstructions ? `
-                <div class="tracker-field" style="grid-column:1/-1">
+                <div class="tracker-field tracker-cookie-field" style="grid-column:1/-1">
                   <label>Cookie de session <span style="color:var(--muted)">— recommandé pour ${escapeHtml(definition.name)}${credential.hasCookie ? ' · <b style="color:var(--green)">défini</b>' : ''}</span></label>
                   ${cookieFieldHtml}
                 </div>` : ''}

--- a/scripts/check-v3x-auth.mjs
+++ b/scripts/check-v3x-auth.mjs
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 const v3x = JSON.parse(fs.readFileSync('config/trackers/v3x.json', 'utf8'));
 const browserFetcher = fs.readFileSync('src/browserFetcher.ts', 'utf8');
 const server = fs.readFileSync('src/server.ts', 'utf8');
+const webUi = fs.readFileSync('public/index.html', 'utf8');
 assert.equal(v3x.login?.cookieOnly, undefined, 'V3X ne doit pas etre force en cookieOnly');
 assert.equal(v3x.login?.body?.login, '{{username}}');
 assert.equal(v3x.login?.body?.password, '{{password}}');
@@ -23,4 +24,6 @@ assert.match(browserFetcher, /session API acceptee mais activite non authentifie
 assert.match(fs.readFileSync('src/fetcher.ts', 'utf8'), /if \(tracker\.id === 'v3x'\) return null/);
 assert.match(server, /function storedCookieReady\(tracker: TrackerConfig\)/);
 assert.doesNotMatch(server, /cookieOnlyReady\(tracker\)/);
+assert.match(webUi, /\.tracker-cookie-field\s*\{[\s\S]*grid-template-columns:\s*minmax\(0, 1fr\)/);
+assert.match(webUi, /<div class="tracker-field tracker-cookie-field" style="grid-column:1\/-1">/);
 console.log('V3X auth OK: username/password normal + cookie fallback + api.v3x.club cookie scope.');


### PR DESCRIPTION
## Résumé

- affiche le bloc cookie V3X sur une colonne pleine largeur
- empêche le texte d’aide de repousser le textarea dans la colonne de label
- conserve le textarea et le bouton d’enregistrement sur une ligne, avec le comportement mobile existant
- ajoute un garde de régression sur la structure du champ

## Validation

- `npm run build`
- `npm run check:integration`
- `git diff --check`